### PR TITLE
feature/track ls sort option

### DIFF
--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -8422,6 +8422,39 @@ DEFAULT_TRACK_LS_COUNT = default(TRACK_LS_COUNT_CONFIG, 10, int)
 DEFAULT_TRACK_LS_ID = default(TRACK_LS_ID_CONFIG, True, bool)
 @
 
+The sort key joins that same category.  The question a user normally
+asks at the prompt is \enquote{what did I most recently finish?} ---
+not \enquote{what did I most recently start?}.  The two questions
+diverge whenever sessions overlap or get backfilled with [[--at]]: a
+long morning block and a brief mid-morning one have opposite orderings
+under the two keys, and only the stop-time view puts the
+finished-most-recently session at the top where a glance expects it.
+So [[stop]] is the default, and [[start]] remains available for users
+who prefer the legacy view (e.g.\ when spotting sessions logged in the
+wrong order).
+
+We encode the two valid choices in a [[str]]-backed [[Enum]] so Typer
+renders them in [[--help]] and supplies shell completion for free, the
+same pattern used by [[ExportFormat]] later in this module.  The
+fallback in [[default()]] is the [[Enum]] member itself, while the
+[[cast]] is the [[Enum]] class --- calling [[TrackLsSort("stop")]]
+constructs the member from the stored config value, and an
+unrecognised string raises [[ValueError]] which [[default()]] catches
+and replaces with the fallback.
+
+<<constants>>=
+class TrackLsSort(str, Enum):
+    start = "start"
+    stop = "stop"
+
+TRACK_LS_SORT_CONFIG = "track.ls.sort"
+DEFAULT_TRACK_LS_SORT = default(
+    TRACK_LS_SORT_CONFIG,
+    TrackLsSort.stop,
+    TrackLsSort,
+)
+@
+
 <<argument and option definitions>>=
 ls_labels_arg = typer.Argument(
     help="Filter by labels "
@@ -8436,6 +8469,11 @@ ls_id_opt = typer.Option(
     help="Remove column with content-hash "
          "prefixes for entries. "
          "[config: track.ls.id]")
+ls_sort_opt = typer.Option(
+    "--sort",
+    help="Sort entries by start or stop time "
+         "(most recent first). "
+         "[config: track.ls.sort]")
 @
 
 <<ls command>>=
@@ -8445,6 +8483,8 @@ def ls_entries(
                       ls_labels_arg] = None,
     n: Annotated[int, ls_number_opt] = DEFAULT_TRACK_LS_COUNT,
     show_id: Annotated[bool, ls_id_opt] = DEFAULT_TRACK_LS_ID,
+    sort_by: Annotated[TrackLsSort,
+                       ls_sort_opt] = DEFAULT_TRACK_LS_SORT,
     who: Annotated[str | None,
                    who_filter_opt] = None,
 ):
@@ -8459,6 +8499,7 @@ def ls_entries(
       nytid track ls
       nytid track ls DD1310 -n 5
       nytid track ls --id
+      nytid track ls --sort start
       nytid track ls --who Dan-Claude
     """
     <<load and filter for ls>>
@@ -8478,14 +8519,24 @@ if not entries:
 
 Entries are sorted most-recent-first because the typical use case is
 checking recent work --- older entries scroll off the terminal rather
-than consuming attention.  Each entry shows start--end times so the
-reader does not have to mentally add start plus duration.
-Like [[stats]], the renderer uses a Rich table when writing
-to a terminal and falls back to plain text for pipes:
+than consuming attention.  The [[sort_by]] argument picks which
+timestamp drives that ordering: [[stop]] (the default, for reasons
+given when we introduced [[TrackLsSort]]) and [[start]] (the legacy
+view).  We evaluate the selector inside the [[key]] lambda so the
+chosen attribute is read once per entry without an extra pass over
+[[entries]].  Each entry shows start--end times so the reader does
+not have to mentally add start plus duration.  Like [[stats]], the
+renderer uses a Rich table when writing to a terminal and falls back
+to plain text for pipes:
 
 <<display ls entries>>=
 entries.sort(
-    key=lambda e: e.start_time, reverse=True
+    key=lambda e: (
+        e.end_time
+        if sort_by == TrackLsSort.stop
+        else e.start_time
+    ),
+    reverse=True,
 )
 hash_prefixes = abbreviate_hashes(
     [entry.content_hash() for entry in entries]
@@ -8958,6 +9009,58 @@ def test_rm_tracking_entry_requires_confirmation(temp_tracking_dir):
     assert result.exit_code == 0
     assert "Cancelled." in result.stdout
     assert len(load_tracking_data()) == 1
+@
+
+The stop-time default is the visible behaviour change introduced
+alongside [[--sort]]: without an explicit test, a future refactor
+could quietly slip the sort key back to [[start_time]] and nobody
+would notice until a user complained.  We construct two entries
+whose start order is the \emph{opposite} of their stop order ---
+a long morning session that finishes at noon and a short
+mid-morning session that finishes well before then --- so any sort
+keyed on start time fails the assertion below:
+
+<<test functions>>=
+def test_ls_sort_default_is_stop_time(temp_tracking_dir):
+    """Default ls sort puts the latest-finishing entry first."""
+    runner.invoke(cli, [
+        "add", "longone",
+        "--at", "2026-03-12 09:00",
+        "--duration", "4"
+    ])
+    runner.invoke(cli, [
+        "add", "shortone",
+        "--at", "2026-03-12 10:00",
+        "--duration", "30m"
+    ])
+    result = runner.invoke(cli, ["ls"])
+    assert result.exit_code == 0
+    assert result.output.index("longone") < \
+        result.output.index("shortone")
+@
+
+The legacy view is the opt-in escape hatch we promised in the
+narrative.  Reusing the same crossed-ordering fixture makes the
+two tests collectively prove that [[--sort]] genuinely switches
+the key --- not merely that one ordering happens to match:
+
+<<test functions>>=
+def test_ls_sort_start_restores_legacy_order(temp_tracking_dir):
+    """--sort start orders entries by start time, most recent first."""
+    runner.invoke(cli, [
+        "add", "longone",
+        "--at", "2026-03-12 09:00",
+        "--duration", "4"
+    ])
+    runner.invoke(cli, [
+        "add", "shortone",
+        "--at", "2026-03-12 10:00",
+        "--duration", "30m"
+    ])
+    result = runner.invoke(cli, ["ls", "--sort", "start"])
+    assert result.exit_code == 0
+    assert result.output.index("shortone") < \
+        result.output.index("longone")
 @
 
 The [[-n]] limit is the primary output-size control; if the slice

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -8522,12 +8522,14 @@ checking recent work --- older entries scroll off the terminal rather
 than consuming attention.  The [[sort_by]] argument picks which
 timestamp drives that ordering: [[stop]] (the default, for reasons
 given when we introduced [[TrackLsSort]]) and [[start]] (the legacy
-view).  We evaluate the selector inside the [[key]] lambda so the
-chosen attribute is read once per entry without an extra pass over
-[[entries]].  Each entry shows start--end times so the reader does
-not have to mentally add start plus duration.  Like [[stats]], the
-renderer uses a Rich table when writing to a terminal and falls back
-to plain text for pipes:
+view).  The selector lives inside the [[key]] lambda so we keep a
+single [[entries.sort()]] call rather than duplicating the call
+across an [[if]]/[[else]] on [[sort_by]] --- the two key choices
+stay in one place where a future third key (say, [[duration]])
+can join them.  Each entry shows start--end times so the reader
+does not have to mentally add start plus duration.  Like [[stats]],
+the renderer uses a Rich table when writing to a terminal and falls
+back to plain text for pipes:
 
 <<display ls entries>>=
 entries.sort(


### PR DESCRIPTION
- **Bumps version**
- **Add --sort option to track ls**
- **Fix misleading rationale in ls sort prose**
