### PR TITLE
configurable cli defaults

### DIFF
--- a/doc/nytid.tex
+++ b/doc/nytid.tex
@@ -53,6 +53,7 @@
 \input{../src/nytid/cli/todo.tex}
 \input{../tests/conftest.tex}
 \input{../src/nytid/cli/utils/init.tex}
+\input{../src/nytid/cli/utils/defaults.tex}
 \input{../src/nytid/cli/utils/rooms.tex}
 
 \part{Storage}

--- a/src/nytid/cli/hr.nw
+++ b/src/nytid/cli/hr.nw
@@ -24,6 +24,7 @@ import os
 import sys
 import typer
 import typerconf as config
+from nytid.cli.utils.defaults import default
 try:
     from typing import Annotated
 except ImportError:
@@ -840,9 +841,14 @@ In that case, we want to separate the output with a newline.
 first_print = True
 csvout = csv.writer(sys.stdout, delimiter=delimiter)
 <<option for CSV delimiter>>=
-delimiter: Annotated[str, delimiter_opt] = "\t"
+delimiter: Annotated[str,
+                     delimiter_opt] = DEFAULT_TIMESHEETS_DELIMITER
 <<argument and option definitions>>=
-delimiter_opt = typer.Option(help="Delimiter to use in CSV output.")
+HR_TIMESHEETS_DELIMITER_CONFIG = "hr.timesheets.delimiter"
+DEFAULT_TIMESHEETS_DELIMITER = default(
+    HR_TIMESHEETS_DELIMITER_CONFIG, "\t", str)
+delimiter_opt = typer.Option(help="Delimiter to use in CSV output. "
+                                  "[config: hr.timesheets.delimiter]")
 <<print [[amanuensis]] data for [[user]]>>=
 if first_print:
   first_print = False
@@ -2262,8 +2268,11 @@ def filter_summarized_events_by_date(events, start_date=None, end_date=None):
 
 We want to add different options to affect the rest of the processing.
 <<option [[diff]] to generate only when there's a difference in salary>>=
-diff: Annotated[bool, diff_opt] = True
+diff: Annotated[bool, diff_opt] = DEFAULT_TIMESHEETS_DIFF
 <<argument and option definitions>>=
+HR_TIMESHEETS_DIFF_CONFIG = "hr.timesheets.diff"
+DEFAULT_TIMESHEETS_DIFF = default(
+    HR_TIMESHEETS_DIFF_CONFIG, True, bool)
 diff_opt = typer.Option(help="diff: Only generate time sheets when there's a "
                              "difference in salary. "
                              "no-diff: Always generate time sheets when there "
@@ -2271,7 +2280,8 @@ diff_opt = typer.Option(help="diff: Only generate time sheets when there's a "
                              "salary to be paid. "
                              "(E.g. it's a change of dates.) "
                              "No time sheets will be generated if there "
-                             "are no new events.")
+                             "are no new events. "
+                             "[config: hr.timesheets.diff]")
 @
 
 By default, we output to stdout for quick previewing.
@@ -2431,9 +2441,14 @@ manager: Annotated[str, manager_opt] = default_manager,
 organization: Annotated[str, org_opt] = default_organization,
 project: Annotated[str, project_opt] = default_project
 <<option [[sign]] to include a signature>>=
-sign: Annotated[bool, sign_opt] = True
+sign: Annotated[bool, sign_opt] = DEFAULT_TIMESHEETS_SIGN
 <<argument and option definitions>>=
-sign_opt = typer.Option(help="Include the course responsible's signature.")
+HR_TIMESHEETS_SIGN_CONFIG = "hr.timesheets.sign"
+DEFAULT_TIMESHEETS_SIGN = default(
+    HR_TIMESHEETS_SIGN_CONFIG, True, bool)
+sign_opt = typer.Option(help="Include the course responsible's "
+                             "signature. "
+                             "[config: hr.timesheets.sign]")
 @
 
 We construct the filename from the TA's username.
@@ -2523,24 +2538,15 @@ their personal config.
 <<config manager>>=
 "<<how to set the value>> hr.manager -s <name>`."
 <<set [[default_manager]]>>=
-try:
-  default_manager = typerconf.get("hr.manager")
-except KeyError:
-  default_manager = ""
+default_manager = default("hr.manager", "", str)
 <<config organization>>=
 "<<how to set the value>> hr.organization -s <code>`."
 <<set [[default_organization]]>>=
-try:
-  default_organization = typerconf.get("hr.organization")
-except KeyError:
-  default_organization = ""
+default_organization = default("hr.organization", "", str)
 <<config project>>=
 "<<how to set the value>> hr.project -s <code>`."
 <<set [[default_project]]>>=
-try:
-  default_project = typerconf.get("hr.project")
-except KeyError:
-  default_project = ""
+default_project = default("hr.project", "", str)
 @
 
 It doesn't make sense to extract these from the course, since the pattern might 

--- a/src/nytid/cli/init.nw
+++ b/src/nytid/cli/init.nw
@@ -2408,6 +2408,7 @@ the flag or setting that consults the key.
     [[track.weekly_limit]]& [[40.0]]        & weekly hour cap \\
     [[track.daily_limit]] & [[8.0]]         & daily hour cap \\
     [[track.auto-suspend.<worker>]] & --    & per-worker auto-suspend \\
+    [[track.debug]]       & [[False]]       & deferred hook tracing \\
     [[track.ls.count]]    & [[10]]          & [[track ls -n]] \\
     [[track.ls.id]]       & [[True]]        & [[track ls --id/--no-id]] \\
     [[track.stats.days]]  & [[1]]           & [[track stats -n]] \\

--- a/src/nytid/cli/init.nw
+++ b/src/nytid/cli/init.nw
@@ -2351,10 +2351,10 @@ for module_name in modules:
 @
 
 For the [[config]] command, we will use the [[typerconf]] package.
-This doesn't have subcommands, so it doesn't have a [[cli]] object, we must 
+This doesn't have subcommands, so it doesn't have a [[cli]] object, we must
 thus do it slightly differently.
-The [[typerconf]] package has added a function [[add_config_cmd]] that takes 
-the Typer instance as argument, and uses that when it create the function for 
+The [[typerconf]] package has added a function [[add_config_cmd]] that takes
+the Typer instance as argument, and uses that when it create the function for
 the command.
 See [[pydoc3 typerconf]] for details.
 <<additional imports>>=
@@ -2362,6 +2362,77 @@ import typerconf
 <<add submodules' [[cli]] to [[cli]]>>=
 typerconf.add_config_cmd(cli)
 @
+
+\subsection{Known configuration keys for CLI defaults}%
+\label{sec:cli-config-keys}
+
+Most CLI options have sensible fallback values baked in, but users
+who want different defaults can set them persistently with
+\begin{quote}
+[[nytid config <key> -s <value>]]
+\end{quote}
+The [[cli.utils.defaults]] module
+(\cref{cli.utils.defaults}) resolves these keys at import time; a
+missing or malformed entry silently falls back to the hard-coded
+default so one bad config value never breaks the CLI.
+The [[--help]] text of every configurable option advertises its key
+with a trailing \enquote{[[[config: key]]]} suffix, so users can
+discover the keys without reading the source.
+
+\Cref{tab:cli-config-keys} lists every key known to the CLI at the
+time of writing.
+It is split by subcommand group; the \enquote{Read by} column names
+the flag or setting that consults the key.
+
+\begin{table}
+  \caption{Configurable CLI defaults, grouped by subcommand.}%
+  \label{tab:cli-config-keys}
+  \centering
+  \small
+  \begin{tabular}{lll}
+    \toprule
+    \textbf{Key} & \textbf{Fallback} & \textbf{Read by} \\
+    \midrule
+    \multicolumn{3}{l}{\emph{[[nytid todo]]}} \\
+    [[todo.data_dir]]     & (home-relative) & todo storage location \\
+    [[todo.max_boost]]    & [[10.0]]        & priority boost cap \\
+    [[todo.work_start]]   & [[08:00]]       & work-hour window start \\
+    [[todo.work_end]]     & [[17:00]]       & work-hour window end \\
+    [[todo.work_days]]    & [[mon..fri]]    & work-day mask \\
+    [[todo.ls.count]]     & [[10]]          & [[todo ls -n]] \\
+    [[todo.ls.format]]    & [[table]]       & [[todo ls -f]] \\
+    [[todo.ls.who]]       & [[$USER]]       & [[todo ls -w]] \\
+    \midrule
+    \multicolumn{3}{l}{\emph{[[nytid track]]}} \\
+    [[track.data_dir]]    & (home-relative) & tracking storage location \\
+    [[track.weekly_limit]]& [[40.0]]        & weekly hour cap \\
+    [[track.daily_limit]] & [[8.0]]         & daily hour cap \\
+    [[track.auto-suspend.<worker>]] & --    & per-worker auto-suspend \\
+    [[track.ls.count]]    & [[10]]          & [[track ls -n]] \\
+    [[track.ls.id]]       & [[True]]        & [[track ls --id/--no-id]] \\
+    [[track.stats.days]]  & [[1]]           & [[track stats -n]] \\
+    [[track.stats.summary]]&[[False]]       & [[track stats --summary]] \\
+    \midrule
+    \multicolumn{3}{l}{\emph{[[nytid schedule]]}} \\
+    [[schedule.show.format]]    & [[table]]  & [[schedule show -f]] \\
+    [[schedule.show.week]]      & [[False]]  & [[schedule show --week]] \\
+    [[schedule.show.location]]  & [[True]]   & [[schedule show --location]] \\
+    [[schedule.show.delimiter]] & [[\t]]     & [[schedule show --delimiter]] \\
+    \midrule
+    \multicolumn{3}{l}{\emph{[[nytid hr]]}} \\
+    [[hr.manager]]        & empty & default manager name \\
+    [[hr.organization]]   & empty & default organization \\
+    [[hr.project]]        & empty & default project \\
+    [[hr.timesheets.delimiter]] & [[\t]]  & [[hr timesheets --delimiter]] \\
+    [[hr.timesheets.diff]]      & [[True]]& [[hr timesheets --diff]] \\
+    [[hr.timesheets.sign]]      & [[True]]& [[hr timesheets --sign]] \\
+    \bottomrule
+  \end{tabular}
+\end{table}
+
+The table is advisory: the authoritative source is the set of
+[[<key>_CONFIG]] module-level constants in each CLI module, which
+are what the [[--help]] output ultimately reflects.
 
 
 \section{Configure logging and verbosity}

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -25,6 +25,7 @@ from nytid import schedules as schedutils
 from nytid.cli.signupsheets import SIGNUPSHEET_URL_PATH
 
 <<imports>>
+<<types>>
 <<constants>>
 
 cli = typer.Typer(
@@ -1012,6 +1013,20 @@ The four printing switches---format, week, location, and delimiter---are
 the kind of preference users set once and never change per invocation,
 so we resolve them from [[typerconf]] via the shared [[default]] helper
 (\cref{cli.utils.defaults}) at module import.
+
+The format setting needs one extra constraint: unlike the boolean and
+delimiter options, it is not free-form.  The config value must be one of
+the three supported output modes.  The natural representation is the
+[[OutputFormat]] enum itself, but that only works if the enum is tangled
+before the defaults block that uses it.
+
+<<types>>=
+class OutputFormat(str, Enum):
+  table = "table"
+  rich = "rich"
+  csv = "csv"
+@
+
 <<constants>>=
 SCHEDULE_SHOW_FORMAT_CONFIG = "schedule.show.format"
 SCHEDULE_SHOW_WEEK_CONFIG = "schedule.show.week"
@@ -1019,7 +1034,7 @@ SCHEDULE_SHOW_LOCATION_CONFIG = "schedule.show.location"
 SCHEDULE_SHOW_DELIMITER_CONFIG = "schedule.show.delimiter"
 
 DEFAULT_SHOW_FORMAT = default(SCHEDULE_SHOW_FORMAT_CONFIG,
-                              "table", str)
+                              OutputFormat.table, OutputFormat)
 DEFAULT_SHOW_WEEK = default(SCHEDULE_SHOW_WEEK_CONFIG, False, bool)
 DEFAULT_SHOW_LOCATION = default(SCHEDULE_SHOW_LOCATION_CONFIG,
                                 True, bool)
@@ -1028,11 +1043,6 @@ DEFAULT_SHOW_DELIMITER = default(SCHEDULE_SHOW_DELIMITER_CONFIG,
 @
 
 <<argument and option definitions>>=
-class OutputFormat(str, Enum):
-  table = "table"
-  rich = "rich"
-  csv = "csv"
-
 output_format_opt = typer.Option("--format", "-f",
                                  help="Output format: table, rich or csv. "
                                       "[config: schedule.show.format]",
@@ -1181,8 +1191,37 @@ The CLI commands themselves depend on course configuration and sign-up
 sheets, making them harder to test in isolation.
 The helper functions, however, contain important logic worth verifying.
 <<test [[clischedule.py]]>>=
+import importlib
 import datetime
+from unittest.mock import MagicMock
+
+import nytid.cli.schedule as schedule_module
+from nytid.cli.utils import defaults
 from nytid.cli.schedule import *
 
 <<test functions>>
+@
+
+An invalid configured output format should not poison the command
+signature at import time.  We reload the module under a fake config to
+exercise the same path that computes [[DEFAULT_SHOW_FORMAT]] in normal
+use.
+<<test functions>>=
+def test_invalid_schedule_show_format_falls_back(monkeypatch):
+  fake = MagicMock()
+
+  def fake_get(key):
+    if key == SCHEDULE_SHOW_FORMAT_CONFIG:
+      return "json"
+    raise KeyError(key)
+
+  fake.get.side_effect = fake_get
+  monkeypatch.setattr(defaults.typerconf, "Config", lambda: fake)
+  defaults._reset_cache()
+  reloaded = importlib.reload(schedule_module)
+  try:
+    assert reloaded.DEFAULT_SHOW_FORMAT == reloaded.OutputFormat.table
+  finally:
+    defaults._reset_cache()
+    importlib.reload(schedule_module)
 @

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -13,6 +13,7 @@ import ics.event
 import logging
 import typer
 import typerconf as config
+from nytid.cli.utils.defaults import default
 from typing import List, Optional
 try:
     from typing import Annotated
@@ -1006,6 +1007,26 @@ Like [[todo ls]], we use auto-format by default: rich table in a terminal,
 tab-separated CSV when piped.  The [[--output]] option writes CSV to a
 file instead of stdout; it also treats the output as non-interactive, so
 the header row is included for self-documentation.
+
+The four printing switches---format, week, location, and delimiter---are
+the kind of preference users set once and never change per invocation,
+so we resolve them from [[typerconf]] via the shared [[default]] helper
+(\cref{cli.utils.defaults}) at module import.
+<<constants>>=
+SCHEDULE_SHOW_FORMAT_CONFIG = "schedule.show.format"
+SCHEDULE_SHOW_WEEK_CONFIG = "schedule.show.week"
+SCHEDULE_SHOW_LOCATION_CONFIG = "schedule.show.location"
+SCHEDULE_SHOW_DELIMITER_CONFIG = "schedule.show.delimiter"
+
+DEFAULT_SHOW_FORMAT = default(SCHEDULE_SHOW_FORMAT_CONFIG,
+                              "table", str)
+DEFAULT_SHOW_WEEK = default(SCHEDULE_SHOW_WEEK_CONFIG, False, bool)
+DEFAULT_SHOW_LOCATION = default(SCHEDULE_SHOW_LOCATION_CONFIG,
+                                True, bool)
+DEFAULT_SHOW_DELIMITER = default(SCHEDULE_SHOW_DELIMITER_CONFIG,
+                                 "\t", str)
+@
+
 <<argument and option definitions>>=
 class OutputFormat(str, Enum):
   table = "table"
@@ -1013,11 +1034,13 @@ class OutputFormat(str, Enum):
   csv = "csv"
 
 output_format_opt = typer.Option("--format", "-f",
-                                 help="Output format: table, rich or csv",
+                                 help="Output format: table, rich or csv. "
+                                      "[config: schedule.show.format]",
                                  case_sensitive=False)
 @
 <<printing control options>>=
-output_format: Annotated[OutputFormat, output_format_opt] = "table",
+output_format: Annotated[OutputFormat,
+                         output_format_opt] = DEFAULT_SHOW_FORMAT,
 
 <<determine effective output format>>=
 if output_format == OutputFormat.table:
@@ -1120,21 +1143,24 @@ import sys
 
 We keep the [[week]] and [[location]] switches for both rich and CSV output.
 <<printing control options>>=
-week: Annotated[bool, week_opt] = False,
+week: Annotated[bool, week_opt] = DEFAULT_SHOW_WEEK,
 <<argument and option definitions>>=
-week_opt = typer.Option(help="Print week number and day of week")
+week_opt = typer.Option(help="Print week number and day of week. "
+                             "[config: schedule.show.week]")
 @
 <<printing control options>>=
-location: Annotated[bool, location_opt] = True,
+location: Annotated[bool, location_opt] = DEFAULT_SHOW_LOCATION,
 <<argument and option definitions>>=
-location_opt = typer.Option(help="Print location of event")
+location_opt = typer.Option(help="Print location of event. "
+                                 "[config: schedule.show.location]")
 @
 
 Finally, CSV uses a configurable delimiter with tab as default.
 <<printing control options>>=
-delimiter: Annotated[str, delimiter_opt] = "\t",
+delimiter: Annotated[str, delimiter_opt] = DEFAULT_SHOW_DELIMITER,
 <<argument and option definitions>>=
-delimiter_opt = typer.Option(help="Delimiter for CSV output")
+delimiter_opt = typer.Option(help="Delimiter for CSV output. "
+                                  "[config: schedule.show.delimiter]")
 @
 
 The [[--output]] option redirects CSV output to a named file.  Specifying

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -75,6 +75,7 @@ import sys
 import tempfile
 import typer
 import typerconf as config
+from nytid.cli.utils.defaults import default
 from typing import List, Optional, Dict
 try:
     from typing import Annotated
@@ -187,12 +188,8 @@ DEFAULT_MAX_BOOST = 10.0
 
 def get_max_boost() -> float:
     """Get the maximum deadline boost value."""
-    try:
-        return float(
-            config.get(TODO_MAX_BOOST_CONFIG)
-        )
-    except (KeyError, ValueError):
-        return DEFAULT_MAX_BOOST
+    return default(TODO_MAX_BOOST_CONFIG,
+                   DEFAULT_MAX_BOOST, float)
 
 
 DEFAULT_WORK_START = "08:00"
@@ -200,10 +197,8 @@ DEFAULT_WORK_START = "08:00"
 
 def get_work_start() -> str:
     """Get configured work day start time."""
-    try:
-        return config.get(TODO_WORK_START_CONFIG)
-    except KeyError:
-        return DEFAULT_WORK_START
+    return default(TODO_WORK_START_CONFIG,
+                   DEFAULT_WORK_START, str)
 
 
 DEFAULT_WORK_END = "17:00"
@@ -211,10 +206,8 @@ DEFAULT_WORK_END = "17:00"
 
 def get_work_end() -> str:
     """Get configured work day end time."""
-    try:
-        return config.get(TODO_WORK_END_CONFIG)
-    except KeyError:
-        return DEFAULT_WORK_END
+    return default(TODO_WORK_END_CONFIG,
+                   DEFAULT_WORK_END, str)
 
 
 DEFAULT_WORK_DAYS = "mon,tue,wed,thu,fri"
@@ -226,10 +219,8 @@ def get_work_days() -> List[str]:
     Handles both string (``"mon,tue,wed"``) and list
     (``["mon", "tue", "wed"]``) config formats.
     """
-    try:
-        days_val = config.get(TODO_WORK_DAYS_CONFIG)
-    except KeyError:
-        days_val = DEFAULT_WORK_DAYS
+    days_val = default(TODO_WORK_DAYS_CONFIG,
+                       DEFAULT_WORK_DAYS)
     if isinstance(days_val, list):
         days_val = ",".join(str(d) for d in days_val)
     return [d.strip().lower()
@@ -4613,6 +4604,26 @@ Label filters are positional arguments, matching the [[add]] command's
 convention ([[todo ls tilkry26 prep]] filters to items with either
 label).
 
+Three defaults on [[ls]] are worth making configurable so a user does
+not have to retype the same flag on every invocation: the row cap
+[[-n]], the output format, and the assignee filter.
+We read each from [[typerconf]] once at module import via the shared
+[[default]] helper (\cref{cli.utils.defaults}), giving Typer a
+resolved value to display in [[--help]].
+The [[--who]] fallback is [[default_username]] (that is, [[\$USER]]),
+matching the pre-existing behaviour.
+<<configuration>>=
+TODO_LS_COUNT_CONFIG = "todo.ls.count"
+TODO_LS_FORMAT_CONFIG = "todo.ls.format"
+TODO_LS_WHO_CONFIG = "todo.ls.who"
+
+DEFAULT_LS_COUNT = default(TODO_LS_COUNT_CONFIG, 10, int)
+DEFAULT_LS_FORMAT = default(TODO_LS_FORMAT_CONFIG,
+                            "table", str)
+DEFAULT_LS_WHO = default(TODO_LS_WHO_CONFIG,
+                         default_username, str)
+@
+
 <<argument and option definitions>>=
 label_filter_arg = typer.Argument(
     help="Filter by label",
@@ -4625,11 +4636,13 @@ ls_all_opt = typer.Option(
     help="Show full tree including subtasks")
 ls_count_opt = typer.Option(
     "-n",
-    help="Limit output to top N items")
+    help="Limit output to top N items. "
+         "[config: todo.ls.count]")
 ls_who_opt = typer.Option(
     "--who", "-w",
     help="Filter by assignee regex "
-         "(default: $USER, use '' for all)",
+         "(default: $USER, use '' for all). "
+         "[config: todo.ls.who]",
     autocompletion=complete_todo_workers)
 ls_flat_opt = typer.Option(
     "--flat",
@@ -4637,7 +4650,8 @@ ls_flat_opt = typer.Option(
 ls_format_opt = typer.Option(
     "--format", "-f",
     help="Output format: table (auto-detects TTY),"
-         " rich, csv, json")
+         " rich, csv, json. "
+         "[config: todo.ls.format]")
 ls_status_opt = typer.Option(
     "--status", "-s",
     help="Filter by status: "
@@ -4659,12 +4673,12 @@ def ls(
                             done_opt] = False,
     show_tree: Annotated[bool, ls_all_opt] = False,
     count: Annotated[Optional[int],
-                     ls_count_opt] = 10,
+                     ls_count_opt] = DEFAULT_LS_COUNT,
     who_filter: Annotated[Optional[str],
-                          ls_who_opt] = default_username,
+                          ls_who_opt] = DEFAULT_LS_WHO,
     flat: Annotated[bool, ls_flat_opt] = False,
     output_format: Annotated[str,
-                             ls_format_opt] = "table",
+                             ls_format_opt] = DEFAULT_LS_FORMAT,
     status_filter: Annotated[Optional[str],
                              ls_status_opt] = None,
     show_prio: Annotated[bool, ls_prio_opt] = False,

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -3243,12 +3243,20 @@ When all children of a parent become done, the parent is auto-completed.
 This runs as a separate locked mutation so that tracking labels can be
 stopped between the child completion and the parent status change.
 
+The new worker-scoped completion rules add one guard here.  A worker may
+complete only that worker's branch, so auto-completion must not let the
+last child completed for one worker silently mark another worker's
+parent done.  We therefore thread the resolved worker context into the
+helper and stop at the boundary when the parent belongs to someone else.
+
 <<helpers>>=
-def auto_complete_parent(item, todos):
+def auto_complete_parent(item, todos, who=None):
     """Auto-complete the parent if all siblings are done.
 
     Runs a second locked mutation so tracking labels
     are stopped before the parent status changes.
+    When ``who`` is given, only parents owned by that
+    worker are auto-completed.
     """
     if item.parent_id is None:
         return
@@ -3259,6 +3267,13 @@ def auto_complete_parent(item, todos):
         None,
     )
     if parent_item is None or parent_item.status == "done":
+        return
+    resolved_who = who
+    if resolved_who is None:
+        resolved_who = item.who or default_username
+    if (
+        parent_item.who or default_username
+    ) != resolved_who:
         return
 
     stop_todo_tracking(parent_item.id, parent_item, todos)
@@ -6457,7 +6472,7 @@ def done(
 
     <<stop tracking if active>>
     <<close github issue>>
-    auto_complete_parent(item, todos)
+    auto_complete_parent(item, todos, who=who)
 @
 
 Let's verify that [[done]] without an argument pops the stack
@@ -6573,6 +6588,43 @@ def test_done_explicit_other_worker_with_who_succeeds(
     )
     assert result.exit_code == 0
     assert "Other's task" in result.output
+
+
+def test_done_other_worker_child_does_not_auto_complete_my_parent(
+    temp_todo_dir,
+):
+    """Completing another worker's child leaves my parent alone."""
+    from nytid.cli.todo import default_username
+
+    save_todos(4, [
+        TodoItem(
+            id=1, title="My parent",
+            created="2026-02-20T10:00:00",
+            status="in-progress",
+            who=default_username,
+        ),
+        TodoItem(
+            id=2, title="Other child",
+            created="2026-02-20T10:00:00",
+            status="in-progress",
+            parent_id=1,
+            who="other-worker",
+        ),
+    ])
+    save_active_stack([1, 2])
+
+    result = runner.invoke(
+        cli, ["done", "2", "--who", "other-worker"]
+    )
+    assert result.exit_code == 0
+    assert "auto-completed" not in result.output
+    assert load_active_stack() == [1]
+
+    _, todos = load_todos()
+    parent = next(t for t in todos if t.id == 1)
+    child = next(t for t in todos if t.id == 2)
+    assert parent.status == "in-progress"
+    assert child.status == "done"
 @
 
 The [[--force]] guard prevents accidental completion of a parent whose

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -2308,6 +2308,17 @@ child to it).  The shutdown path treats both cases identically---one
 [[TrackingEntry]] per label at child exit---so the only difference is
 whether the original start time survives.
 
+The same rule must also cover the implicit label contributed by
+[[--command]].  Otherwise a launch could smuggle in an already-active
+command label after the preflight check and silently downgrade a conflict
+to [[Already tracking]].
+
+The effective launch label set should also be the one we report back to the
+user.  If an explicit label matches the implicit command basename, keeping
+the raw pre-deduplicated list would produce noisy output such as
+[[Already tracking: echo, echo]] even though the session state correctly
+tracks only one [[echo]] label.
+
 Track and todo should also present launch context the same way.  We therefore
 compute one context string up front and reuse it for tmux window names and
 as a best-effort [[PS1]] seed.  In tmux the user's [[~/.bashrc]] will
@@ -2317,6 +2328,7 @@ the primary context indicator for pane and window launches.
 <<prepare launch mode>>=
 launch_requested = command is not None or pane or window
 tracking_labels = list(labels)
+launch_owned_labels = list(tracking_labels)
 command_args = None
 command_text = None
 proc_env = None
@@ -2360,22 +2372,6 @@ if launch_requested:
     <<resolve working directory>>
     proc_cwd = wd_path if wd_path else proc_cwd
     proc_env = os.environ.copy()
-    launch_context = build_context_name(
-        "track", tracking_labels
-    )
-
-    conflicting_launch_labels = [
-        label for label in labels
-        if session.get_label_info(label) is not None
-    ]
-    if conflicting_launch_labels and not (replace or continue_labels):
-        typer.echo(
-            "Error: launch mode requires inactive labels, "
-            "--replace, or --continue: "
-            f"{', '.join(sorted(conflicting_launch_labels))}",
-            err=True,
-        )
-        raise typer.Exit(1)
 
     if command is not None:
         try:
@@ -2388,9 +2384,29 @@ if launch_requested:
             raise typer.Exit(1)
         command_text = command
         tracking_labels.append(os.path.basename(command_args[0]))
-        launch_context = build_context_name(
-            "track", tracking_labels
+
+    launch_owned_labels = list(dict.fromkeys(
+        tracking_labels
+    ))
+
+    launch_context = build_context_name(
+        "track", launch_owned_labels
+    )
+
+    conflicting_launch_labels = sorted({
+        label for label in launch_owned_labels
+        if session.get_label_info(label) is not None
+    })
+    if conflicting_launch_labels and not (replace or continue_labels):
+        typer.echo(
+            "Error: launch mode requires inactive labels, "
+            "--replace, or --continue: "
+            f"{', '.join(conflicting_launch_labels)}",
+            err=True,
         )
+        raise typer.Exit(1)
+
+    if command is not None:
         apply_context_prompt(launch_context, proc_env)
     elif pane or window:
         apply_context_prompt(launch_context, proc_env)
@@ -2407,7 +2423,7 @@ is encountered first during shutdown.
 
 <<start tracking and report results>>=
 started, already_tracking, discarded = start_tracking_labels(
-    tracking_labels,
+    launch_owned_labels,
     start_time=start_time,
     who=who,
     replace=replace,
@@ -2539,6 +2555,12 @@ labels via the normal window/pane-labels path.  When the window or
 pane exits, the ordinary shutdown path stops the labels and records a
 single [[TrackingEntry]] covering the original start time through the
 child's exit.
+
+That shutdown obligation belongs to the full effective launch label set,
+not just the subset that happened to be newly started for this launch.
+We therefore freeze the deduplicated ownership set in
+[[launch_owned_labels]] during launch setup and reuse it for both direct
+subprocess cleanup and the detached tmux finalizer.
 
 The two flags express different intents and are mutually exclusive in
 spirit (though the code tolerates either one being set): pick
@@ -2885,6 +2907,21 @@ def test_start_launch_requires_replace_for_active_labels(
     ) in result.stdout
 
 
+def test_start_launch_requires_replace_for_active_command_label(
+    temp_tracking_dir,
+):
+    """Launch mode also rejects an already-active implicit command label."""
+    runner.invoke(cli, ["start", "echo"])
+
+    result = runner.invoke(cli, [
+        "start", "work", "--command", "echo test"
+    ])
+
+    assert result.exit_code == 1
+    assert "launch mode requires inactive labels" in result.stdout
+    assert "echo" in result.stdout
+
+
 def test_start_launch_with_replace_restarts_active_label(
     temp_tracking_dir,
 ):
@@ -2900,8 +2937,8 @@ def test_start_launch_with_replace_restarts_active_label(
     assert "Running 'echo test'" in result.stdout
 
 
-def test_start_continue_preserves_active_session(temp_tracking_dir):
-    """--continue lets launch mode accept active labels and preserves start time."""
+def test_start_continue_stops_borrowed_labels_on_exit(temp_tracking_dir):
+    """--continue preserves the interval but still stops it on exit."""
     runner.invoke(cli, ["start", "labelA", "--offset", "-45m"])
 
     result = runner.invoke(cli, [
@@ -2913,12 +2950,22 @@ def test_start_continue_preserves_active_session(temp_tracking_dir):
     assert "Replaced" not in result.stdout
     assert "Running 'echo test'" in result.stdout
 
-    # The original ~45-minute-old start time must survive untouched.
     session = load_active_session(default_username)
-    start_time, _, _ = session.get_label_info("labelA")
-    delta = datetime.datetime.now() - start_time
-    assert delta.total_seconds() > 40 * 60, (
-        "--continue must not rewrite the original start time"
+    assert session.get_label_info("labelA") is None
+    assert session.get_label_info("echo") is None
+
+    label_entries = [
+        entry for entry in load_tracking_data()
+        if "labelA" in entry.labels
+    ]
+    assert len(label_entries) == 1
+    interval = (
+        label_entries[0].end_time
+        - label_entries[0].start_time
+    )
+    assert interval.total_seconds() > 40 * 60, (
+        "--continue must preserve the original start time "
+        "through child exit"
     )
 
 
@@ -6370,6 +6417,13 @@ source and destination.  We detect this by comparing the two IDs: a
 real switch always changes the selected window, so equality means
 the hook fired redundantly and should be silently discarded.
 
+An absent selected window ID is another case where the hook must do
+nothing.  [[get_tmux_selected_window_id()]] returns [[None]] when the
+detached subprocess cannot read tmux state reliably---for example if the
+session has already disappeared.  Treating that observation failure as a
+real switch to an untracked window would spuriously stop the source
+labels, so we bail out before appending any deferred event.
+
 <<detached window switch command>>=
 @cli.command(
     name="_window-switch-detached", hidden=True
@@ -6383,6 +6437,8 @@ def window_switch_detached(
     selected_window_id = get_tmux_selected_window_id(
         session_id,
     )
+    if selected_window_id is None:
+        return
     def read_and_update():
         prev_window_id = read_last_selected_window(
             who, tmux_server_key, session_id,
@@ -8261,6 +8317,34 @@ def test_window_switch_detached_skips_when_prev_equals_selected(
 
     mock_append.assert_not_called()
 
+
+def test_window_switch_detached_skips_when_selected_window_missing(
+    temp_tracking_dir,
+):
+    """Missing selected-window state must not emit a deferred switch."""
+    who = "me"
+    write_last_selected_window(
+        who, TEST_SERVER_KEY, TEST_SESSION_ID, "@3",
+    )
+
+    with patch(
+        "nytid.cli.track.get_tmux_selected_window_id",
+        return_value=None,
+    ), patch(
+        "nytid.cli.track.append_and_check_window_event",
+    ) as mock_append:
+        runner.invoke(cli, [
+            "_window-switch-detached",
+            "--server-key", TEST_SERVER_KEY,
+            "--session-id", TEST_SESSION_ID,
+            "--who", who,
+        ])
+
+    assert read_last_selected_window(
+        who, TEST_SERVER_KEY, TEST_SESSION_ID,
+    ) == "@3"
+    mock_append.assert_not_called()
+
 def test_window_switch_detached_emits_window_aware_marker(
     temp_tracking_dir,
 ):
@@ -9367,17 +9451,17 @@ if launch_requested:
 if command_text is not None:
     typer.echo(
         f"Running '{command_text}' and tracking with "
-        f"labels: {', '.join(sorted(tracking_labels))}"
+        f"labels: {', '.join(sorted(launch_owned_labels))}"
     )
 elif pane:
     typer.echo(
         f"Opening tracked shell in tmux pane with "
-        f"labels: {', '.join(sorted(tracking_labels))}"
+        f"labels: {', '.join(sorted(launch_owned_labels))}"
     )
 else:
     typer.echo(
         f"Opening tracked shell in tmux window with "
-        f"labels: {', '.join(sorted(tracking_labels))}"
+        f"labels: {', '.join(sorted(launch_owned_labels))}"
     )
 @
 
@@ -9446,7 +9530,7 @@ exit_fd, exit_code_file = tempfile.mkstemp(
 os.close(exit_fd)
 finalize_cmd = \
     build_detached_track_finalize_command(
-        tracking_labels, who
+        launch_owned_labels, who
     )
 finalize_cmd += (
     f"; rm -f {shlex.quote(exit_code_file)}"
@@ -9492,22 +9576,23 @@ finally:
 @
 
 <<stop launched labels>>=
+launched_labels = list(launch_owned_labels)
 end_time = datetime.datetime.now()
 session, completed_entries = stop_tracking_labels(
     who=who,
-    labels=started,
+    labels=launched_labels,
     end_time=end_time,
     quiet_if_missing=True,
 )
 @
 
-The launch cleanup path must unregister the labels this command started even
-when they were already auto-suspended before the subprocess exited.  Using the
-freshly computed [[completed_entries]] would miss that case and leave stale
-window or pane declarations behind.
+The launch cleanup path must unregister every label this launch owned even
+when some were only borrowed via [[--continue]] or were already auto-suspended
+before the subprocess exited.  Using the freshly computed
+[[completed_entries]] would miss those cases and leave stale window or pane
+declarations behind.
 
 <<unregister launched labels from tracked tmux context>>=
-launched_labels = list(started)
 if launched_labels:
     unregister_tmux_context_labels(
         launched_labels, who,
@@ -11519,6 +11604,28 @@ def test_start_command_without_labels_uses_command_label(
     assert result.exit_code == 0
     assert "Running 'echo test'" in result.stdout
     assert "tracking with labels: echo" in result.stdout
+
+
+def test_start_command_deduplicates_matching_explicit_label(
+    temp_tracking_dir,
+):
+    """Explicit and implicit command labels should not be reported twice."""
+    result = runner.invoke(cli, [
+        "start", "echo", "--command", "echo test"
+    ])
+
+    assert result.exit_code == 0
+    assert "Started tracking: echo" in result.stdout
+    assert "Started tracking: echo, echo" not in result.stdout
+    assert "Already tracking: echo, echo" not in result.stdout
+    assert "tracking with labels: echo" in result.stdout
+    assert "tracking with labels: echo, echo" not in result.stdout
+
+    entries = load_tracking_data()
+    assert len(entries) > 0
+    last_entry = entries[-1]
+    assert last_entry.labels == ["echo"]
+    assert last_entry.description == "echo test"
 
 
 def test_start_command_uses_command_basename_as_label(temp_tracking_dir):

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -154,6 +154,7 @@ import subprocess
 import tempfile
 import typer
 import typerconf as config
+from nytid.cli.utils.defaults import default
 from typing import List, Optional, Dict
 try:
     from typing import Annotated
@@ -401,10 +402,8 @@ DEFAULT_WEEKLY_LIMIT_CONFIG = "track.weekly_limit"
 <<configuration management>>=
 def get_default_weekly_limit() -> float:
     """Get the default weekly hour limit from config"""
-    try:
-        return float(config.get(DEFAULT_WEEKLY_LIMIT_CONFIG))
-    except (KeyError, ValueError):
-        return DEFAULT_WEEKLY_LIMIT_HOURS
+    return default(DEFAULT_WEEKLY_LIMIT_CONFIG,
+                   DEFAULT_WEEKLY_LIMIT_HOURS, float)
 @
 
 Likewise, the daily-limit key belongs with the daily-limit helper.
@@ -416,10 +415,8 @@ DEFAULT_DAILY_LIMIT_CONFIG = "track.daily_limit"
 <<configuration management>>=
 def get_default_daily_limit() -> float:
     """Get the default daily hour limit from config"""
-    try:
-        return float(config.get(DEFAULT_DAILY_LIMIT_CONFIG))
-    except (KeyError, ValueError):
-        return DEFAULT_DAILY_LIMIT_HOURS
+    return default(DEFAULT_DAILY_LIMIT_CONFIG,
+                   DEFAULT_DAILY_LIMIT_HOURS, float)
 @
 
 Auto-suspend has both runtime logic and tests that refer to the same
@@ -9835,9 +9832,21 @@ requested (or fewer if the history is shorter).
 
 When the user wants to repair history, though, a bare timestamp line is
 not enough: they need a stable way to name one specific entry.  The
-optional [[--id]] flag (which is actually default now) prepends a short, unique 
-prefix of each entry's [[content_hash()]], giving us Git-style identification 
+optional [[--id]] flag (which is actually default now) prepends a short, unique
+prefix of each entry's [[content_hash()]], giving us Git-style identification
 without storing a separate persistent identifier.
+
+Both the default row count and the default for the id column are worth
+configuring, since users tend to settle on a personal preference.  We
+read them once at module import through the shared [[default]] helper
+(\cref{cli.utils.defaults}).
+<<constants>>=
+TRACK_LS_COUNT_CONFIG = "track.ls.count"
+TRACK_LS_ID_CONFIG = "track.ls.id"
+
+DEFAULT_TRACK_LS_COUNT = default(TRACK_LS_COUNT_CONFIG, 10, int)
+DEFAULT_TRACK_LS_ID = default(TRACK_LS_ID_CONFIG, True, bool)
+@
 
 <<argument and option definitions>>=
 ls_labels_arg = typer.Argument(
@@ -9846,11 +9855,13 @@ ls_labels_arg = typer.Argument(
     autocompletion=complete_historical_labels)
 ls_number_opt = typer.Option(
     "--number", "-n",
-    help="Number of entries to show")
+    help="Number of entries to show. "
+         "[config: track.ls.count]")
 ls_id_opt = typer.Option(
     "--id/--no-id",
     help="Remove column with content-hash "
-         "prefixes for entries")
+         "prefixes for entries. "
+         "[config: track.ls.id]")
 @
 
 <<ls command>>=
@@ -9858,8 +9869,8 @@ ls_id_opt = typer.Option(
 def ls_entries(
     labels: Annotated[List[str],
                       ls_labels_arg] = None,
-    n: Annotated[int, ls_number_opt] = 10,
-    show_id: Annotated[bool, ls_id_opt] = True,
+    n: Annotated[int, ls_number_opt] = DEFAULT_TRACK_LS_COUNT,
+    show_id: Annotated[bool, ls_id_opt] = DEFAULT_TRACK_LS_ID,
     who: Annotated[Optional[str],
                    who_filter_opt] = None,
 ):
@@ -10450,6 +10461,18 @@ prorated: if the window is 3 days and the weekly limit is 40 hours, we
 warn after 40 * 3/7 ≈ 17 hours rather than a fixed 40. This keeps the
 warning meaningful for both short and long windows.
 
+The window length and summary toggle are the two defaults worth
+configuring per user; the weekly/daily limits are already config-backed
+elsewhere.
+<<constants>>=
+TRACK_STATS_DAYS_CONFIG = "track.stats.days"
+TRACK_STATS_SUMMARY_CONFIG = "track.stats.summary"
+
+DEFAULT_TRACK_STATS_DAYS = default(TRACK_STATS_DAYS_CONFIG, 1, int)
+DEFAULT_TRACK_STATS_SUMMARY = default(TRACK_STATS_SUMMARY_CONFIG,
+                                      False, bool)
+@
+
 <<argument and option definitions>>=
 stats_labels_arg = typer.Argument(
     help="Filter statistics by specific labels "
@@ -10457,19 +10480,23 @@ stats_labels_arg = typer.Argument(
     autocompletion=complete_historical_labels)
 stats_days_opt = typer.Option(
     "--days", "-n",
-    help="Number of days to include in stats")
+    help="Number of days to include in stats. "
+         "[config: track.stats.days]")
 weekly_limit_opt = typer.Option(
     "--weekly-limit",
     help="Weekly hour limit for warnings "
-         "(uses config default if not specified)")
+         "(uses config default if not specified). "
+         "[config: track.weekly_limit]")
 daily_limit_opt = typer.Option(
     "--daily-limit",
     help="Daily hour limit for warnings "
-         "(uses config default if not specified)")
+         "(uses config default if not specified). "
+         "[config: track.daily_limit]")
 summary_opt = typer.Option(
     "--summary",
     help="Include an overall summary "
-         "for the whole window")
+         "for the whole window. "
+         "[config: track.stats.summary]")
 @
 
 <<stats command>>=
@@ -10477,14 +10504,16 @@ summary_opt = typer.Option(
 def stats(
     labels: Annotated[List[str],
                       stats_labels_arg] = None,
-    days: Annotated[int, stats_days_opt] = 1,
+    days: Annotated[int,
+                    stats_days_opt] = DEFAULT_TRACK_STATS_DAYS,
     weekly_limit: Annotated[Optional[float],
                             weekly_limit_opt] = None,
     daily_limit: Annotated[Optional[float],
                            daily_limit_opt] = None,
     who: Annotated[Optional[str],
                    who_filter_opt] = None,
-    summary: Annotated[bool, summary_opt] = False,
+    summary: Annotated[bool,
+                       summary_opt] = DEFAULT_TRACK_STATS_SUMMARY,
 ):
     """
     Show aggregated statistics for recent tracking history.

--- a/src/nytid/cli/utils/Makefile
+++ b/src/nytid/cli/utils/Makefile
@@ -1,6 +1,7 @@
 SUBDIR_GOALS=	all clean distclean
 
 MODULES+=	__init__.py
+MODULES+=	defaults.py
 MODULES+=	rooms.py
 
 .PHONY: all

--- a/src/nytid/cli/utils/defaults.nw
+++ b/src/nytid/cli/utils/defaults.nw
@@ -1,0 +1,180 @@
+\chapter{Configurable CLI defaults, the \texttt{cli.utils.defaults}
+module}%
+\label{cli.utils.defaults}
+
+Many CLI options have sensible fallback values---for instance,
+[[nytid todo ls]] lists ten items when invoked without [[-n]]---but
+different users prefer different numbers.
+Rather than hard-coding each such default in the [[typer.Option(...)]]
+call, we read it from the personal [[typerconf]] config on startup and
+let the user override it with [[nytid config <key> -s <value>]].
+
+This module provides the single helper that every CLI module calls to
+resolve its defaults.
+The design is motivated by two observations.
+
+\begin{description}
+\item[Fallback must never raise.]
+  A missing key, a malformed value, or a wrong type must return the
+  hard-coded fallback rather than propagate an exception.
+  We resolve defaults at module import time, so a single corrupt
+  config entry would otherwise break \emph{every} [[nytid]] subcommand
+  until the user fixed the config file by hand.
+
+\item[One disk read per process.]
+  The [[typerconf.get]] module-level function constructs a new
+  [[Config]] object and calls [[read_config]] on every invocation;
+  that is one JSON file read per lookup.
+  With dozens of configurable defaults spread across four CLI
+  modules, that adds up to noticeable latency before Typer even
+  dispatches the subcommand.
+  We read the file once into an in-memory [[Config]] object and reuse
+  it.
+\end{description}
+
+\section{Module structure}
+
+<<[[defaults.py]]>>=
+"""Resolve CLI option defaults from the personal ``typerconf`` config.
+
+All CLI modules use ``default(key, fallback, cast)`` to seed their
+``typer.Option(...)`` declarations. See the ``cli.utils.defaults``
+chapter in the manual for the design rationale.
+"""
+import typerconf
+
+<<cached config helpers>>
+<<the default function>>
+@
+
+\section{Caching the config object}
+
+\label{cli.utils.defaults.cache}
+
+We keep a single [[Config]] object at module scope and populate it on
+first use.
+Doing the read lazily (rather than at import) keeps tests that patch
+[[typerconf]] before calling [[default]] working as expected.
+
+Constructing [[Config]] without a [[conf_file]] argument disables
+automatic write-back, which is exactly what we want: the cache is
+read-only by design.
+The cache is deliberately \emph{not} invalidated when code elsewhere
+calls [[typerconf.set]]: that call writes through its own [[Config]]
+instance to persist a value for \emph{future} invocations, not to
+re-read it within the same process.
+Call sites that write and then read within a single run continue to
+use [[typerconf.get]] directly.
+<<cached config helpers>>=
+_CACHE = None
+
+def _cached_config():
+  """Return a process-lifetime ``Config`` populated from disk once."""
+  global _CACHE
+  if _CACHE is None:
+    cfg = typerconf.Config()
+    cfg.read_config()
+    _CACHE = cfg
+  return _CACHE
+@
+
+For tests that want to exercise a different config within a single
+process, we also expose a private reset hook.
+<<cached config helpers>>=
+def _reset_cache():
+  """Drop the cached config so the next ``default`` call re-reads it."""
+  global _CACHE
+  _CACHE = None
+@
+
+\section{The [[default]] function}
+
+Every caller spells its lookup the same way: a dotted key, a
+fallback, and an optional type cast.
+<<the default function>>=
+def default(key, fallback, cast=None):
+  """Read ``key`` from the cached config, falling back to ``fallback``.
+
+  ``cast``, if given, is applied to the stored value; any
+  ``TypeError`` or ``ValueError`` it raises is swallowed and
+  ``fallback`` is returned.
+  """
+  try:
+    value = _cached_config().get(key)
+  except KeyError:
+    return fallback
+  if cast is None:
+    return value
+  try:
+    return cast(value)
+  except (TypeError, ValueError):
+    return fallback
+@
+
+\section{Tests}
+
+Tests are tangled into [[tests/test_cliutilsdefaults.py]].
+We rely on [[unittest.mock]] to substitute the cached config without
+touching the real config file.
+Every test resets the cache first, via an autouse fixture, so the
+ordering between tests does not matter.
+<<test [[cliutilsdefaults.py]]>>=
+import sys
+sys.path.insert(0, "../src")
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from nytid.cli.utils import defaults
+from nytid.cli.utils.defaults import default
+
+<<test fixtures>>
+<<test functions>>
+@
+
+<<test fixtures>>=
+@pytest.fixture(autouse=True)
+def reset_defaults_cache():
+  defaults._reset_cache()
+  yield
+  defaults._reset_cache()
+@
+
+A missing key returns the fallback unchanged.
+<<test functions>>=
+def test_default_missing_key_returns_fallback():
+  fake = MagicMock()
+  fake.get.side_effect = KeyError("nope")
+  with patch.object(defaults.typerconf, "Config", return_value=fake):
+    assert default("absent.key", 42) == 42
+@
+
+A present key is cast to the requested type.
+<<test functions>>=
+def test_default_casts_value():
+  fake = MagicMock()
+  fake.get.return_value = "25"
+  with patch.object(defaults.typerconf, "Config", return_value=fake):
+    assert default("todo.ls.count", 10, int) == 25
+@
+
+A malformed value falls back silently rather than raising.
+<<test functions>>=
+def test_default_malformed_value_falls_back():
+  fake = MagicMock()
+  fake.get.return_value = "not a number"
+  with patch.object(defaults.typerconf, "Config", return_value=fake):
+    assert default("todo.ls.count", 10, int) == 10
+@
+
+And the core performance property: the config is read from disk
+exactly once regardless of how many keys we look up.
+<<test functions>>=
+def test_default_reads_config_once():
+  fake = MagicMock()
+  fake.get.side_effect = KeyError("nope")
+  with patch.object(defaults.typerconf, "Config", return_value=fake):
+    for _ in range(5):
+      default("some.key", 0)
+  assert fake.read_config.call_count == 1
+@

--- a/src/nytid/cli/utils/defaults.nw
+++ b/src/nytid/cli/utils/defaults.nw
@@ -44,6 +44,7 @@ chapter in the manual for the design rationale.
 import typerconf
 
 <<cached config helpers>>
+<<bool parsing helper>>
 <<the default function>>
 @
 
@@ -87,6 +88,28 @@ def _reset_cache():
   _CACHE = None
 @
 
+The only cast that needs more than a direct constructor call is
+[[bool]].
+Python treats every non-empty string as true, so a config value like
+[["false"]] would otherwise enable the option we are trying to disable.
+We therefore parse the common textual forms explicitly and reject the
+rest so [[default()]] can fall back safely.
+<<bool parsing helper>>=
+def _cast_bool(value):
+  """Parse boolean config values from native or textual forms."""
+  if isinstance(value, bool):
+    return value
+  if isinstance(value, int) and value in (0, 1):
+    return bool(value)
+  if isinstance(value, str):
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+      return True
+    if normalized in {"0", "false", "no", "off"}:
+      return False
+  raise ValueError(f"invalid boolean value: {value!r}")
+@
+
 \section{The [[default]] function}
 
 Every caller spells its lookup the same way: a dotted key, a
@@ -106,6 +129,8 @@ def default(key, fallback, cast=None):
   if cast is None:
     return value
   try:
+    if cast is bool:
+      return _cast_bool(value)
     return cast(value)
   except (TypeError, ValueError):
     return fallback
@@ -165,6 +190,27 @@ def test_default_malformed_value_falls_back():
   fake.get.return_value = "not a number"
   with patch.object(defaults.typerconf, "Config", return_value=fake):
     assert default("todo.ls.count", 10, int) == 10
+@
+
+Boolean defaults are often stored as strings in config files, so we
+parse the common textual forms explicitly.
+<<test functions>>=
+def test_default_parses_boolean_strings():
+  fake = MagicMock()
+  fake.get.side_effect = ["false", "yes"]
+  with patch.object(defaults.typerconf, "Config", return_value=fake):
+    assert default("schedule.show.week", True, bool) is False
+    assert default("track.ls.id", False, bool) is True
+@
+
+Unknown boolean spellings should fall back rather than act like
+[[True]] just because the string is non-empty.
+<<test functions>>=
+def test_default_invalid_boolean_falls_back():
+  fake = MagicMock()
+  fake.get.return_value = "sometimes"
+  with patch.object(defaults.typerconf, "Config", return_value=fake):
+    assert default("schedule.show.week", False, bool) is False
 @
 
 And the core performance property: the config is read from disk

--- a/src/nytid/cli/utils/init.nw
+++ b/src/nytid/cli/utils/init.nw
@@ -25,6 +25,12 @@ modules = package_contents(__name__)
 for module_name in modules:
   try:
     module = importlib.import_module(module_name)
+  except Exception as err:
+    logging.warning(f"Trying to import {module_name} yields: {err}")
+    continue
+  if not hasattr(module, "cli"):
+    continue
+  try:
     cli.add_typer(module.cli)
   except Exception as err:
     logging.warning(f"Trying to add {module_name} yields: {err}")

--- a/src/nytid/cli/utils/init.nw
+++ b/src/nytid/cli/utils/init.nw
@@ -23,18 +23,10 @@ cli = typer.Typer(
 
 modules = package_contents(__name__)
 for module_name in modules:
-  try:
-    module = importlib.import_module(module_name)
-  except Exception as err:
-    logging.warning(f"Trying to import {module_name} yields: {err}")
-    continue
+  module = importlib.import_module(module_name)
   if not hasattr(module, "cli"):
     continue
-  try:
-    cli.add_typer(module.cli)
-  except Exception as err:
-    logging.warning(f"Trying to add {module_name} yields: {err}")
-    continue
+  cli.add_typer(module.cli)
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
- **Add cli.utils.defaults helper for config-backed CLI defaults**
- **Make todo ls defaults configurable via nytid config**
- **Make track ls and track stats defaults configurable**
- **Make schedule show defaults configurable**
- **Make hr timesheets defaults configurable**
- **Document configurable CLI default keys**
- **Fix configurable CLI default parsing**
- **Stop masking utils loader failures**
- **Respect worker scope in todo parent completion**
- **Fix tmux launch bookkeeping in track**
