### PR TITLE
fix amanuensis create to create separate contracts

### DIFF
--- a/src/nytid/cli/hr.nw
+++ b/src/nytid/cli/hr.nw
@@ -522,6 +522,9 @@ This way we can easily calculate what has changed later to track
 \enquote{\foreignlanguage{swedish}{mertid}}.
 
 We let the [[create]] command generate a contract for an amanuensis.
+<<amanuensis create command doc>>=
+Creates contracts for amanuenses and stores the contracts in the configured 
+directory. This tracks all the sessions that an amanuensis has booked.
 <<subcommands>>=
 @amanuensis.command(name="create")
 def cli_amanuens_create(<<option for TAs to filter for>>,
@@ -535,7 +538,7 @@ def cli_amanuens_create(<<option for TAs to filter for>>,
                         <<option [[draft]] to not store contract>>,
                         <<option for CSV delimiter>>):
   """
-  Computes amanuensis data for a TA.
+  <<amanuensis create command doc>>
   """
   <<make all dates timezone aware>>
   <<set list [[courses]] to ((course, register), config)-pairs>>

--- a/src/nytid/signup/sheets.nw
+++ b/src/nytid/signup/sheets.nw
@@ -402,7 +402,7 @@ def filter_events_by_date(csv_rows, start_date=None, end_date=None):
   Output: a list of CSV rows containing only the rows with an event starting 
   between start_date and end_date.
   """
-  filtered = csv_rows.copy()
+  filtered = csv_rows
 
   if start_date:
     filtered = filter(


### PR DESCRIPTION
One TA had a contract until 2024-10-27. I later wanted to create a new contract 
from 2024-10-28. But that new contract included the old contract's events. It 
shouldn't, it should only contain events from 2024-10-28 onwards.

Other changes:

- Clarifies docstring for the amanuensis create command
- Removes unneeded `.copy()` from `filter_events_by_date` function
