### PR TITLE
Refactors `nytid.cli.courses`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -853,14 +853,14 @@ test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.
 
 [[package]]
 name = "typerconf"
-version = "2.2"
+version = "2.3"
 description = "Library to read and write configs using API and CLI with Typer"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "typerconf-2.2-py3-none-any.whl", hash = "sha256:741b1cbca9f72fdaa604eb71c562737310c794c11f0d725eb4a5db83bb144c43"},
-    {file = "typerconf-2.2.tar.gz", hash = "sha256:ea33f12a5a57e2b9f8a8f4c437ad0616db13829eae17fdab7ee183ea40c0ee2f"},
+    {file = "typerconf-2.3-py3-none-any.whl", hash = "sha256:34db27c5fe75360b5ab49d5e802b70c0ac05bd8f506d23b6e9d128d04d279681"},
+    {file = "typerconf-2.3.tar.gz", hash = "sha256:a2c425bf3e73176fe38e7f8c7df8aeb1dac12e5eef226fc52489901dfde6eea7"},
 ]
 
 [package.dependencies]
@@ -903,4 +903,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "03e2132d04d18beb4d18b6b485af5513d92020860efb35bc4669f73e4e7be020"
+content-hash = "0e32a8ef78c0919926a41e3327340aed018f05d0bbb78b84d74a644f52c1a50a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -853,14 +853,14 @@ test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.
 
 [[package]]
 name = "typerconf"
-version = "1.10"
+version = "2.2"
 description = "Library to read and write configs using API and CLI with Typer"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "typerconf-1.10-py3-none-any.whl", hash = "sha256:84ed0ffb508a4985fbf89129201bff2cfeb2378ac383066d045eaa51fe4d5c97"},
-    {file = "typerconf-1.10.tar.gz", hash = "sha256:40c3bbd655b0bcbb95e456b2526a5448fd5912ddef215b01a746d0d059194e83"},
+    {file = "typerconf-2.2-py3-none-any.whl", hash = "sha256:741b1cbca9f72fdaa604eb71c562737310c794c11f0d725eb4a5db83bb144c43"},
+    {file = "typerconf-2.2.tar.gz", hash = "sha256:ea33f12a5a57e2b9f8a8f4c437ad0616db13829eae17fdab7ee183ea40c0ee2f"},
 ]
 
 [package.dependencies]
@@ -903,4 +903,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "33d4f1c64735ea5b7623b3b75201ae6a602e84a180ced5e56aea8f9adb520026"
+content-hash = "03e2132d04d18beb4d18b6b485af5513d92020860efb35bc4669f73e4e7be020"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ ics = "^0.7"
 openpyxl = "^3.0.10"
 Pillow = "^9.3.0"
 typer = "^0.7.0"
-typerconf = "^2.2"
+typerconf = "^2.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ ics = "^0.7"
 openpyxl = "^3.0.10"
 Pillow = "^9.3.0"
 typer = "^0.7.0"
-typerconf = "^1.10"
+typerconf = "^2.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"

--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -29,8 +29,10 @@ That structure looks like this:
 
 import typerconf as config
 
+from nytid import courses
 import logging
 import pathlib
+from nytid.courses import registry
 from nytid import storage
 import sys
 import typer
@@ -38,7 +40,6 @@ import typing
 
 cli = typer.Typer(help="Manage courses")
 
-<<helper constants>>
 <<helper functions>>
 
 <<subcommands>>
@@ -63,7 +64,7 @@ from nytid.cli.courses import *
 
 In this chapter we will cover the overall storage structure used for data.
 The idea is that we have a dictionary containing configurations for several 
-courses, we call this a courses directory (or directory of courses).
+courses, we call this a register (or directory of courses).
 This way, we can access all existing courses through this directory.
 These configurations will point to the course data directories, \ie where the 
 actual course data is located.
@@ -87,109 +88,96 @@ By this design, we'll let AFS and GitHub do the access control for us.
 We will use the [[storage]] module (\cref{storage}) to access the directories 
 and manage them.
 
-Since we can have several courses directories, we will refer to them by name in 
+Since we can have several registers, we will refer to them by name in 
 other commands.
 The idea is similar to that of \enquote{remotes} in Git.
 
 
-\section{Adding courses directories, the [[directory]] subcommands}
+\section{Managing registers, the [[registry]] subcommands}
 
-We will now manage the courses directories, where we can find all available 
+We will now manage the registers, where we can find all available 
 courses.
 We want the subcommands [[add]], [[rm]] and [[ls]].
-We will add a new Typer instance for the [[directory]] command and add the 
-three subcommands above.
+We will add a new Typer instance for the [[registry]] command and add the three 
+subcommands above.
 <<subcommands>>=
-directory = typer.Typer(name="directory",
-                        help="Manage courses directories")
+registrycli = typer.Typer(name="registry",
+                          help="Manage course registers")
 
-cli.add_typer(directory)
+cli.add_typer(registrycli)
 
-@directory.command(name="ls")
-def directory_ls():
+@registrycli.command(name="ls")
+def registry_ls():
   """
-  Lists courses directories added to configuration.
+  Lists registers added to the configuration.
   """
-  <<list courses directories>>
+  <<list registers>>
 
-@directory.command(name="add")
-def directory_add(<<directory add args>>):
+@registrycli.command(name="add")
+def registry_add(<<registry add args>>):
   """
-  Adds a courses directory.
+  Adds a register to the configuration.
 
-  <<directory add args doc>>
+  <<registry add args doc>>
   """
-  <<add courses directory>>
+  <<add register>>
 
-@directory.command(name="rm")
-def directory_rm(<<directory rm args>>):
+@registrycli.command(name="rm")
+def registry_rm(<<registry rm args>>):
   """
-  Removes a courses directory.
+  Removes a register from the configuration.
 
-  <<directory rm args doc>>
+  <<registry rm args doc>>
   """
-  <<remove courses directory>>
+  <<remove register>>
 @
 
-As mentioned above, we want each courses directory to be named, so that we can 
-reference it easily.
+As mentioned above, we want each register to be named, so that we can reference 
+each easily.
 This means that we need those two arguments.
-<<directory add args>>=
+<<registry add args>>=
 name: str,
-courses_dir: str
-<<directory add args doc>>=
-- `name` is the name to refer to this courses directory
-- `courses_dir` is the actual path to the directory
+register_path: str
+<<registry add args doc>>=
+- `name` is the name to refer to this register 
+- `register_path` is the actual path to the register
 @
 
-Finally, to add the courses directory, we simply enter it into the config.
+Finally, to add the register, we simply make the proper call to the 
+[[registry]] module.
 We replace any existing entry with the same name.
-<<add courses directory>>=
-<<check that name is valid, raise ValueError otherwise>>
-config.set(f"{COURSES_DIRS}.{name}", courses_dir)
-<<helper constants>>=
-COURSES_DIRS = "courses_dirs"
+<<add register>>=
+try:
+  registry.add(name, register_path)
+except KeyError as err:
+  logging.error(f"Can't add {name}: {err}")
+  return
 @
 
-This means that we can list all courses directories by listing the contents of 
-the [[courses_dirs]] path in the config.
-<<list courses directories>>=
-try:
-  for name, courses_dir in config.get(COURSES_DIRS).items():
-    print(f"{name}\t{courses_dir}")
-except KeyError:
-  pass
+This means that we can list all registers by using the [[registry]] module 
+again.
+This requires no arguments.
+<<list registers>>=
+for name, register_path in registry.ls():
+  print(f"{name}\t{register_path}")
 @
 
 Finally, to remove an entry, we simply need the name.
-Then we can drop that entry from the config.
-<<directory rm args>>=
+<<registry rm args>>=
 name
-<<directory rm args doc>>=
-- `name` is the name of the courses directory entry
+<<registry rm args doc>>=
+- `name` is the name of the courses registry entry
 
 @
 
-To remove the entry; we must fetch the dictionary containing all 
-name--directory pairs from the config, then we remove this particular 
-name--directory pair and, finally, we can set the resulting dictionary to 
-replace that entire tree in the config.
-<<remove courses directory>>=
-<<check that name is valid, raise ValueError otherwise>>
-current_dirs = config.get(COURSES_DIRS)
+To remove the entry; we simply make the appropriate call to the [[registry]] 
+module.
+<<remove register>>=
 try:
-  del current_dirs[name]
-except KeyError:
-  logging.warning(f"There is no such directory: {name}")
-else:
-  config.set(COURSES_DIRS, current_dirs)
-@
-
-Now, we need to check that the [[name]] is valid, \ie that it doesn't contain 
-any periods.
-<<check that name is valid, raise ValueError otherwise>>=
-if "." in name:
-  raise ValueError(f"`{name}` can't contain a period due to config addressing")
+  registry.remove(name)
+except KeyError as err:
+  logging.error(f"Can't remove {name}: {err}")
+  return
 @
 
 
@@ -210,6 +198,9 @@ def new(<<new command args>>):
 @ We will write the help section (docstring) along with the arguments and how 
 they are used by the command.
 
+To finally create the courses, we'll use the [[new]] function from the 
+[[nytid.courses]] module.
+
 \subsection{Creating the course}\label{CreatingTheCourse}
 
 To create a course, we need a name for the course.
@@ -224,68 +215,32 @@ name_arg = typer.Argument(...,
                           help="A name to use to refer to the course.")
 @
 
-We will create the course by creating a directory in an available courses 
-directory and write a [[config.json]] file there.
-However, if it exists, we want to exit with an error.
-<<new command body>>=
-<<determine which course directory to use>>
-
-with storage.open_root(f"{courses_dir}/{name}") as root:
-  try:
-    with root.open("config.json", "r") as course_conf_file:
-      pass
-  except FileNotFoundError:
-    course_conf = config.Config()
-  else:
-    logging.error(f"The directory for {name} already exists: "
-                  f"{courses_dir}/{name}")
-    sys.exit(1)
-
-  <<add settings to [[course_conf]]>>
-
-  with root.open("config.json", "w") as course_conf_file:
-    course_conf.write_config(course_conf_file)
-@
-
-We would first like to create the course in one of the courses directories 
-available.
-If there is only one directory, we'll create the course there.
+We would first like to create the course in one of the registers available.
+If there is only one register, we'll create the course there.
 If there are more, however, we need the user to decide which one to use.
 <<new command doc>>=
-- `courses_dir_name` is the name of the courses directory to use. Required if 
-  there are more than one courses directory in the config.
+- `register_name` is the name of the register to use. Required if there are 
+  more than one register in the config.
 
 <<new arguments and options>>=
-courses_dir_option = typer.Option(None,
-                                  help="Name of courses directory to use.",
-                                  shell_complete=complete_courses_dir_name)
+register_option = typer.Option(None,
+                               help="Name of register to use.",
+                               shell_complete=complete_register_name)
 <<new command args>>=
-courses_dir_name: str = courses_dir_option,
-<<determine which course directory to use>>=
-courses_dirs = config.get(COURSES_DIRS)
-
-if not courses_dir_name:
-  if len(courses_dirs) > 1:
-    raise ValueError(f"Must specify courses_dir: {courses_dirs.keys()}")
-  elif len(courses_dirs) < 1:
-    raise ValueError(f"There are no courses directories, "
-                     f"see `nytid courses directory --help`.")
-  else:
-    courses_dir_name = list(courses_dirs.keys())[0]
-
-courses_dir = courses_dirs[courses_dir_name]
+register_name: str = register_option,
 @
 
 We also want to have a function for autocompletion in the shell.
-We simply filter out the matching names available in the config.
+We simply filter out the matching names available in the registry.
 <<helper functions>>=
-def complete_courses_dir_name(ctx, param, incomplete: str):
+def complete_register_name(ctx, param, incomplete: str):
   """
-  Returns list of matching courses directory names available.
+  Returns list of matching register names available.
   """
   return filter(lambda x: x.startswith(incomplete),
-                config.get(COURSES_DIRS).keys())
+                registry.ls().keys())
 @
+
 
 \section{Setting the course settings}
 
@@ -300,8 +255,8 @@ package\footnote{%
 }.
 When we create the course, we will set all options to some value (possibly 
 [[None]]).
-Then we can let the [[config]] command read the available options from the 
-course config.
+Then we can let the [[courses config]] command read the available options from 
+the course config.
 
 Let's add the settings.
 
@@ -328,25 +283,10 @@ contact_opt = typer.Option(None, help="The course responsible's contact info. "
                                       "Default can be set using "
                                       "`nytid config me.name --set xxx` and "
                                       "`nytid config me.email --set yyy`.")
-<<add settings to [[course_conf]]>>=
-if not contact:
-  try:
-    contact = config.get("me.name")
-  except KeyError:
-    contact = ""
-
-  try:
-    email = config.get("me.email")
-  except KeyError:
-    pass
-  else:
-    if contact:
-      contact += f" <{email}>"
-    else:
-      contact = email
-
-course_conf.set("contact", contact)
 @
+
+Note that we don't have to set those values to anything but [[None]] here, the 
+call to [[courses.new]] will do that for us.
 
 \subsection{Course code}
 
@@ -375,9 +315,6 @@ related_codes: typing.List[str] = related_opt,
 related_opt = typer.Option([], help="List of related course codes, "
                                     "courses with any of these codes can "
                                     "share TAs.")
-<<add settings to [[course_conf]]>>=
-course_conf.set("code", code)
-course_conf.set("related_codes", related_codes)
 @
 
 \subsection{The schedule}
@@ -393,8 +330,6 @@ ics: str = ics_opt,
 <<new arguments and options>>=
 ics_opt = typer.Option(None, help="A URL to an ICS file containing the "
                                   "schedule. E.g. from TimeEdit.")
-<<add settings to [[course_conf]]>>=
-course_conf.set("ics", ics)
 @
 
 \subsection{The data directory}
@@ -418,13 +353,16 @@ data_path_opt = typer.Option(None,
 
 If the user didn't specify a data directory, then [[data_path]] will be 
 [[None]].
-In this case, we should update it with the default value.
-We get the default value from [[root.path]] (see
-[[<<new command body>>]]).
-<<add settings to [[course_conf]]>>=
-if not data_path:
-  data_path = str(root.path / "data")
-course_conf.set("data_path", data_path)
+The [[courses.new]] function will set the default.
+
+\subsection{Finally creating the course}
+
+Now that we have all the arguments, we can simply make the call to 
+[[courses.new]].
+<<new command body>>=
+courses.new(name, register_name, contact,
+            code, related_codes,
+            ics, data_path)
 @
 
 
@@ -443,7 +381,7 @@ nytid courses config course path --set value
 \end{minted}
 We need to know which course's config to operate on.
 This is the only difference to the config command of [[typerconf]].
-However, since we can have multiple courses directories, the user must be able 
+However, since we can have multiple registers, the user must be able 
 to specify, in case the same name occurs in more than one.
 But if the user doesn't specify, we search through all of them.
 
@@ -457,7 +395,7 @@ This corresponds to how the [[.set]] method of [[Config]] works.
 
 @cli.command(name="config")
 def config_cmd(course: str = name_arg_autocomplete,
-               courses_dir = courses_dir_option,
+               register = register_option,
                path: str = path_arg,
                values: typing.List[str] = value_arg):
   """
@@ -472,7 +410,7 @@ def config_cmd(course: str = name_arg_autocomplete,
     print_config(conf.get(path), path)
 @
 
-We will now cover [[name_arg_autocomplete]], [[courses_dir_option]] \etc in
+We will now cover [[name_arg_autocomplete]], [[register_option]] \etc in
 [[<<default values for [[config_cmd]]>>]]
 as we cover the relevant parts of the algorithm.
 
@@ -480,9 +418,9 @@ as we cover the relevant parts of the algorithm.
 
 Let's start with the course.
 We need the name of the course ([[course_name]]) so that we can look it up in 
-the courses directory ([[courses_dir]]) to get its config file.
+the register ([[register]]) to get its config file.
 
-We'll reuse the [[courses_dir_option]] from earlier, see 
+We'll reuse the [[register_option]] from earlier, see 
 \cref{CreatingTheCourse}.
 We don't want to reuse [[name_arg]], since that one lacks autocompletion.
 <<default values for [[config_cmd]]>>=
@@ -493,116 +431,67 @@ name_arg_autocomplete = typer.Argument(...,
 @
 
 To complete the course name we simply need to look up all matching courses in 
-the courses directories.
+the registers.
 We want to improve the autocompletion for the user by including from which 
-courses directory as course is.
-Hence, we need both the courses directory name and its path.
+register each course is.
+Hence, we need both the register name and its path.
 <<helper functions>>=
 def complete_course_name(ctx: typer.Context, incomplete: str):
   """
   Returns a list of course names matching `incomplete`.
   """
-  <<populate [[courses_dirs]] with the courses directories to use>>
-  for course_dir_name, course_dir_path in courses_dirs:
-    <<yield (course name, course dir name) tuples that matches [[incomplete]]>>
+  <<populate [[registers]] with the registers to use>>
+  for register_name, register_path in registers:
+    <<yield (course name, register name) tuples that matches [[incomplete]]>>
 @
 
-As mentioned above, if the user doesn't specify a courses directory, we search 
-through all of them.
-Remember that we want the name--path tuple for each courses directory.
-<<populate [[courses_dirs]] with the courses directories to use>>=
-courses_dirs = courses_dirs_pairs(ctx.params.get("courses_dir"))
+As mentioned above, if the user doesn't specify a register, we search through 
+all of them.
+Remember that we want the name--path tuple for each register.
+<<populate [[registers]] with the registers to use>>=
+registers = register_pairs(ctx.params.get("register"))
 <<helper functions>>=
-def courses_dirs_pairs(courses_dir_name=None):
+def register_pairs(register_name=None):
   """
-  Returns a list of (name, path)-tuples (pairs) for courses directories to use.
+  Returns a list of (name, path)-tuples (pairs) for registers to use.
 
-  If `courses_dir_name` is None, we use all existing courses directories found 
+  If `register_name` is None, we use all existing registers found 
   in the config. Otherwise, we look up the path of the one specified and return 
   a list containing only that name--path-tuple.
   """
-  if courses_dir_name:
-    return [(courses_dir_name,
-             config.get(f"{COURSES_DIRS}.{courses_dir_name}"))]
+  if register_name:
+    return [(register_name,
+             registry.get(register_name))]
   else:
-    return list(config.get(COURSES_DIRS).items())
+    return registry.ls()
 @
 
-In the courses directory, each course has its own subdirectory.
-So we simply need to return the subdirectories of [[course_dir_path]] matching 
-[[incomplete]] together with [[course_dir_name]].
-<<yield (course name, course dir name) tuples that matches [[incomplete]]>>=
-courses = all_courses(courses_dir_path)
+In the register, each course has its own subdirectory.
+So we simply need to return the subdirectories of [[register_path]] matching 
+[[incomplete]] together with [[register_name]].
+<<yield (course name, register name) tuples that matches [[incomplete]]>>=
+courses = all_courses(register_path)
 matching_courses = filter(lambda x: x.startswith(incomplete), courses)
-return map(lambda x: (x, f"from {courses_dir_name}"),
+return map(lambda x: (x, f"from {register_name}"),
            matching_courses)
 <<helper functions>>=
-def all_courses(courses_dir_path):
+def all_courses(register_path):
   """
-  Returns a list (generator) of all courses found in `courses_dir_path`.
+  Returns a list (generator) of all courses found in `register_path`.
   """
-  for file in pathlib.Path(course_dir_path).iterdir():
+  for file in pathlib.Path(register_path).iterdir():
     if file.is_dir():
       yield file.name
 @
 
-Now let's turn back to the main problem.
+Now let's turn back to the main problem:
+we want to find the configuration of the given course.
 <<set [[course]]'s config file as [[conf]]>>=
-courses_dirs = courses_dirs_pairs(courses_dir)
-
 try:
-  conf_path = get_conf_path(course, courses_dirs)
+  conf = courses.get_course_config(course, register)
 except KeyError as err:
   logging.error(err)
   sys.exit(1)
-
-conf = Config()
-conf.read_config(conf_path)
-@
-
-We want [[get_conf_path]] to ensure a unique match for [[course]].
-This means that we must search through all the courses directories and keep 
-track of the number of matches.
-<<helper functions>>=
-def get_conf_path(course, courses_dirs):
-  """
-  Find the course named `course` among all the courses in `courses_dirs`.
-  If `course` is not a unique match, it raises a `KeyError`.
-  """
-  <<[[get_conf_path]] variables>>
-
-  for course_dir_name, course_dir_path in courses_dirs:
-    <<search for matches to [[course]] in [[course_dir_path]]>>
-
-  <<check ending criteria for [[get_conf_path]], return>>
-@
-
-In each courses directory, we go through the courses to check for a match.
-If we find the course, we note its [[conf_path]] and also note that we had a 
-hit in [[courses_dir_name]].
-<<search for matches to [[course]] in [[course_dir_path]]>>=
-courses = all_courses(course_dir_path)
-matching_courses = list(filter(lambda x: x == course, courses))
-if len(matching_courses) > 0:
-  conf_path = course_dir_path / course / "config.json"
-  hits_from_courses_dirs.append(course_dir_name)
-<<[[get_conf_path]] variables>>=
-hits_from_courses_dirs = []
-conf_path = None
-@
-
-Once we're through all the courses, we check if we have a non-[[None]] value in 
-[[conf_path]].
-If not, we didn't find anything.
-Otherwise, we check how many entries we have in [[hits_from_courses_dirs]].
-If we have more than one, we raise an exception saying there were too many 
-matches.
-<<check ending criteria for [[get_conf_path]], return>>=
-if not conf_path:
-  raise KeyError(f"Couldn't find course {course}.")
-elif len(hits_from_courses_dirs) > 1:
-  raise KeyError(f"Course `{course}` found in "
-                  f"several courses directories ({hits_from_course_dirs}).")
 @
 
 \subsection{Navigating the course config}
@@ -623,10 +512,12 @@ def complete_config_path(ctx: typer.Context, incomplete: str):
   """
   Returns all valid paths in the config starting with `incomplete`.
   """
-  courses_dirs = courses_dirs_pairs(ctx.params.get("course_dir"))
-  conf_path = get_conf_path(ctx.params.get("course"), courses_dirs)
-  conf = Config()
-  conf.read_config(conf_path)
+  register = ctx.params.get("register")
+  course = ctx.params.get("course")
+  try:
+    conf = courses.get_course_config(course, register)
+  except:
+    return []
 
   return filter(lambda x: x.startswith(incomplete),
                 conf.paths())

--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -407,7 +407,10 @@ def config_cmd(course: str = name_arg_autocomplete,
     <<if [[values]] is empty string, replace it with [[None]]>>
     conf.set(path, values)
   else:
-    print_config(conf.get(path), path)
+    try:
+      print_config(conf.get(path), path)
+    except KeyError as err:
+      logging.error(f"{path} doen't exist in the config: {err}")
 @
 
 We will now cover [[name_arg_autocomplete]], [[register_option]] \etc in

--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -158,8 +158,8 @@ This means that we can list all registers by using the [[registry]] module
 again.
 This requires no arguments.
 <<list registers>>=
-for name, register_path in registry.ls():
-  print(f"{name}\t{register_path}")
+for register in registry.ls():
+  print(f"{register}\t{registry.get(register)}")
 @
 
 Finally, to remove an entry, we simply need the name.
@@ -238,7 +238,7 @@ def complete_register_name(ctx, param, incomplete: str):
   Returns list of matching register names available.
   """
   return filter(lambda x: x.startswith(incomplete),
-                registry.ls().keys())
+                registry.ls())
 @
 
 
@@ -463,7 +463,9 @@ def register_pairs(register_name=None):
     return [(register_name,
              registry.get(register_name))]
   else:
-    return registry.ls()
+    return [(register_name,
+             registry.get(register_name))
+            for register_name in registry.ls()]
 @
 
 In the register, each course has its own subdirectory.

--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -151,7 +151,7 @@ try:
   registry.add(name, register_path)
 except KeyError as err:
   logging.error(f"Can't add {name}: {err}")
-  return
+  sys.exit(1)
 @
 
 This means that we can list all registers by using the [[registry]] module 
@@ -177,7 +177,7 @@ try:
   registry.remove(name)
 except KeyError as err:
   logging.error(f"Can't remove {name}: {err}")
-  return
+  sys.exit(1)
 @
 
 

--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -56,6 +56,8 @@ from nytid.cli.courses import *
 
 <<test imports>>
 
+<<test setup>>
+
 <<test functions>>
 @
 
@@ -411,11 +413,33 @@ def config_cmd(course: str = name_arg_autocomplete,
       print_config(conf.get(path), path)
     except KeyError as err:
       logging.error(f"{path} doen't exist in the config: {err}")
+      sys.exit(1)
 @
 
 We will now cover [[name_arg_autocomplete]], [[register_option]] \etc in
 [[<<default values for [[config_cmd]]>>]]
 as we cover the relevant parts of the algorithm.
+
+\subsection{Testing the [[courses config]] command}
+
+Before we delve into the details, let's first device the testing.
+Typer makes this very easy.
+<<test setup>>=
+runner = CliRunner()
+
+register = "test register"
+register_path = tempfile.mkdtemp()
+runner.invoke(cli, ["registry", "add", register, register_path])
+
+target_course = "test course"
+target_path = "contact"
+target_value = "Test Tester"
+
+runner.invoke(cli, ["new", target_course])
+<<test imports>>=
+import tempfile
+from typer.testing import CliRunner
+@
 
 \subsection{Finding the course}
 
@@ -553,6 +577,34 @@ if values == "":
   values = None
 @
 
+\subsection{Testing setting values}
+
+Let's look at the actual tests.
+We want to set a value, this should yield no error.
+We also check that this worked by looking for the target value when we print 
+the whole config.
+<<test functions>>=
+def test_set():
+  result = runner.invoke(cli, ["config", target_course,
+                               target_path, "--set", target_value])
+  assert result.exit_code == 0
+
+  result = runner.invoke(cli, ["config", target_course, target_path])
+  assert target_value in result.stdout
+@
+
+We also want to remove the target again.
+This should work by setting it to the empty string.
+<<test functions>>=
+def test_clear():
+  result = runner.invoke(cli, ["config", target_course,
+                              target_path, "--set", ""])
+  assert result.exit_code == 0
+
+  result = runner.invoke(cli, ["config", target_course])
+  assert target_path not in result.stdout
+@
+
 \subsection{Printing the config}
 
 That [[print_config]] function should print the remaining levels of the config 
@@ -600,47 +652,26 @@ except AttributeError:
   print(f"{path} = {conf}")
 @
 
-\subsection{Testing the [[courses config]] command}
+\subsection{Testing the printing of the config}
 
-Let's test this command.
-We'll set up the testing.
+There are two cases that we want to test.
+The first is to specify a non-existing path of the config, that should result 
+in an error.
+In the second case, we should try to get a part of the config that actually 
+does exist.
+The same should happen if we don't specify any part of the config, then we 
+should get the whole config; in which case, we also get the target value.
 <<test functions>>=
-runner = CliRunner()
+def test_get():
+  result = runner.invoke(cli, ["config", target_course,
+                               f"{target_path}.nonexisting"])
+  assert result.exit_code == 1
 
-def test_cli():
-  <<run tests on [[cli]]>>
-<<test imports>>=
-from typer.testing import CliRunner
-@
+  result = runner.invoke(cli, ["config", target_course,
+                               target_path, "--set", target_value])
+  result = runner.invoke(cli, ["config", target_course,
+                               target_path])
+  assert target_value in result.stdout
 
-Let's look at the actual tests.
-<<run tests on [[cli]]>>=
-target_course = "test"
-target_path = "contact"
-target_value = "Test Tester"
-
-result = runner.invoke(cli, ["new", target_course]),
-
-# set example data
-result = runner.invoke(cli, ["config", target_course,
-                             target_path, "--set", target_value])
-assert result.exit_code == 0
-
-# try access nonexisting
-result = runner.invoke(cli, ["config", target_course,
-                             f"{target_path}.nonexisting"])
-assert result.exit_code == 1
-
-# access existing
-result = runner.invoke(cli, ["config", target_course,
-                             target_path])
-assert target_value in result.stdout
-
-# clear config
-result = runner.invoke(cli, ["config", target_course,
-                             target_path, "--set", None])
-assert result.exit_code == 0
-
-# check that it's cleared
-result = runner.invoke(cli, ["config", target_course])
-assert target_path not in result.stdout
+  result = runner.invoke(cli, ["config", target_course])
+  assert target_value in result.stdout

--- a/src/nytid/courses/.gitignore
+++ b/src/nytid/courses/.gitignore
@@ -1,0 +1,2 @@
+registry.py
+registry.tex

--- a/src/nytid/courses/init.nw
+++ b/src/nytid/courses/init.nw
@@ -27,13 +27,41 @@ import typing
 <<functions>>
 @
 
+\subsection{Testing}
+
 We also add tests.
 These are all prepended [[test_]] to the function name.
 We will run them using [[pytest]].
+
+We need some setup for the testing.
+Particularly, we must set up a register.
+For this we need a config and a temporary directory.
 <<test courses.py>>=
+from typerconf import Config
+import pathlib
+import tempfile
+
 from nytid.cli.courses import *
 
+register = "register"
+reg_path = pathlib.Path(tempfile.mkdtemp())
+
+course = "course"
+
+config = Config()
+
+registry.add(register, str(reg_path), config=config)
+
 <<test functions>>
+@
+
+We want to be able to override the default configuration by supplying a value 
+to the [[config]] argument of these functions.
+This also helps with testing.
+<<config arg>>=
+config=config
+<<config arg doc>>=
+The default `config` is the default config of the `typerconf` package.
 @
 
 
@@ -41,15 +69,22 @@ from nytid.cli.courses import *
 
 We will add a function [[new]] to create a new course.
 <<functions>>=
-def new(<<new args>>):
+def new(<<new args>>
+        <<config arg>>):
   """
   Creates a new course. It takes the following arguments:
 
   <<new doc>>
+
+  <<config arg doc>>
   """
   <<new body>>
 @ We will write the help section (docstring) along with the arguments and how 
 they are used by the command.
+(Note that there is no comma between [[<<new args>>]] and [[<<config arg>>]] in 
+the function head, this is due to there being enough commas in [[<<new args>>]] 
+due to it not knowing what is the last argument---so it terminates with a 
+comma.)
 
 \subsection{Creating the course}\label{CreatingTheCourse}
 
@@ -84,9 +119,32 @@ with storage.open_root(f"{register_path}/{name}") as root:
     course_conf.write_config(course_conf_file)
 @
 
+Now we want to test the function~[[new]].
+This means that we want to check that there is a directory for the course in 
+the path~[[reg_path]].
+And inside it, there should be a file~[[config.json]].
+<<test functions>>=
+def test_new_create():
+  for subdir in reg_path.iterdir():
+    if subdir.name == course:
+      assert False
+
+  <<call new to test>>
+
+  found = False
+  for subdir in reg_path.iterdir():
+    if subdir.name == course:
+      for file in subdir.iterdir():
+        if file.name == "config.json":
+          found = True
+
+  if not found:
+    assert False
+@
+
 We would first like to create the course in one of the available course 
 registers.
-If there is only one directory, we'll create the course there.
+If there is only one register, we'll create the course there.
 If there are more, however, we need the user to decide which one to use.
 <<new args>>=
 register: str = None,
@@ -96,9 +154,13 @@ register: str = None,
   the only available course register. If more registers, raises exception 
   `ValueError`.
 
+@
+
+Now, remember that when we make calls to [[registry]], we must pass on the 
+[[config]] argument in case it's overridden.
 <<determine which course register path [[register_path]] to use>>=
 if not register:
-  registers = registry.ls()
+  registers = registry.ls(config=config)
 
   if len(registers) > 1:
     raise ValueError(f"Must specify a course register: {registers.keys()}")
@@ -107,11 +169,11 @@ if not register:
   else:
     register = registers[0]
 
-register_path = registry.get(register)
+register_path = registry.get(register, config=config)
 @
 
 
-\section{Setting the course settings}
+\subsection{Setting the course settings}
 
 We want to be able to set the course settings at two times:
 first, when we create the course; second, when we want to see or modify the 
@@ -230,6 +292,13 @@ if not data_path:
 course_conf.set("data_path", data_path)
 @
 
+\subsection{Testing the [[new]] function}
+
+Now we can finally make the call to [[new]] to test it.
+<<call new to test>>=
+new(course, register, config=config)
+@
+
 
 \section{Revising the config of a course}
 
@@ -241,7 +310,8 @@ We need two things to locate a course.
 We need the course name and the course register in which it is located.
 <<functions>>=
 def get_course_config(course: str,
-                      register: str = None) -> config.Config:
+                      register: str = None,
+                      <<config arg>>) -> config.Config:
   """
   Returns a typerconf.Config object for the course's configuration. Writeback 
   is enabled meaning that any changes made to the config object will be written 
@@ -250,9 +320,26 @@ def get_course_config(course: str,
   `course` identifies the course in the `register`. If `register` is None, 
   search through all registers in the registry, use the first one found 
   (undefined in which order duplicates are sorted).
+
+  <<config arg doc>>
   """
   <<set [[course]]'s config file as [[conf]]>>
   return conf
+@
+
+Let's test this.
+<<test functions>>=
+def test_get_course_config():
+  conf = get_course_config(course, register, config=config)
+  assert conf.get("data_path") == str(reg_path / course / "data")
+  assert conf.get("contact") is None
+
+  conf.set("data_path", "a/b/c")
+  conf.set("contact", "Me")
+
+  conf2 = get_course_config(course, register, config=config)
+  assert conf2.get("data_path") == "a/b/c"
+  assert conf2.get("contact") == "Me"
 @
 
 \subsection{Finding the course}
@@ -267,7 +354,7 @@ In that case, we'll use [[registry.ls()]].
 If we have a register specified, we'll use [[registry.get(register_name)]].
 <<set [[course]]'s config file as [[conf]]>>=
 if register:
-  register_map = [register, registry.get(register)]
+  register_map = [(register, registry.get(register, config=config))]
 else:
   register_map = [(register, registry.get(register, config=config))
                   for register in registry.ls(config=config)]

--- a/src/nytid/courses/init.nw
+++ b/src/nytid/courses/init.nw
@@ -1,0 +1,554 @@
+\chapter{Course management, the [[courses]] module}\label{courses}
+
+In this chapter we cover the [[nytid.courses]] module and API for managing 
+courses.
+We want to add courses to course registers (\cref{registry}).
+
+Each course register is a directory.
+We can add a course by creating a subdirectory for the course.
+Then we can manage access by managing access to that subdirectory.
+Each course subdirectory contains a config file for the course.
+
+
+\section{Code outline}
+
+Here we provide the module [[nytid.courses]] ([[<<init.py>>]]) that is used to 
+manage courses found in the course registers.
+<<init.py>>=
+"""The nytid course management module"""
+
+import typerconf as config
+
+import pathlib
+from nytid.courses import registry
+from nytid import storage
+
+<<constants>>
+<<functions>>
+@
+
+We also add tests.
+These are all prepended [[test_]] to the function name.
+We will run them using [[pytest]].
+<<test courses.py>>=
+from nytid.cli.courses import *
+<<test imports>>
+
+<<test functions>>
+@
+
+
+\section{Adding a new course}
+
+We will add a function [[new]] to create a new course.
+<<functions>>=
+def new(<<new args>>):
+  """
+  Creates a new course. It takes the following arguments:
+
+  <<new doc>>
+  """
+  <<new body>>
+@ We will write the help section (docstring) along with the arguments and how 
+they are used by the command.
+
+\subsection{Creating the course}\label{CreatingTheCourse}
+
+To create a course, we need a name for the course.
+<<new args>>=
+name: str,
+<<new doc>>=
+- `name` (mandatory), which is the human readable nickname of the course. This 
+  is used to refer to the course with other parts of nytid.
+
+@
+
+We will create the course by creating a directory in an available courses 
+directory and write a [[config.json]] file there.
+However, if it exists, we want to exit with an error.
+<<new body>>=
+<<determine which course register path [[register_path]] to use>>
+
+with storage.open_root(f"{register_path}/{name}") as root:
+  try:
+    with root.open("config.json", "r") as course_conf_file:
+      pass
+  except FileNotFoundError:
+    course_conf = config.Config()
+  else:
+    raise FileExistsError(f"The config for {name} already exists: "
+                          f"{register_path}/{name}/config.json")
+
+  <<add settings to [[course_conf]]>>
+
+  with root.open("config.json", "w") as course_conf_file:
+    course_conf.write_config(course_conf_file)
+@
+
+We would first like to create the course in one of the available course 
+registers.
+If there is only one directory, we'll create the course there.
+If there are more, however, we need the user to decide which one to use.
+<<new args>>=
+course_register: str = None,
+<<new doc>>=
+- `course_register` is the name of the course register to use. Required if 
+  there are more than one course register in the config. Default is `None`, 
+  which selects the only available course register. If more registers, raises 
+  exception `ValueError`.
+
+<<determine which course register path [[register_path]] to use>>=
+if not course_register:
+  registers = registry.list()
+
+  if len(registers) > 1:
+    raise ValueError(f"Must specify a course register: {registers.keys()}")
+  elif len(registers) < 1:
+    raise ValueError(f"There are no course registers in the config.")
+  else:
+    course_register = registers[0]
+
+register_path = registry.get(course_register)
+@
+
+
+\section{Setting the course settings}
+
+We want to be able to set the course settings at two times:
+first, when we create the course; second, when we want to see or modify the 
+course settings afterwards.
+
+We will have a similar design as the [[config]] command of the [[typerconf]] 
+package\footnote{%
+  See URL \url{https://pypi.org/project/typerconf/} or
+  the latest PDF from URL \url{https://github.com/dbosk/typerconf/releases}.
+}.
+When we create the course, we will set all options to some value (possibly 
+[[None]]).
+Then we can let the [[config]] command read the available options from the 
+course config.
+
+Let's add the settings.
+
+\subsection{Contact information}
+
+We want to include the contact information for whoever is responsible for the 
+course.
+
+Usually, it's the course responsible who will run the [[courses new]] command.
+We will let the user adjust the default values through the main config file, in 
+the same fashion as Git.
+<<new args>>=
+contact: str = None,
+<<new doc>>=
+- `contact` contains the contact information for the course responsible, it can 
+  be any format, but we recommend "Firstname Lastname <email>". The default 
+  value is built from values in the main config file:
+
+    - `me.name` contains the name,
+    - `me.email` contains the email address.
+
+<<add settings to [[course_conf]]>>=
+if not contact:
+  try:
+    contact = config.get("me.name")
+  except KeyError:
+    contact = ""
+
+  try:
+    email = config.get("me.email")
+  except KeyError:
+    pass
+  else:
+    if contact:
+      contact += f" <{email}>"
+    else:
+      contact = email
+
+course_conf.set("contact", contact)
+@
+
+\subsection{Course code}
+
+Each course has a course code.
+We need one to identity the course from year to year and to identify similar 
+courses.
+The reason we're interested in this is because then we can recruit TAs from 
+similar enough courses.
+<<new args>>=
+code: str,
+<<new doc>>=
+- `code`, which is the course code. This is to relate the course to other 
+  courses through `related_codes`.
+
+<<new args>>=
+related_codes: typing.List[str],
+<<new doc>>=
+- `related_codes`, a list of related course codes. Courses with one of these 
+  course codes can share TAs.
+
+<<add settings to [[course_conf]]>>=
+course_conf.set("code", code)
+course_conf.set("related_codes", related_codes)
+@
+
+\subsection{The schedule}
+
+All courses need a schedule for their teaching.
+We add a URL to the ICS file, \eg TimeEdit.
+<<new args>>=
+ics: str,
+<<new doc>>=
+- `ics` (optional, default None), a URL to an ICS file with the schedule of the 
+  course. E.g. a URL to a TimeEdit export/subscription.
+
+<<add settings to [[course_conf]]>>=
+course_conf.set("ics", ics)
+@
+
+\subsection{The data directory}
+
+Each course also needs a data directory.
+The data directory is a directory that only members can access.
+It can contain a more detailed config or TA bookings.
+The default path is simply to append [[data]] to the course's config path.
+<<new args>>=
+data_path: str = None,
+<<new doc>>=
+- `data_path` is the path to the course's data directory. The default value is 
+  `None`, that means append `/data` to the course's config directory.
+
+@
+
+If the user didn't specify a data directory, then [[data_path]] will be 
+[[None]].
+In this case, we should update it with the default value.
+We get the default value from [[root.path]] (see
+[[<<new body>>]]).
+<<add settings to [[course_conf]]>>=
+if not data_path:
+  data_path = str(root.path / "data")
+course_conf.set("data_path", data_path)
+@
+
+
+\section{Revising the config of a course, the [[courses config]] command}
+
+We'll add a [[courses config]] command to show and change the settings of an 
+existing course.
+This command should be similar to [[typerconf]]'s config command\footnote{%
+  This section is an adapted version of that of [[typerconf]].
+}, however, we can't reuse that one since we must specify the course; only once 
+we have the course can we fetch which config file to use.
+
+The config command should work as follows.
+\begin{minted}{text}
+nytid courses config course path --set value
+\end{minted}
+We need to know which course's config to operate on.
+This is the only difference to the config command of [[typerconf]].
+However, since we can have multiple course registers, the user must be able 
+to specify, in case the same name occurs in more than one.
+But if the user doesn't specify, we search through all of them.
+
+If we get a path, but the user didn't use [[--set]] and provide a value, we 
+simply print the value at the end of the path.
+If we get a value through [[--set]], we'll update the value at the end of the 
+path (or create it if it doesn't exist).
+This corresponds to how the [[.set]] method of [[Config]] works.
+<<functions>>=
+<<default values for [[config_cmd]]>>
+
+@cli.command(name="config")
+def config_cmd(course: str = name_arg_autocomplete,
+               courses_dir = courses_dir_option,
+               path: str = path_arg,
+               values: typing.List[str] = value_arg):
+  """
+  Reads values from or writes `values` to the config of `course` at `path`.
+  """
+  <<set [[course]]'s config file as [[conf]]>>
+  if values:
+    <<change [[values]] to non-list if one-element list>>
+    <<if [[values]] is empty string, replace it with [[None]]>>
+    conf.set(path, values)
+  else:
+    print_config(conf.get(path), path)
+@
+
+We will now cover [[name_arg_autocomplete]], [[courses_dir_option]] \etc in
+[[<<default values for [[config_cmd]]>>]]
+as we cover the relevant parts of the algorithm.
+
+\subsection{Finding the course}
+
+Let's start with the course.
+We need the name of the course ([[course_name]]) so that we can look it up in 
+the course register ([[courses_dir]]) to get its config file.
+
+We'll reuse the [[courses_dir_option]] from earlier, see 
+\cref{CreatingTheCourse}.
+We don't want to reuse [[name_arg]], since that one lacks autocompletion.
+<<default values for [[config_cmd]]>>=
+name_arg_autocomplete = typer.Argument(...,
+                            help="Name of the course whose config we want to "
+                                 "operate on.",
+                            autocompletion=complete_course_name)
+@
+
+To complete the course name we simply need to look up all matching courses in 
+the course registers.
+We want to improve the autocompletion for the user by including from which 
+course register as course is.
+Hence, we need both the course register name and its path.
+<<helper functions>>=
+def complete_course_name(ctx: typer.Context, incomplete: str):
+  """
+  Returns a list of course names matching `incomplete`.
+  """
+  <<populate [[courses_dirs]] with the course registers to use>>
+  for course_dir_name, course_dir_path in courses_dirs:
+    <<yield (course name, course dir name) tuples that matches [[incomplete]]>>
+@
+
+As mentioned above, if the user doesn't specify a course register, we search 
+through all of them.
+Remember that we want the name--path tuple for each course register.
+<<populate [[courses_dirs]] with the course registers to use>>=
+courses_dirs = courses_dirs_pairs(ctx.params.get("courses_dir"))
+<<helper functions>>=
+def courses_dirs_pairs(courses_dir_name=None):
+  """
+  Returns a list of (name, path)-tuples (pairs) for course registers to use.
+
+  If `courses_dir_name` is None, we use all existing course registers found 
+  in the config. Otherwise, we look up the path of the one specified and return 
+  a list containing only that name--path-tuple.
+  """
+  if courses_dir_name:
+    return [(courses_dir_name,
+             config.get(f"{REGISTERS}.{courses_dir_name}"))]
+  else:
+    return list(config.get(REGISTERS).items())
+@
+
+In the course register, each course has its own subdirectory.
+So we simply need to return the subdirectories of [[course_dir_path]] matching 
+[[incomplete]] together with [[course_dir_name]].
+<<yield (course name, course dir name) tuples that matches [[incomplete]]>>=
+courses = all_courses(courses_dir_path)
+matching_courses = filter(lambda x: x.startswith(incomplete), courses)
+return map(lambda x: (x, f"from {courses_dir_name}"),
+           matching_courses)
+<<helper functions>>=
+def all_courses(courses_dir_path):
+  """
+  Returns a list (generator) of all courses found in `courses_dir_path`.
+  """
+  for file in pathlib.Path(course_dir_path).iterdir():
+    if file.is_dir():
+      yield file.name
+@
+
+Now let's turn back to the main problem.
+<<set [[course]]'s config file as [[conf]]>>=
+courses_dirs = courses_dirs_pairs(courses_dir)
+
+try:
+  conf_path = get_conf_path(course, courses_dirs)
+except KeyError as err:
+  logging.error(err)
+  sys.exit(1)
+
+conf = Config()
+conf.read_config(conf_path)
+@
+
+We want [[get_conf_path]] to ensure a unique match for [[course]].
+This means that we must search through all the course registers and keep 
+track of the number of matches.
+<<helper functions>>=
+def get_conf_path(course, courses_dirs):
+  """
+  Find the course named `course` among all the courses in `courses_dirs`.
+  If `course` is not a unique match, it raises a `KeyError`.
+  """
+  <<[[get_conf_path]] variables>>
+
+  for course_dir_name, course_dir_path in courses_dirs:
+    <<search for matches to [[course]] in [[course_dir_path]]>>
+
+  <<check ending criteria for [[get_conf_path]], return>>
+@
+
+In each course register, we go through the courses to check for a match.
+If we find the course, we note its [[conf_path]] and also note that we had a 
+hit in [[courses_dir_name]].
+<<search for matches to [[course]] in [[course_dir_path]]>>=
+courses = all_courses(course_dir_path)
+matching_courses = list(filter(lambda x: x == course, courses))
+if len(matching_courses) > 0:
+  conf_path = course_dir_path / course / "config.json"
+  hits_from_courses_dirs.append(course_dir_name)
+<<[[get_conf_path]] variables>>=
+hits_from_courses_dirs = []
+conf_path = None
+@
+
+Once we're through all the courses, we check if we have a non-[[None]] value in 
+[[conf_path]].
+If not, we didn't find anything.
+Otherwise, we check how many entries we have in [[hits_from_courses_dirs]].
+If we have more than one, we raise an exception saying there were too many 
+matches.
+<<check ending criteria for [[get_conf_path]], return>>=
+if not conf_path:
+  raise KeyError(f"Couldn't find course {course}.")
+elif len(hits_from_courses_dirs) > 1:
+  raise KeyError(f"Course `{course}` found in "
+                  f"several course registers ({hits_from_course_dirs}).")
+@
+
+\subsection{Navigating the course config}
+
+We can autocomplete the path since we can predict the possible values.
+<<default values for [[config_cmd]]>>=
+path_arg = typer.Argument("",
+                          help="Path in config, e.g. 'courses.datintro22'. "
+                               "Empty string is root of config. Defaults to "
+                               "the empty string.",
+                          autocompletion=complete_config_path)
+@
+
+The [[complete_config_path]] function returns the possible completions for an 
+incomplete path from the command line.
+<<helper functions>>=
+def complete_config_path(ctx: typer.Context, incomplete: str):
+  """
+  Returns all valid paths in the config starting with `incomplete`.
+  """
+  courses_dirs = courses_dirs_pairs(ctx.params.get("course_dir"))
+  conf_path = get_conf_path(ctx.params.get("course"), courses_dirs)
+  conf = Config()
+  conf.read_config(conf_path)
+
+  return filter(lambda x: x.startswith(incomplete),
+                conf.paths())
+@
+
+\subsection{Setting a value in course config}
+
+We let the user supply a list of values to set on the target path.
+<<default values for [[config_cmd]]>>=
+value_arg = typer.Option([], "-s", "--set",
+                         help="Values to store. "
+                              "More than one value makes a list. "
+                              "Values are treated as JSON if possible.")
+@
+
+If the user supplies only one argument on the command line, we don't want it to 
+be interpreted as a one-element list, but rather as a value that is not a list.
+Hence, we check and convert if necessary.
+<<change [[values]] to non-list if one-element list>>=
+if len(values) == 1:
+  values = values[0]
+@
+
+Additionally, if that one element is an empty string, we replace it with 
+[[None]] to trigger a delete.
+<<if [[values]] is empty string, replace it with [[None]]>>=
+if values == "":
+  values = None
+@
+
+\subsection{Printing the config}
+
+That [[print_config]] function should print the remaining levels of the config 
+tree.
+And we want it to print on the format of
+[[courses.datintro22.url = https://...]].
+This function will do a depth-first traversal through the config to print all 
+values.
+The idea is that the config path will move from the dictionary representation 
+in [[conf]] to the string representation in [[path]].
+When at the leaf, [[conf]] will contain the value and [[path]] the entire path.
+<<helper functions>>=
+def print_config(conf, path=""):
+  """
+  Prints the config tree contained in `conf` to stdout.
+  Optional `path` is prepended.
+  """
+  try:
+    for key in conf.keys():
+      <<recurse deeper into the config tree>>
+  <<print the leaf of config tree and return>>
+@
+
+The recursive step is quite straight-forward, we just call [[print_config]] 
+with the subtree ([[conf[key]]]) as an argument.
+However, we must check whether to prepend anything ([[path]]).
+The deeper we progress, the more we want to prepend.
+For instance, at the [[courses.datintro22]] level, [[print_config]] only knows 
+[[datintro22]], not the [[courses]] parent.
+Hence, we must supply [[courses]] to prepend to [[datintro22]] to get 
+[[courses.datintro22]].
+<<recurse deeper into the config tree>>=
+if path:
+  print_config(conf[key], f"{path}.{key}")
+else:
+  print_config(conf[key], key)
+@
+
+Finally, we get the base-case by exception.
+When a node ([[conf]]) doesn't have an attribute [[.keys()]], we know we're at 
+a leaf, so we print it.
+Then the complete path is in [[path]], the value in [[conf]].
+<<print the leaf of config tree and return>>=
+except AttributeError:
+  print(f"{path} = {conf}")
+@
+
+\subsection{Testing the [[courses config]] command}
+
+Let's test this command.
+We'll set up the testing.
+<<test functions>>=
+runner = CliRunner()
+
+def test_cli():
+  <<run tests on [[cli]]>>
+<<test imports>>=
+from typer.testing import CliRunner
+@
+
+Let's look at the actual tests.
+<<run tests on [[cli]]>>=
+target_course = "test"
+target_path = "contact"
+target_value = "Test Tester"
+
+result = runner.invoke(cli, ["new", target_course]),
+
+# set example data
+result = runner.invoke(cli, ["config", target_course,
+                             target_path, "--set", target_value])
+assert result.exit_code == 0
+
+# try access nonexisting
+result = runner.invoke(cli, ["config", target_course,
+                             f"{target_path}.nonexisting"])
+assert result.exit_code == 1
+
+# access existing
+result = runner.invoke(cli, ["config", target_course,
+                             target_path])
+assert target_value in result.stdout
+
+# clear config
+result = runner.invoke(cli, ["config", target_course,
+                             target_path, "--set", None])
+assert result.exit_code == 0
+
+# check that it's cleared
+result = runner.invoke(cli, ["config", target_course])
+assert target_path not in result.stdout

--- a/src/nytid/courses/init.nw
+++ b/src/nytid/courses/init.nw
@@ -17,7 +17,7 @@ manage courses found in the course registers.
 <<init.py>>=
 """The nytid course management module"""
 
-import typerconf as config
+import typerconf
 
 import pathlib
 from nytid.courses import registry
@@ -41,7 +41,7 @@ from typerconf import Config
 import pathlib
 import tempfile
 
-from nytid.cli.courses import *
+from nytid.courses import *
 
 register = "register"
 reg_path = pathlib.Path(tempfile.mkdtemp())
@@ -59,7 +59,7 @@ We want to be able to override the default configuration by supplying a value
 to the [[config]] argument of these functions.
 This also helps with testing.
 <<config arg>>=
-config=config
+config: typerconf.Config = typerconf
 <<config arg doc>>=
 The default `config` is the default config of the `typerconf` package.
 @
@@ -108,7 +108,7 @@ with storage.open_root(f"{register_path}/{name}") as root:
     with root.open("config.json", "r") as course_conf_file:
       pass
   except FileNotFoundError:
-    course_conf = config.Config()
+    course_conf = typerconf.Config()
   else:
     raise FileExistsError(f"The config for {name} already exists: "
                           f"{register_path}/{name}/config.json")
@@ -163,7 +163,7 @@ if not register:
   registers = registry.ls(config=config)
 
   if len(registers) > 1:
-    raise ValueError(f"Must specify a course register: {registers.keys()}")
+    raise ValueError(f"Must specify a course register: {registers}")
   elif len(registers) < 1:
     raise ValueError(f"There are no course registers in the config.")
   else:
@@ -311,7 +311,7 @@ We need the course name and the course register in which it is located.
 <<functions>>=
 def get_course_config(course: str,
                       register: str = None,
-                      <<config arg>>) -> config.Config:
+                      <<config arg>>) -> typerconf.Config:
   """
   Returns a typerconf.Config object for the course's configuration. Writeback 
   is enabled meaning that any changes made to the config object will be written 
@@ -332,7 +332,6 @@ Let's test this.
 def test_get_course_config():
   conf = get_course_config(course, register, config=config)
   assert conf.get("data_path") == str(reg_path / course / "data")
-  assert conf.get("contact") is None
 
   conf.set("data_path", "a/b/c")
   conf.set("contact", "Me")
@@ -354,10 +353,10 @@ In that case, we'll use [[registry.ls()]].
 If we have a register specified, we'll use [[registry.get(register_name)]].
 <<set [[course]]'s config file as [[conf]]>>=
 if register:
-  register_map = [(register, registry.get(register, config=config))]
+  register_map = {register: registry.get(register, config=config)}
 else:
-  register_map = [(register, registry.get(register, config=config))
-                  for register in registry.ls(config=config)]
+  register_map = {register: registry.get(register, config=config)
+                  for register in registry.ls(config=config)}
 @
 
 In the course register, each course has its own subdirectory.
@@ -369,7 +368,7 @@ except KeyError as err:
   raise KeyError(f"Couldn't uniquely identify {course} in "
                  f"registers {register_map.keys()}: {err}")
 
-conf = config.Config(conf_file=conf_path)
+conf = typerconf.Config(conf_file=conf_path)
 @
 
 We want [[get_course_conf_path]] to ensure a unique match for [[course]].
@@ -385,7 +384,7 @@ def get_course_conf_path(course, register_map):
   """
   <<[[get_course_conf_path]] variables>>
 
-  for register_name, register_path in register_map:
+  for register_name, register_path in register_map.items():
     <<search for matches to [[course]] in [[register_path]]>>
 
   <<check ending criteria for [[get_course_conf_path]], return>>

--- a/src/nytid/courses/init.nw
+++ b/src/nytid/courses/init.nw
@@ -105,7 +105,7 @@ if not register:
   elif len(registers) < 1:
     raise ValueError(f"There are no course registers in the config.")
   else:
-    register = registers[0][0]
+    register = registers[0]
 
 register_path = registry.get(register)
 @
@@ -269,7 +269,8 @@ If we have a register specified, we'll use [[registry.get(register_name)]].
 if register:
   register_map = [register, registry.get(register)]
 else:
-  register_map = registry.ls()
+  register_map = [(register, registry.get(register, config=config))
+                  for register in registry.ls(config=config)]
 @
 
 In the course register, each course has its own subdirectory.

--- a/src/nytid/courses/init.nw
+++ b/src/nytid/courses/init.nw
@@ -32,7 +32,6 @@ These are all prepended [[test_]] to the function name.
 We will run them using [[pytest]].
 <<test courses.py>>=
 from nytid.cli.courses import *
-<<test imports>>
 
 <<test functions>>
 @
@@ -99,7 +98,7 @@ register: str = None,
 
 <<determine which course register path [[register_path]] to use>>=
 if not register:
-  registers = registry.list()
+  registers = registry.ls()
 
   if len(registers) > 1:
     raise ValueError(f"Must specify a course register: {registers.keys()}")
@@ -264,13 +263,13 @@ course register ([[register]]) to get its config file.
 
 As mentioned above, if the user doesn't specify a course register, we must 
 search through all of them.
-In that case, we'll use [[registry.list()]].
+In that case, we'll use [[registry.ls()]].
 If we have a register specified, we'll use [[registry.get(register_name)]].
 <<set [[course]]'s config file as [[conf]]>>=
 if register:
   register_map = [register, registry.get(register)]
 else:
-  register_map = registry.list()
+  register_map = registry.ls()
 @
 
 In the course register, each course has its own subdirectory.
@@ -282,13 +281,13 @@ except KeyError as err:
   raise KeyError(f"Couldn't uniquely identify {course} in "
                  f"registers {register_map.keys()}: {err}")
 
-conf = Config(conf_file=conf_path)
+conf = config.Config(conf_file=conf_path)
 @
 
 We want [[get_course_conf_path]] to ensure a unique match for [[course]].
 This means that we must search through all the course registers and keep 
 track of the number of matches.
-<<helper functions>>=
+<<functions>>=
 def get_course_conf_path(course, register_map):
   """
   Find the course named `course` among all the courses in the registers found 
@@ -311,7 +310,7 @@ hit in [[register_name]].
 courses = all_courses(register_path)
 matching_courses = list(filter(lambda x: x == course, courses))
 if len(matching_courses) > 0:
-  conf_path = course_dir_path / course / "config.json"
+  conf_path = f"{register_path}/{course}/config.json"
   hits_from_register_dirs.append(register_name)
 <<[[get_course_conf_path]] variables>>=
 hits_from_register_dirs = []
@@ -320,7 +319,7 @@ conf_path = None
 
 To list all the courses, we simply list all directories in the register's 
 directory.
-<<helper functions>>=
+<<functions>>=
 def all_courses(register_path):
   """
   Returns a list (generator) of all courses found in `register_path`.
@@ -343,3 +342,4 @@ elif len(hits_from_register_dirs) > 1:
   raise KeyError(f"Course `{course}` found in "
                   f"several course registers: {hits_from_course_dirs}.")
 
+return conf_path

--- a/src/nytid/courses/init.nw
+++ b/src/nytid/courses/init.nw
@@ -22,8 +22,8 @@ import typerconf as config
 import pathlib
 from nytid.courses import registry
 from nytid import storage
+import typing
 
-<<constants>>
 <<functions>>
 @
 
@@ -90,15 +90,15 @@ registers.
 If there is only one directory, we'll create the course there.
 If there are more, however, we need the user to decide which one to use.
 <<new args>>=
-course_register: str = None,
+register: str = None,
 <<new doc>>=
-- `course_register` is the name of the course register to use. Required if 
-  there are more than one course register in the config. Default is `None`, 
-  which selects the only available course register. If more registers, raises 
-  exception `ValueError`.
+- `register` is the name of the course register to use. Required if there are 
+  more than one course register in the config. Default is `None`, which selects 
+  the only available course register. If more registers, raises exception 
+  `ValueError`.
 
 <<determine which course register path [[register_path]] to use>>=
-if not course_register:
+if not register:
   registers = registry.list()
 
   if len(registers) > 1:
@@ -106,9 +106,9 @@ if not course_register:
   elif len(registers) < 1:
     raise ValueError(f"There are no course registers in the config.")
   else:
-    course_register = registers[0]
+    register = registers[0]
 
-register_path = registry.get(course_register)
+register_path = registry.get(register)
 @
 
 
@@ -176,13 +176,13 @@ courses.
 The reason we're interested in this is because then we can recruit TAs from 
 similar enough courses.
 <<new args>>=
-code: str,
+code: str = None,
 <<new doc>>=
 - `code`, which is the course code. This is to relate the course to other 
-  courses through `related_codes`.
+  courses through `related_codes`. However, it's not mandatory.
 
 <<new args>>=
-related_codes: typing.List[str],
+related_codes: typing.List[str] = None,
 <<new doc>>=
 - `related_codes`, a list of related course codes. Courses with one of these 
   course codes can share TAs.
@@ -197,7 +197,7 @@ course_conf.set("related_codes", related_codes)
 All courses need a schedule for their teaching.
 We add a URL to the ICS file, \eg TimeEdit.
 <<new args>>=
-ics: str,
+ics: str = None,
 <<new doc>>=
 - `ics` (optional, default None), a URL to an ICS file with the schedule of the 
   course. E.g. a URL to a TimeEdit export/subscription.
@@ -232,323 +232,114 @@ course_conf.set("data_path", data_path)
 @
 
 
-\section{Revising the config of a course, the [[courses config]] command}
+\section{Revising the config of a course}
 
-We'll add a [[courses config]] command to show and change the settings of an 
-existing course.
-This command should be similar to [[typerconf]]'s config command\footnote{%
-  This section is an adapted version of that of [[typerconf]].
-}, however, we can't reuse that one since we must specify the course; only once 
-we have the course can we fetch which config file to use.
+We want to be able to read a config file of a course and to update it.
+Here we provide that functionality.
+Fortunately, most of what we need is already provided by [[typerconf]].
 
-The config command should work as follows.
-\begin{minted}{text}
-nytid courses config course path --set value
-\end{minted}
-We need to know which course's config to operate on.
-This is the only difference to the config command of [[typerconf]].
-However, since we can have multiple course registers, the user must be able 
-to specify, in case the same name occurs in more than one.
-But if the user doesn't specify, we search through all of them.
-
-If we get a path, but the user didn't use [[--set]] and provide a value, we 
-simply print the value at the end of the path.
-If we get a value through [[--set]], we'll update the value at the end of the 
-path (or create it if it doesn't exist).
-This corresponds to how the [[.set]] method of [[Config]] works.
+We need two things to locate a course.
+We need the course name and the course register in which it is located.
 <<functions>>=
-<<default values for [[config_cmd]]>>
-
-@cli.command(name="config")
-def config_cmd(course: str = name_arg_autocomplete,
-               courses_dir = courses_dir_option,
-               path: str = path_arg,
-               values: typing.List[str] = value_arg):
+def get_course_config(course: str,
+                      register: str = None) -> config.Config:
   """
-  Reads values from or writes `values` to the config of `course` at `path`.
+  Returns a typerconf.Config object for the course's configuration. Writeback 
+  is enabled meaning that any changes made to the config object will be written 
+  back to the config file.
+
+  `course` identifies the course in the `register`. If `register` is None, 
+  search through all registers in the registry, use the first one found 
+  (undefined in which order duplicates are sorted).
   """
   <<set [[course]]'s config file as [[conf]]>>
-  if values:
-    <<change [[values]] to non-list if one-element list>>
-    <<if [[values]] is empty string, replace it with [[None]]>>
-    conf.set(path, values)
-  else:
-    print_config(conf.get(path), path)
+  return conf
 @
-
-We will now cover [[name_arg_autocomplete]], [[courses_dir_option]] \etc in
-[[<<default values for [[config_cmd]]>>]]
-as we cover the relevant parts of the algorithm.
 
 \subsection{Finding the course}
 
 Let's start with the course.
-We need the name of the course ([[course_name]]) so that we can look it up in 
-the course register ([[courses_dir]]) to get its config file.
+We need the name of the course ([[course]]) so that we can look it up in the 
+course register ([[register]]) to get its config file.
 
-We'll reuse the [[courses_dir_option]] from earlier, see 
-\cref{CreatingTheCourse}.
-We don't want to reuse [[name_arg]], since that one lacks autocompletion.
-<<default values for [[config_cmd]]>>=
-name_arg_autocomplete = typer.Argument(...,
-                            help="Name of the course whose config we want to "
-                                 "operate on.",
-                            autocompletion=complete_course_name)
-@
-
-To complete the course name we simply need to look up all matching courses in 
-the course registers.
-We want to improve the autocompletion for the user by including from which 
-course register as course is.
-Hence, we need both the course register name and its path.
-<<helper functions>>=
-def complete_course_name(ctx: typer.Context, incomplete: str):
-  """
-  Returns a list of course names matching `incomplete`.
-  """
-  <<populate [[courses_dirs]] with the course registers to use>>
-  for course_dir_name, course_dir_path in courses_dirs:
-    <<yield (course name, course dir name) tuples that matches [[incomplete]]>>
-@
-
-As mentioned above, if the user doesn't specify a course register, we search 
-through all of them.
-Remember that we want the name--path tuple for each course register.
-<<populate [[courses_dirs]] with the course registers to use>>=
-courses_dirs = courses_dirs_pairs(ctx.params.get("courses_dir"))
-<<helper functions>>=
-def courses_dirs_pairs(courses_dir_name=None):
-  """
-  Returns a list of (name, path)-tuples (pairs) for course registers to use.
-
-  If `courses_dir_name` is None, we use all existing course registers found 
-  in the config. Otherwise, we look up the path of the one specified and return 
-  a list containing only that name--path-tuple.
-  """
-  if courses_dir_name:
-    return [(courses_dir_name,
-             config.get(f"{REGISTERS}.{courses_dir_name}"))]
-  else:
-    return list(config.get(REGISTERS).items())
+As mentioned above, if the user doesn't specify a course register, we must 
+search through all of them.
+In that case, we'll use [[registry.list()]].
+If we have a register specified, we'll use [[registry.get(register_name)]].
+<<set [[course]]'s config file as [[conf]]>>=
+if register:
+  register_map = [register, registry.get(register)]
+else:
+  register_map = registry.list()
 @
 
 In the course register, each course has its own subdirectory.
-So we simply need to return the subdirectories of [[course_dir_path]] matching 
-[[incomplete]] together with [[course_dir_name]].
-<<yield (course name, course dir name) tuples that matches [[incomplete]]>>=
-courses = all_courses(courses_dir_path)
-matching_courses = filter(lambda x: x.startswith(incomplete), courses)
-return map(lambda x: (x, f"from {courses_dir_name}"),
-           matching_courses)
-<<helper functions>>=
-def all_courses(courses_dir_path):
-  """
-  Returns a list (generator) of all courses found in `courses_dir_path`.
-  """
-  for file in pathlib.Path(course_dir_path).iterdir():
-    if file.is_dir():
-      yield file.name
-@
-
 Now let's turn back to the main problem.
 <<set [[course]]'s config file as [[conf]]>>=
-courses_dirs = courses_dirs_pairs(courses_dir)
-
 try:
-  conf_path = get_conf_path(course, courses_dirs)
+  conf_path = get_course_conf_path(course, register_map)
 except KeyError as err:
-  logging.error(err)
-  sys.exit(1)
+  raise KeyError(f"Couldn't uniquely identify {course} in "
+                 f"registers {register_map.keys()}: {err}")
 
-conf = Config()
-conf.read_config(conf_path)
+conf = Config(conf_file=conf_path)
 @
 
-We want [[get_conf_path]] to ensure a unique match for [[course]].
+We want [[get_course_conf_path]] to ensure a unique match for [[course]].
 This means that we must search through all the course registers and keep 
 track of the number of matches.
 <<helper functions>>=
-def get_conf_path(course, courses_dirs):
+def get_course_conf_path(course, register_map):
   """
-  Find the course named `course` among all the courses in `courses_dirs`.
+  Find the course named `course` among all the courses in the registers found 
+  in `register_map`, a list of (name, path)-tuples.
+
   If `course` is not a unique match, it raises a `KeyError`.
   """
-  <<[[get_conf_path]] variables>>
+  <<[[get_course_conf_path]] variables>>
 
-  for course_dir_name, course_dir_path in courses_dirs:
-    <<search for matches to [[course]] in [[course_dir_path]]>>
+  for register_name, register_path in register_map:
+    <<search for matches to [[course]] in [[register_path]]>>
 
-  <<check ending criteria for [[get_conf_path]], return>>
+  <<check ending criteria for [[get_course_conf_path]], return>>
 @
 
 In each course register, we go through the courses to check for a match.
 If we find the course, we note its [[conf_path]] and also note that we had a 
-hit in [[courses_dir_name]].
-<<search for matches to [[course]] in [[course_dir_path]]>>=
-courses = all_courses(course_dir_path)
+hit in [[register_name]].
+<<search for matches to [[course]] in [[register_path]]>>=
+courses = all_courses(register_path)
 matching_courses = list(filter(lambda x: x == course, courses))
 if len(matching_courses) > 0:
   conf_path = course_dir_path / course / "config.json"
-  hits_from_courses_dirs.append(course_dir_name)
-<<[[get_conf_path]] variables>>=
-hits_from_courses_dirs = []
+  hits_from_register_dirs.append(register_name)
+<<[[get_course_conf_path]] variables>>=
+hits_from_register_dirs = []
 conf_path = None
+@
+
+To list all the courses, we simply list all directories in the register's 
+directory.
+<<helper functions>>=
+def all_courses(register_path):
+  """
+  Returns a list (generator) of all courses found in `register_path`.
+  """
+  for file in pathlib.Path(register_path).iterdir():
+    if file.is_dir():
+      yield file.name
 @
 
 Once we're through all the courses, we check if we have a non-[[None]] value in 
 [[conf_path]].
 If not, we didn't find anything.
-Otherwise, we check how many entries we have in [[hits_from_courses_dirs]].
+Otherwise, we check how many entries we have in [[hits_from_register_dirs]].
 If we have more than one, we raise an exception saying there were too many 
 matches.
-<<check ending criteria for [[get_conf_path]], return>>=
+<<check ending criteria for [[get_course_conf_path]], return>>=
 if not conf_path:
   raise KeyError(f"Couldn't find course {course}.")
-elif len(hits_from_courses_dirs) > 1:
+elif len(hits_from_register_dirs) > 1:
   raise KeyError(f"Course `{course}` found in "
-                  f"several course registers ({hits_from_course_dirs}).")
-@
+                  f"several course registers: {hits_from_course_dirs}.")
 
-\subsection{Navigating the course config}
-
-We can autocomplete the path since we can predict the possible values.
-<<default values for [[config_cmd]]>>=
-path_arg = typer.Argument("",
-                          help="Path in config, e.g. 'courses.datintro22'. "
-                               "Empty string is root of config. Defaults to "
-                               "the empty string.",
-                          autocompletion=complete_config_path)
-@
-
-The [[complete_config_path]] function returns the possible completions for an 
-incomplete path from the command line.
-<<helper functions>>=
-def complete_config_path(ctx: typer.Context, incomplete: str):
-  """
-  Returns all valid paths in the config starting with `incomplete`.
-  """
-  courses_dirs = courses_dirs_pairs(ctx.params.get("course_dir"))
-  conf_path = get_conf_path(ctx.params.get("course"), courses_dirs)
-  conf = Config()
-  conf.read_config(conf_path)
-
-  return filter(lambda x: x.startswith(incomplete),
-                conf.paths())
-@
-
-\subsection{Setting a value in course config}
-
-We let the user supply a list of values to set on the target path.
-<<default values for [[config_cmd]]>>=
-value_arg = typer.Option([], "-s", "--set",
-                         help="Values to store. "
-                              "More than one value makes a list. "
-                              "Values are treated as JSON if possible.")
-@
-
-If the user supplies only one argument on the command line, we don't want it to 
-be interpreted as a one-element list, but rather as a value that is not a list.
-Hence, we check and convert if necessary.
-<<change [[values]] to non-list if one-element list>>=
-if len(values) == 1:
-  values = values[0]
-@
-
-Additionally, if that one element is an empty string, we replace it with 
-[[None]] to trigger a delete.
-<<if [[values]] is empty string, replace it with [[None]]>>=
-if values == "":
-  values = None
-@
-
-\subsection{Printing the config}
-
-That [[print_config]] function should print the remaining levels of the config 
-tree.
-And we want it to print on the format of
-[[courses.datintro22.url = https://...]].
-This function will do a depth-first traversal through the config to print all 
-values.
-The idea is that the config path will move from the dictionary representation 
-in [[conf]] to the string representation in [[path]].
-When at the leaf, [[conf]] will contain the value and [[path]] the entire path.
-<<helper functions>>=
-def print_config(conf, path=""):
-  """
-  Prints the config tree contained in `conf` to stdout.
-  Optional `path` is prepended.
-  """
-  try:
-    for key in conf.keys():
-      <<recurse deeper into the config tree>>
-  <<print the leaf of config tree and return>>
-@
-
-The recursive step is quite straight-forward, we just call [[print_config]] 
-with the subtree ([[conf[key]]]) as an argument.
-However, we must check whether to prepend anything ([[path]]).
-The deeper we progress, the more we want to prepend.
-For instance, at the [[courses.datintro22]] level, [[print_config]] only knows 
-[[datintro22]], not the [[courses]] parent.
-Hence, we must supply [[courses]] to prepend to [[datintro22]] to get 
-[[courses.datintro22]].
-<<recurse deeper into the config tree>>=
-if path:
-  print_config(conf[key], f"{path}.{key}")
-else:
-  print_config(conf[key], key)
-@
-
-Finally, we get the base-case by exception.
-When a node ([[conf]]) doesn't have an attribute [[.keys()]], we know we're at 
-a leaf, so we print it.
-Then the complete path is in [[path]], the value in [[conf]].
-<<print the leaf of config tree and return>>=
-except AttributeError:
-  print(f"{path} = {conf}")
-@
-
-\subsection{Testing the [[courses config]] command}
-
-Let's test this command.
-We'll set up the testing.
-<<test functions>>=
-runner = CliRunner()
-
-def test_cli():
-  <<run tests on [[cli]]>>
-<<test imports>>=
-from typer.testing import CliRunner
-@
-
-Let's look at the actual tests.
-<<run tests on [[cli]]>>=
-target_course = "test"
-target_path = "contact"
-target_value = "Test Tester"
-
-result = runner.invoke(cli, ["new", target_course]),
-
-# set example data
-result = runner.invoke(cli, ["config", target_course,
-                             target_path, "--set", target_value])
-assert result.exit_code == 0
-
-# try access nonexisting
-result = runner.invoke(cli, ["config", target_course,
-                             f"{target_path}.nonexisting"])
-assert result.exit_code == 1
-
-# access existing
-result = runner.invoke(cli, ["config", target_course,
-                             target_path])
-assert target_value in result.stdout
-
-# clear config
-result = runner.invoke(cli, ["config", target_course,
-                             target_path, "--set", None])
-assert result.exit_code == 0
-
-# check that it's cleared
-result = runner.invoke(cli, ["config", target_course])
-assert target_path not in result.stdout

--- a/src/nytid/courses/init.nw
+++ b/src/nytid/courses/init.nw
@@ -105,7 +105,7 @@ if not register:
   elif len(registers) < 1:
     raise ValueError(f"There are no course registers in the config.")
   else:
-    register = registers[0]
+    register = registers[0][0]
 
 register_path = registry.get(register)
 @

--- a/src/nytid/courses/registry.nw
+++ b/src/nytid/courses/registry.nw
@@ -66,7 +66,7 @@ import pathlib
 from nytid.courses.registry import *
 
 test_name = "test_register"
-test_path = "/a/nonexisting/path"
+test_path = tempfile.mkdtemp()
 
 <<test functions>>
 @
@@ -271,9 +271,22 @@ implementation details.
 <<test functions>>=
 def test_rm():
   config = Config()
+
   add(test_name, test_path, config=config)
+  try:
+    get(test_name, config=config)
+  except KeyError:
+    assert False
+  else:
+    assert True
+
   remove(test_name, config=config)
-  assert test_name not in ls(config=config)
+  try:
+    get(test_name, config=config)
+  except KeyError:
+    assert True
+  else:
+    assert False
 
   try:
     remove(test_name, config=Config())

--- a/src/nytid/courses/registry.nw
+++ b/src/nytid/courses/registry.nw
@@ -45,7 +45,7 @@ module.
 <<registry.py>>=
 """The nytid course registry"""
 
-import typerconf as config
+import typerconf
 
 import pathlib
 from nytid import storage
@@ -87,7 +87,7 @@ We want to be able to override the default configuration by supplying a value
 to the [[config]] argument of these functions.
 This also helps with testing.
 <<config arg>>=
-config=config
+config: typerconf.Config = typerconf
 <<config arg doc>>=
 The default `config` is the default config of the `typerconf` package.
 @
@@ -211,16 +211,16 @@ want to test the relationship between [[add]] and [[get]], not implementation
 details.
 <<test functions>>=
 def test_get():
-  config = Config()
-  add(test_name, test_path, config=config)
-  assert get(test_name, config=config) == test_name
+  conf = Config()
+  add(test_name, test_path, config=conf)
+  assert get(test_name, config=conf) == test_path
 
   try:
-    get(test_name, config=Config())
-  except KeyError:
+    value = get(test_name, config=Config())
+  except:
     assert True
   else:
-    assert False
+    assert value and False
 @
 
 

--- a/src/nytid/courses/registry.nw
+++ b/src/nytid/courses/registry.nw
@@ -59,9 +59,10 @@ These are all prepended [[test_]] to the function name.
 We will run them using [[pytest]].
 We will set a default course and path to use.
 (Note that the path will not be created).
-<<test coursesdirs.py>>=
+<<test registry.py>>=
 from typerconf import Config
 import pathlib
+import tempfile
 
 from nytid.courses.registry import *
 

--- a/src/nytid/courses/registry.nw
+++ b/src/nytid/courses/registry.nw
@@ -79,7 +79,8 @@ We want to be able to
 \begin{itemize}
 \item add,
 \item remove,
-\item list
+\item list, and
+\item get the path of
 \end{itemize}
 course registers.
 
@@ -152,7 +153,8 @@ def test_add():
 <<functions>>=
 def list(<<config arg>>):
   """
-  Lists course registers added to configuration `config`.
+  Lists course registers added to configuration `config`. Returns a list of 
+  (name, path)-tuples.
 
   <<config arg doc>>
   """
@@ -209,7 +211,7 @@ We add the course register to test for in the listing by using [[add]] since we
 want to test the relationship between [[add]] and [[get]], not implementation 
 details.
 <<test functions>>=
-def test_list():
+def test_get():
   config = Config()
   add(test_name, test_path, config=config)
   assert get(test_name, config=config) == test_name
@@ -241,7 +243,7 @@ def remove(<<directory rm args>>
 Finally, to remove an entry, we simply need the name.
 Then we can drop that entry from the config.
 <<directory rm args>>=
-name
+name,
 <<directory rm args doc>>=
 - `name` is the name of the course register entry
 
@@ -269,7 +271,7 @@ We add the course register to test for in the listing by using [[add]] since we
 want to test the relationship between [[add]], [[remove]] and [[list]], not 
 implementation details.
 <<test functions>>=
-def test_list():
+def test_rm():
   config = Config()
   add(test_name, test_path, config=config)
   remove(test_name, config=config)

--- a/src/nytid/courses/registry.nw
+++ b/src/nytid/courses/registry.nw
@@ -63,8 +63,6 @@ We will set a default course and path to use.
 from typerconf import Config
 import pathlib
 
-<<test imports>>
-
 from nytid.courses.registry import *
 
 test_name = "test_register"
@@ -151,7 +149,7 @@ def test_add():
 \section{Listing all course registers}
 
 <<functions>>=
-def list(<<config arg>>):
+def ls(<<config arg>>):
   """
   Lists course registers added to configuration `config`. Returns a list of 
   (name, path)-tuples.
@@ -181,9 +179,9 @@ details.
 def test_list():
   config = Config()
   add(test_name, test_path, config=config)
-  assert test_name in list(config=config)
+  assert test_name in ls(config=config)
 
-  assert list(config=Config()) == []
+  assert ls(config=Config()) == []
 @
 
 
@@ -275,7 +273,7 @@ def test_rm():
   config = Config()
   add(test_name, test_path, config=config)
   remove(test_name, config=config)
-  assert test_name not in list(config=config)
+  assert test_name not in ls(config=config)
 
   try:
     remove(test_name, config=Config())

--- a/src/nytid/courses/registry.nw
+++ b/src/nytid/courses/registry.nw
@@ -151,8 +151,8 @@ def test_add():
 <<functions>>=
 def ls(<<config arg>>):
   """
-  Lists course registers added to configuration `config`. Returns a list of 
-  (name, path)-tuples.
+  Lists course registers added to configuration `config`. Returns a list of all 
+  register names.
 
   <<config arg doc>>
   """
@@ -164,7 +164,7 @@ the [[REGISTERS]] path in the config.
 If there is no [[REGISTERS]] in the config, we simply return an empty list.
 <<list course registers>>=
 try:
-  return list(config.get(REGISTERS).items())
+  return list(config.get(REGISTERS).keys())
 except KeyError:
   return []
 @

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -17,7 +17,7 @@ $(foreach files,${TESTS},$(eval $(call def_target, ${files})))
 
 .PHONY: test
 test: all
-	poetry run pytest
+	poetry run pytest ${PYTEST_FLAGS}
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
We want to break out the crucial functions into the `nytid.courses` module and keep only the CLI functions in `nytid.cli.courses`. So that `nytid.cli.courses` will use `nytid.courses`.

In this work we also want to rename courses directories to course registers. And have a `registry` module managing all registers.