### PR TITLE
Adds start of `nytid.monthly.sh`

### DIFF
--- a/src/nytid/cli/Makefile
+++ b/src/nytid/cli/Makefile
@@ -7,6 +7,7 @@ MODULES+=	signupsheets.py
 MODULES+=	hr.py
 
 EXTRAS+=	nytid.hourly.sh
+EXTRAS+=	nytid.monthly.sh
 
 .PHONY: all
 all: ${MODULES} ${EXTRAS}
@@ -15,7 +16,7 @@ all: ${MODULES} ${EXTRAS}
 __init__.py: init.py
 	${MV} $< $@
 
-nytid.hourly.sh: init.nw
+nytid.hourly.sh nytid.monthly.sh: init.nw
 	${NOTANGLE}
 
 .PHONY: clean

--- a/src/nytid/cli/init.nw
+++ b/src/nytid/cli/init.nw
@@ -18,16 +18,21 @@ We describe them in chronological order.
 So in essence, this section serves as a how-to-use manual.
 We will also create two scripts to use [[nytid]] to automate some tasks.
 <<nytid.hourly.sh>>=
+<<cronjob header>>
+<<nytid.monthly.sh>>=
+<<cronjob header>>
+<<cronjob header>>=
 #!/bin/bash
 
 source ${HOME}/.profile
 
 year=$(date +%y)
-@ We will expand on this as we proceed.
-But we can add the script to Cron to automate some tasks.
+@ We will expand on these as we proceed.
+But we can add them to Cron to automate some tasks.
 \begin{minted}{text}
 # m h  dom mon dow   command
   0 *  *   *   *     ${HOME}/bin/nytid.hourly.sh
+  0 0  1   *   *     ${HOME}/bin/nytid.monthly.sh
 \end{minted}
 
 \subsection{Setting up a course}


### PR DESCRIPTION
We want to include the timesheet generation in the monthly cronjob, so we need #65.