### PR TITLE
Add shell completion for tracking-entry hashes

### DIFF
--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -256,7 +256,7 @@ register: Annotated[str, register_option] = MINE,
 register_option = typer.Option(help="Name of register to use. "
                                     "Must be used if there are more than "
                                     "one register in the config.",
-                               shell_complete=complete_register)
+                               autocompletion=complete_register)
 @ See \cref{mine} for the [[MINE]] constant.
 
 We also want to have a function for autocompletion in the shell.
@@ -1181,7 +1181,7 @@ We'd sometimes like to match courses from several registers.
 Then we'd like to filter them based on regex.
 <<argument and option definitions>>=
 register_opt_regex = typer.Option(help="Regex for register names to use.",
-                                     shell_complete=registers_regex)
+                                     autocompletion=registers_regex)
 @
 
 The autocomplete function should take the regex and match all registers that 

--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -340,9 +340,55 @@ related: Annotated[list[str], related_opt] = [],
 <<new arguments and options>>=
 related_opt = typer.Option(help="List of related course codes, "
                                 "courses with any of these codes can "
-                                "share TAs.")
+                                "share TAs.",
+                           autocompletion=complete_course_code)
 <<course settings>>=
 "related_codes": related,
+@
+
+A related code is, by construction, a [[code]] that some existing
+course already carries---that is the whole point of relating courses
+to share TAs.  So rather than ask the user to remember codes, we
+complete from the codes recorded across the registers.  We reuse
+[[register_pairs]] and [[all_courses]] (\cref{cli.courses}) to walk the
+same course tree the other completers use, and read each course's
+[[code]] setting.  Unreadable courses are skipped individually so one
+broken config cannot suppress every suggestion.
+<<helper functions>>=
+def complete_course_code(ctx: typer.Context, incomplete: str):
+  """
+  Returns distinct course codes matching `incomplete`.
+  """
+  try:
+    pairs = register_pairs(ctx.params.get("register"))
+  except Exception:
+    return []
+  codes = set()
+  for register, register_path in pairs:
+    for course in courses.all_courses(register_path):
+      try:
+        code = courses.get_course_config(course, register).get("code")
+      except Exception:
+        continue
+      if code and code.startswith(incomplete):
+        codes.add(code)
+  return sorted(codes)
+@
+
+We create a course carrying a known code and confirm completion finds
+it, honours the typed prefix, and yields nothing for a non-matching
+prefix.  The completer reads [[ctx.params]] for the register, so we
+stand in a minimal context object:
+
+<<test functions>>=
+def test_complete_course_code():
+  runner.invoke(cli, ["new", "coursewithcode",
+                      "--register", register,
+                      "--code", "DD1301"])
+  ctx = SimpleNamespace(params={"register": register})
+  assert "DD1301" in complete_course_code(ctx, "")
+  assert complete_course_code(ctx, "DD13") == ["DD1301"]
+  assert complete_course_code(ctx, "zzz") == []
 @
 
 \subsection{The schedule}
@@ -469,6 +515,7 @@ target_value = "Test Tester"
 runner.invoke(cli, ["new", target_course, "--register", register])
 <<test imports>>=
 import tempfile
+from types import SimpleNamespace
 from typer.testing import CliRunner
 @
 

--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -261,8 +261,16 @@ register_option = typer.Option(help="Name of register to use. "
 
 We also want to have a function for autocompletion in the shell.
 We simply filter out the matching names available in the registry.
+
+Typer builds the completion wrapper by inspecting this callback's
+signature and injecting only the arguments it recognises by type or
+name---a [[click.Context]], the prior [[args]], or the [[str]] being
+completed.  An unrecognised parameter is rejected outright, so unlike
+Click's [[shell_complete]] hook (which always passes [[ctx]], [[param]],
+[[incomplete]]) we declare only the [[incomplete]] prefix we actually
+use.
 <<helper functions>>=
-def complete_register(ctx, param, incomplete: str):
+def complete_register(incomplete: str):
   """
   Returns list of matching register names available.
   """

--- a/src/nytid/cli/hr.nw
+++ b/src/nytid/cli/hr.nw
@@ -33,6 +33,7 @@ import operator
 
 from nytid.cli import courses as coursescli
 from nytid.cli.signupsheets import SIGNUPSHEET_URL_PATH
+from nytid.cli.signupsheets import complete_signup_users
 from nytid import schedules as schedutils
 from nytid.signup import hr
 from nytid.signup import sheets
@@ -747,12 +748,15 @@ draft_opt = typer.Option(help="Create a draft, "
 \subsection{Default arguments for user regex}
 
 We just set up an option defaulting to match anything.
+The completion source should match [[schedule]] so users can tab-complete
+known TA usernames instead of guessing or retyping them.
 <<option for TAs to filter for>>=
 user_regex: Annotated[str, user_regex_opt] = ".*"
 <<argument and option definitions>>=
 user_regex_opt = typer.Option("--user",
                               help="Regex to match TAs' usernames that "
-                                   "should be included.")
+                                   "should be included.",
+                              autocompletion=complete_signup_users)
 @
 
 This allows us to do the check using regexes.
@@ -1092,7 +1096,8 @@ def cli_amanuens_show(<<argument [[user_regex]] to match TAs>> = ".*",
 user_regex: Annotated[str, user_regex_arg]
 <<argument and option definitions>>=
 user_regex_arg = typer.Argument(help="Regex to match TAs' usernames that "
-                                     "should be included.")
+                                      "should be included.",
+                                 autocompletion=complete_signup_users)
 @
 
 This is similar as above, we just give a different warning message.

--- a/src/nytid/cli/init.nw
+++ b/src/nytid/cli/init.nw
@@ -2577,6 +2577,32 @@ def test_verbosity_level_mapping(
     assert level == expected_level
 @
 
+\section{The whole command tree must build}
+
+Typer materialises each command---and validates every option's
+[[autocompletion]] callback---only when the Click command tree is
+constructed, not when the module is imported.  Because our per-module
+tests invoke individual sub-apps, a malformed parameter on a command
+that no test happens to build can still ship and only fail in the user's
+shell when they first run [[nytid]].  A completer whose signature Typer
+cannot satisfy (a parameter that is neither the context, the prior args,
+nor the [[str]] being completed) is exactly such a latent failure.
+
+One test closes the gap: [[get_command]] walks every registered group
+and command and builds each parameter, so any such defect raises here
+instead of at first use.  We assert nothing beyond \enquote{it builds}
+because the construction itself is the contract under test.
+
+<<test [[init.py]]>>=
+import typer.main
+
+from nytid.cli import cli as nytid_cli
+
+def test_command_tree_builds():
+  """Building the full CLI must not raise."""
+  typer.main.get_command(nytid_cli)
+@
+
 
 \section{Shared utilities}
 

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -19,6 +19,7 @@ from typing import Annotated
 from nytid.cli import courses as coursescli
 from nytid import schedules as schedutils
 from nytid.cli.signupsheets import SIGNUPSHEET_URL_PATH
+from nytid.cli.signupsheets import complete_signup_users
 
 <<imports>>
 <<types>>
@@ -158,75 +159,15 @@ from nytid.cli import get_default_username
 default_username = get_default_username()
 
 username_opt = typer.Option(help="Username to filter sign-up sheet for, "
-                                 "defaults to logged in user's username.",
-                            autocompletion=complete_schedule_users)
+                                  "defaults to logged in user's username.",
+                             autocompletion=complete_signup_users)
 @
 
 The candidates for [[--user]] are exactly the TAs appearing on the
-sign-up sheets of the matching courses, so we complete by reading the
-same sheets the [[ics]] command itself reads.  We mirror its data
-path---resolve the matching courses with [[get_courses_configs]], then
-read each sheet and collect TA identifiers with [[get_TAs_from_csv]].
-
-Unlike the other completers in nytid, this one reaches out to the
-network: each sign-up sheet lives behind a URL.  That is acceptable
-because completion is opt-in (the user pressed \textsc{tab}), but it
-means a slow or unreachable sheet must never hang or crash the shell.
-We therefore swallow every error per course and overall, returning
-whatever we managed to gather---in the worst case an empty list, which
-simply offers no suggestions.
-<<helper functions>>=
-def complete_schedule_users(ctx, args, incomplete):
-  """Complete usernames from matching courses' sign-up sheets."""
-  try:
-    course = ctx.params.get("course") or ".*"
-    register = ctx.params.get("register") or coursescli.MINE
-    users = set()
-    for (_, _), config in coursescli.get_courses_configs(
-        course, register).items():
-      try:
-        url = config.get(SIGNUPSHEET_URL_PATH)
-        if "docs.google.com" in url:
-          url = sheets.google_sheet_to_csv_url(url)
-        for row in sheets.read_signup_sheet_from_url(url):
-          users.update(sheets.get_TAs_from_csv(row))
-      except Exception:
-        continue
-    return sorted(u for u in users if u.startswith(incomplete))
-  except Exception:
-    return []
-@
-
-We verify the gathering and prefix filtering without touching the
-network by stubbing the course lookup and sheet reading.  The empty
-context exercises the default course and register:
-
-<<test functions>>=
-def test_complete_schedule_users(monkeypatch):
-  """Completion gathers TA usernames from sign-up sheets."""
-  config = MagicMock()
-  config.get.return_value = "http://example/sheet.csv"
-  monkeypatch.setattr(
-    schedule_module.coursescli, "get_courses_configs",
-    lambda course, register: {("c", "r"): config},
-  )
-  monkeypatch.setattr(
-    schedule_module.sheets, "read_signup_sheet_from_url",
-    lambda url: [["row1"], ["row2"]],
-  )
-  monkeypatch.setattr(
-    schedule_module.sheets, "get_TAs_from_csv",
-    lambda row: ["alice", "bob"] if row == ["row1"]
-                else ["carol"],
-  )
-  ctx = MagicMock()
-  ctx.params = {}
-  assert complete_schedule_users(ctx, None, "") == [
-    "alice", "bob", "carol",
-  ]
-  assert complete_schedule_users(ctx, None, "a") == ["alice"]
-  assert complete_schedule_users(ctx, None, "z") == []
-@
+sign-up sheets of the matching courses.  That logic is shared with the
+[[hr]] commands, so [[schedule]] reuses
+[[signupsheets.complete_signup_users]] rather than keeping a second copy
+of the same network-tolerant completer here.
 
 We will filter [[booked]] by the sought-after username, if there is one.
 We also want to prefix a "RESERVE:" to the event if the person is a reserve and 
@@ -521,7 +462,8 @@ external_source_arg = typer.Argument(
     ..., help="External ICS source to remove",
     autocompletion=complete_external_sources)
 external_opt = typer.Option("--external", "-x",
-                            help="Additional ICS URL or file path")
+                            help="Additional ICS URL or file path",
+                            autocompletion=complete_external_sources)
 @
 
 The configured path is a list value in config, but we also accept a single

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -158,7 +158,74 @@ from nytid.cli import get_default_username
 default_username = get_default_username()
 
 username_opt = typer.Option(help="Username to filter sign-up sheet for, "
-                                 "defaults to logged in user's username.")
+                                 "defaults to logged in user's username.",
+                            autocompletion=complete_schedule_users)
+@
+
+The candidates for [[--user]] are exactly the TAs appearing on the
+sign-up sheets of the matching courses, so we complete by reading the
+same sheets the [[ics]] command itself reads.  We mirror its data
+path---resolve the matching courses with [[get_courses_configs]], then
+read each sheet and collect TA identifiers with [[get_TAs_from_csv]].
+
+Unlike the other completers in nytid, this one reaches out to the
+network: each sign-up sheet lives behind a URL.  That is acceptable
+because completion is opt-in (the user pressed \textsc{tab}), but it
+means a slow or unreachable sheet must never hang or crash the shell.
+We therefore swallow every error per course and overall, returning
+whatever we managed to gather---in the worst case an empty list, which
+simply offers no suggestions.
+<<helper functions>>=
+def complete_schedule_users(ctx, args, incomplete):
+  """Complete usernames from matching courses' sign-up sheets."""
+  try:
+    course = ctx.params.get("course") or ".*"
+    register = ctx.params.get("register") or coursescli.MINE
+    users = set()
+    for (_, _), config in coursescli.get_courses_configs(
+        course, register).items():
+      try:
+        url = config.get(SIGNUPSHEET_URL_PATH)
+        if "docs.google.com" in url:
+          url = sheets.google_sheet_to_csv_url(url)
+        for row in sheets.read_signup_sheet_from_url(url):
+          users.update(sheets.get_TAs_from_csv(row))
+      except Exception:
+        continue
+    return sorted(u for u in users if u.startswith(incomplete))
+  except Exception:
+    return []
+@
+
+We verify the gathering and prefix filtering without touching the
+network by stubbing the course lookup and sheet reading.  The empty
+context exercises the default course and register:
+
+<<test functions>>=
+def test_complete_schedule_users(monkeypatch):
+  """Completion gathers TA usernames from sign-up sheets."""
+  config = MagicMock()
+  config.get.return_value = "http://example/sheet.csv"
+  monkeypatch.setattr(
+    schedule_module.coursescli, "get_courses_configs",
+    lambda course, register: {("c", "r"): config},
+  )
+  monkeypatch.setattr(
+    schedule_module.sheets, "read_signup_sheet_from_url",
+    lambda url: [["row1"], ["row2"]],
+  )
+  monkeypatch.setattr(
+    schedule_module.sheets, "get_TAs_from_csv",
+    lambda row: ["alice", "bob"] if row == ["row1"]
+                else ["carol"],
+  )
+  ctx = MagicMock()
+  ctx.params = {}
+  assert complete_schedule_users(ctx, None, "") == [
+    "alice", "bob", "carol",
+  ]
+  assert complete_schedule_users(ctx, None, "a") == ["alice"]
+  assert complete_schedule_users(ctx, None, "z") == []
 @
 
 We will filter [[booked]] by the sought-after username, if there is one.

--- a/src/nytid/cli/signupsheets.nw
+++ b/src/nytid/cli/signupsheets.nw
@@ -21,6 +21,7 @@ from nytid.signup import hr
 from nytid.signup import sheets
 
 <<imports>>
+<<helper functions>>
 <<constants>>
 
 cli = typer.Typer(
@@ -63,6 +64,74 @@ signupsheets subcommand requires at least one course.
 courses = coursescli.get_courses_configs(course, register)
 if not courses:
   sys.exit(1)
+@
+
+The same course lookup and sign-up-sheet reading logic is also useful
+for shell completion.  Both [[schedule]] and [[hr]] need to suggest TA
+usernames from the matching courses' sheets, so we keep that completer
+here with the sign-up-sheet code instead of duplicating it in each
+command module.
+
+Like the schedule completer it replaces, this helper may need to fetch a
+remote CSV when the sign-up sheet lives in Google Sheets or similar.
+That makes failures normal rather than exceptional at completion time:
+the shell asked for suggestions, but the command itself has not started
+yet.  We therefore swallow per-course failures and return whatever names
+we managed to gather, which keeps \textsc{tab} completion responsive.
+
+<<helper functions>>=
+def complete_signup_users(ctx, args, incomplete):
+  """Complete usernames from matching courses' sign-up sheets."""
+  try:
+    course = ctx.params.get("course") or ".*"
+    register = ctx.params.get("register") or coursescli.MINE
+    users = set()
+    for (_, _), config in coursescli.get_courses_configs(
+        course, register).items():
+      try:
+        url = config.get(SIGNUPSHEET_URL_PATH)
+        if "docs.google.com" in url:
+          url = sheets.google_sheet_to_csv_url(url)
+        for row in sheets.read_signup_sheet_from_url(url):
+          users.update(sheets.get_TAs_from_csv(row))
+      except Exception:
+        continue
+    return sorted(u for u in users if u.startswith(incomplete))
+  except Exception:
+    return []
+@
+
+We can verify the gathering and prefix filtering without touching the
+network by stubbing the course lookup and sheet-reading functions on the
+[[signupsheets]] module itself.  An empty context exercises the default
+course and register fallback used by commands that only know the current
+user's courses.
+
+<<test functions>>=
+def test_complete_signup_users(monkeypatch):
+  """Completion gathers TA usernames from sign-up sheets."""
+  config = MagicMock()
+  config.get.return_value = "http://example/sheet.csv"
+  monkeypatch.setattr(
+    signupsheets_module.coursescli, "get_courses_configs",
+    lambda course, register: {("c", "r"): config},
+  )
+  monkeypatch.setattr(
+    signupsheets_module.sheets, "read_signup_sheet_from_url",
+    lambda url: [["row1"], ["row2"]],
+  )
+  monkeypatch.setattr(
+    signupsheets_module.sheets, "get_TAs_from_csv",
+    lambda row: ["alice", "bob"] if row == ["row1"]
+                else ["carol"],
+  )
+  ctx = MagicMock()
+  ctx.params = {}
+  assert complete_signup_users(ctx, None, "") == [
+    "alice", "bob", "carol",
+  ]
+  assert complete_signup_users(ctx, None, "a") == ["alice"]
+  assert complete_signup_users(ctx, None, "z") == []
 @
 
 \section{Generate sign-up sheet}
@@ -216,9 +285,25 @@ def set_url(<<argument for matching courses>>,
 SIGNUPSHEET_URL_PATH = "signupsheet.url"
 <<argument and option definitions>>=
 url_arg = typer.Argument(help="The URL for the sign-up sheet. "
-                              "For Google Sheets, it's the same URL as the "
-                              "one shared with TAs to sign up. "
-                              "For others, it's a URL to a CSV file.")
+                               "For Google Sheets, it's the same URL as the "
+                               "one shared with TAs to sign up. "
+                               "For others, it's a URL to a CSV file.")
+@
+
+
+\section{Test setup}
+
+We only need a light-weight setup here: import the generated module,
+bring its public names into scope, and provide the mocking helpers used
+by the completer test.
+
+<<test [[clisignupsheets.py]]>>=
+from unittest.mock import MagicMock
+
+import nytid.cli.signupsheets as signupsheets_module
+from nytid.cli.signupsheets import *
+
+<<test functions>>
 @
 
 

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -5138,14 +5138,14 @@ def ls(
 
     Ranked items are shown first by effective priority; unranked
     items follow in deadline order. By default shows only top-level
-    items assigned to the current user. Pass [[--all]] to see the
-    full tree including subtasks, or [[-n N]] to cap the output at
+    items assigned to the current user. Pass `--all` to see the
+    full tree including subtasks, or `-n N` to cap the output at
     N items.
 
-    [[--who]] defaults to [[\\$USER]]; pass an empty string
-    ([[--who '']]) to show all assignees.
+    `--who` defaults to $USER; pass an empty string
+    (`--who ''`) to show all assignees.
 
-    Output format defaults to [[table]], which auto-detects the
+    Output format defaults to `table`, which auto-detects the
     terminal: rich-formatted when stdout is a TTY, plain CSV
     otherwise (suitable for piping).
     """

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -2640,14 +2640,19 @@ def complete_todo_workers(ctx, args, incomplete):
         return []
 @
 
-The [[sync]] command's [[--repo]] filter only makes sense for a
-repository that has actually been imported, so we draw candidates
-from the [[github]] metadata already stored on local items rather
-than querying GitHub.  This keeps completion instant and offline---a
-repository the user never imported could not match any item anyway.
+Both [[sync --repo]] and the [[import]] repository argument benefit
+from knowing which repositories the user has already worked with: the
+[[sync]] filter only makes sense for an imported repository, and
+[[import]] is most often used to pull \emph{more} items from a repo
+already in play.  We therefore draw candidates from the [[github]]
+metadata already stored on local items rather than querying GitHub.
+This keeps completion instant and offline.  A repository never
+imported before will not be suggested, but that is acceptable---the
+user types the new [[owner/repo]] once and it becomes a candidate
+thereafter.
 
 <<autocompletion functions>>=
-def complete_sync_repos(ctx, args, incomplete):
+def complete_known_repos(ctx, args, incomplete):
     """Complete repo names from imported todos."""
     try:
         _, todos = load_todos()
@@ -2669,7 +2674,7 @@ imported, and respects the typed prefix.  The locally created item
 (with no [[github]] metadata) must not appear:
 
 <<test functions>>=
-def test_complete_sync_repos(temp_todo_dir):
+def test_complete_known_repos(temp_todo_dir):
   """Completion lists imported repos, filtered by prefix."""
   save_todos(4, [
     TodoItem(id=1, title="From alpha",
@@ -2681,13 +2686,13 @@ def test_complete_sync_repos(temp_todo_dir):
     TodoItem(id=3, title="Local only",
              created="2026-02-20T10:00:00"),
   ])
-  assert complete_sync_repos(None, None, "") == [
+  assert complete_known_repos(None, None, "") == [
     "owner/alpha", "owner/beta",
   ]
-  assert complete_sync_repos(None, None, "owner/a") == [
+  assert complete_known_repos(None, None, "owner/a") == [
     "owner/alpha",
   ]
-  assert complete_sync_repos(None, None, "zzz") == []
+  assert complete_known_repos(None, None, "zzz") == []
 @
 
 \section{GitHub Integration}
@@ -11097,7 +11102,8 @@ def test_import_type_enum_values():
 
 <<argument and option definitions>>=
 import_repo_arg = typer.Argument(
-    help="GitHub repo (owner/repo)")
+    help="GitHub repo (owner/repo)",
+    autocompletion=complete_known_repos)
 import_number_opt = typer.Option(
     "--number", "-n",
     help="Import only this issue/PR number")
@@ -12142,7 +12148,7 @@ network blip for one issue should not prevent syncing the rest.
 sync_repo_opt = typer.Option(
     "--repo", "-r",
     help="Only sync items from this repo",
-    autocompletion=complete_sync_repos)
+    autocompletion=complete_known_repos)
 @
 
 <<sync command>>=
@@ -12559,7 +12565,7 @@ from nytid.cli.todo import (
     append_note_to_item,
     NotInTmuxError,
     resolve_todo_from_tmux_context,
-    complete_sync_repos,
+    complete_known_repos,
     ImportType,
     TodoStatus,
     LsFormat,

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -10891,6 +10891,16 @@ in a separate task list.
 
 \subsection{The [[export]] Command}
 
+As with [[todo ls]], the export format is a closed set of meaningful
+choices.  Modeling it as an enum lets Typer validate and complete the
+accepted values instead of treating [[--format]] as arbitrary text.
+
+<<constants>>=
+class TodoExportFormat(str, Enum):
+    """Export formats for `todo export`."""
+    vtodo = "vtodo"
+@
+
 <<argument and option definitions>>=
 export_output_opt = typer.Option(
     "--output", "-o",
@@ -10910,8 +10920,8 @@ def export(
                       export_output_opt] = None,
     all_items: Annotated[bool,
                          export_all_opt] = False,
-    format: Annotated[str,
-                      export_format_opt] = "vtodo",
+    format: Annotated[TodoExportFormat,
+                      export_format_opt] = TodoExportFormat.vtodo,
 ):
     """Export todos as ICS (VTODO)."""
     _, todos = load_todos()
@@ -10923,7 +10933,7 @@ def export(
         typer.echo("No todos to export.", err=True)
         return
 
-    if format == "vtodo":
+    if format == TodoExportFormat.vtodo:
         ics_data = export_vtodo(todos)
     else:
         typer.echo(

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -80,6 +80,7 @@ from nytid.cli.utils.defaults import default
 from nytid.cli.utils.labels import apply_label_edits
 from typing import Annotated
 from dataclasses import dataclass, field
+from enum import Enum
 
 from nytid import storage
 
@@ -2554,10 +2555,10 @@ def test_assign_priority_between():
 \section{Shell Autocompletion}
 
 Following the patterns established in [[track.nw]], we provide
-completion functions for labels, worker names, and todo IDs. We
-import [[complete_workers]] and [[complete_historical_labels]] from
-the track module where possible, and extend them with todo-specific
-data.
+completion functions for labels, worker names, todo IDs, and the
+repositories of imported items. We import [[complete_workers]] and
+[[complete_historical_labels]] from the track module where possible,
+and extend them with todo-specific data.
 
 <<autocompletion functions>>=
 def complete_labels(ctx, args, incomplete):
@@ -2637,6 +2638,56 @@ def complete_todo_workers(ctx, args, incomplete):
         )
     except Exception:
         return []
+@
+
+The [[sync]] command's [[--repo]] filter only makes sense for a
+repository that has actually been imported, so we draw candidates
+from the [[github]] metadata already stored on local items rather
+than querying GitHub.  This keeps completion instant and offline---a
+repository the user never imported could not match any item anyway.
+
+<<autocompletion functions>>=
+def complete_sync_repos(ctx, args, incomplete):
+    """Complete repo names from imported todos."""
+    try:
+        _, todos = load_todos()
+        repos = {
+            t.github["repo"]
+            for t in todos
+            if t.github
+        }
+        return sorted(
+            r for r in repos
+            if r.startswith(incomplete)
+        )
+    except Exception:
+        return []
+@
+
+Let's verify that completion offers only the repositories actually
+imported, and respects the typed prefix.  The locally created item
+(with no [[github]] metadata) must not appear:
+
+<<test functions>>=
+def test_complete_sync_repos(temp_todo_dir):
+  """Completion lists imported repos, filtered by prefix."""
+  save_todos(4, [
+    TodoItem(id=1, title="From alpha",
+             created="2026-02-20T10:00:00",
+             github={"repo": "owner/alpha", "number": "1"}),
+    TodoItem(id=2, title="From beta",
+             created="2026-02-20T10:00:00",
+             github={"repo": "owner/beta", "number": "2"}),
+    TodoItem(id=3, title="Local only",
+             created="2026-02-20T10:00:00"),
+  ])
+  assert complete_sync_repos(None, None, "") == [
+    "owner/alpha", "owner/beta",
+  ]
+  assert complete_sync_repos(None, None, "owner/a") == [
+    "owner/alpha",
+  ]
+  assert complete_sync_repos(None, None, "zzz") == []
 @
 
 \section{GitHub Integration}
@@ -4961,6 +5012,21 @@ Label filters are positional arguments, matching the [[add]] command's
 convention ([[todo ls tilkry26 prep]] filters to items with either
 label).
 
+The output format is one of a closed set of choices, so we model it
+as an enumeration.  Typing the [[--format]] option as this enum lets
+Typer validate the input and complete the four values, instead of
+accepting any string and silently auto-detecting when it does not
+match a known format.
+
+<<constants>>=
+class LsFormat(str, Enum):
+    """Output formats for ``todo ls``."""
+    table = "table"
+    rich = "rich"
+    csv = "csv"
+    json = "json"
+@
+
 Three defaults on [[ls]] are worth making configurable so a user does
 not have to retype the same flag on every invocation: the row cap
 [[-n]], the output format, and the assignee filter.
@@ -4969,16 +5035,42 @@ We read each from [[typerconf]] once at module import via the shared
 resolved value to display in [[--help]].
 The [[--who]] fallback is [[default_username]] (that is, [[\$USER]]),
 matching the pre-existing behaviour.
+
+The format default needs care: it comes from configuration as a bare
+string, but the option is now typed as [[LsFormat]].  We coerce the
+configured value into the enum, falling back to [[table]] if a stale
+or hand-edited config holds a value outside the set---an invalid
+default must not crash every [[ls]] invocation at import time.
 <<configuration>>=
 TODO_LS_COUNT_CONFIG = "todo.ls.count"
 TODO_LS_FORMAT_CONFIG = "todo.ls.format"
 TODO_LS_WHO_CONFIG = "todo.ls.who"
 
+
+def coerce_ls_format(value):
+    """Return `value` as an `LsFormat`, or `table` if unknown."""
+    try:
+        return LsFormat(value)
+    except ValueError:
+        return LsFormat.table
+
+
 DEFAULT_LS_COUNT = default(TODO_LS_COUNT_CONFIG, 10, int)
-DEFAULT_LS_FORMAT = default(TODO_LS_FORMAT_CONFIG,
-                            "table", str)
+DEFAULT_LS_FORMAT = coerce_ls_format(
+    default(TODO_LS_FORMAT_CONFIG, "table", str))
 DEFAULT_LS_WHO = default(TODO_LS_WHO_CONFIG,
                          default_username, str)
+@
+
+A valid configured format resolves to its member; anything outside
+the set falls back to [[table]] rather than raising:
+
+<<test functions>>=
+def test_coerce_ls_format():
+  """Known values map to members; unknown values fall back."""
+  assert coerce_ls_format("rich") == LsFormat.rich
+  assert coerce_ls_format("table") == LsFormat.table
+  assert coerce_ls_format("bogus") == LsFormat.table
 @
 
 <<argument and option definitions>>=
@@ -5034,9 +5126,9 @@ def ls(
     who_filter: Annotated[str | None,
                           ls_who_opt] = DEFAULT_LS_WHO,
     flat: Annotated[bool, ls_flat_opt] = False,
-    output_format: Annotated[str,
+    output_format: Annotated[LsFormat,
                              ls_format_opt] = DEFAULT_LS_FORMAT,
-    status_filter: Annotated[str | None,
+    status_filter: Annotated[TodoStatus | None,
                              ls_status_opt] = None,
     show_prio: Annotated[bool, ls_prio_opt] = False,
     output: Annotated[str | None,
@@ -5078,6 +5170,32 @@ agent workflow needs to query only pending tasks without fragile
 [[awk]] filtering in shell scripts.  When [[--status]] is given, it
 takes precedence over [[--done]] since the user has expressed a
 more specific intent.
+
+A todo is always in one of three lifecycle states, so [[--status]] is
+another closed-choice option.  Modelling it as an enum stops a typo
+like [[--status in_progress]] from silently matching nothing---Typer
+rejects the unknown value outright.  The member name [[in_progress]]
+must use an underscore (a hyphen is not a valid identifier), but its
+\emph{value} keeps the hyphen so it matches the stored status string.
+
+<<constants>>=
+class TodoStatus(str, Enum):
+    """The lifecycle states a todo item can be in."""
+    pending = "pending"
+    in_progress = "in-progress"
+    done = "done"
+@
+
+The underscore-versus-hyphen split is exactly the property the filter
+relies on, so we pin it down:
+
+<<test functions>>=
+def test_todo_status_values():
+  """The in-progress member keeps its hyphenated value."""
+  assert TodoStatus.in_progress == "in-progress"
+  assert TodoStatus.pending == "pending"
+  assert TodoStatus.done == "done"
+@
 
 <<filter todos>>=
 filtered = todos
@@ -10948,6 +11066,35 @@ and capture the working context in which we discovered them.
 <<note command>>
 @
 
+The [[--type]] flag accepts exactly three values.  Modelling it as an
+enumeration rather than a free string gives us two things for free:
+Typer rejects a misspelled value with a helpful message instead of
+silently importing nothing, and the shell completes the valid values.
+Because the members subclass [[str]], the existing comparisons against
+literal strings ([[item_type in ("all", "issue")]]) keep working
+unchanged.
+
+<<constants>>=
+class ImportType(str, Enum):
+    """Which GitHub item kinds ``todo import`` fetches."""
+    issue = "issue"
+    pr = "pr"
+    all = "all"
+@
+
+The compatibility we rely on is that each member equals its string
+value and participates in membership tests, so the import command's
+existing string comparisons need no change:
+
+<<test functions>>=
+def test_import_type_enum_values():
+  """Members equal their string values for back-compat."""
+  assert ImportType.issue == "issue"
+  assert ImportType.pr == "pr"
+  assert ImportType.all == "all"
+  assert ImportType.all in ("all", "issue")
+@
+
 <<argument and option definitions>>=
 import_repo_arg = typer.Argument(
     help="GitHub repo (owner/repo)")
@@ -10977,8 +11124,8 @@ def import_github(
     label: Annotated[list[str] | None,
                      import_label_opt] = None,
     <<import metadata options>>
-    item_type: Annotated[str,
-                         import_type_opt] = "all",
+    item_type: Annotated[ImportType,
+                         import_type_opt] = ImportType.all,
     skip_priority: Annotated[bool,
                              import_skip_prio_opt] = False,
     github_labels: Annotated[bool,
@@ -11994,7 +12141,8 @@ network blip for one issue should not prevent syncing the rest.
 <<argument and option definitions>>=
 sync_repo_opt = typer.Option(
     "--repo", "-r",
-    help="Only sync items from this repo")
+    help="Only sync items from this repo",
+    autocompletion=complete_sync_repos)
 @
 
 <<sync command>>=
@@ -12411,6 +12559,11 @@ from nytid.cli.todo import (
     append_note_to_item,
     NotInTmuxError,
     resolve_todo_from_tmux_context,
+    complete_sync_repos,
+    ImportType,
+    TodoStatus,
+    LsFormat,
+    coerce_ls_format,
 )
 
 runner = CliRunner()

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -8684,12 +8684,60 @@ def render_tracking_entry(entry: TrackingEntry) -> list[str]:
 @
 
 The [[show]], [[edit]], and [[rm]] commands all identify one entry by the
-short hash prefix produced by [[track ls --id]].  We define the argument
-once so the help text stays consistent across all three:
+short hash prefix produced by [[track ls --id]].  Completion needs the
+same abbreviation rule as the list view so the shell offers prefixes the
+commands can actually resolve.  We therefore derive completion candidates
+from [[abbreviate_hashes]] rather than guessing a fixed prefix length.
+
+Opaque hashes are hard to tell apart at the prompt, so the completion
+helper returns Click's annotated [[(value, help)]] form.  The inserted
+value stays a short unique prefix, while the help text reuses the same
+time and label formatting as [[ls]] so the user can recognize the right
+entry before accepting it.
+
+<<helper functions>>=
+def complete_entry_hashes(ctx, args, incomplete):
+    """
+    Shell completion function for tracking entry hashes.
+
+    Returns abbreviated entry-hash prefixes, annotated with
+    a human-readable summary, for historical entries whose
+    full content hash matches the incomplete prefix.
+    """
+    try:
+        entries = load_tracking_data()
+        full_hashes = [entry.content_hash() for entry in entries]
+        abbreviations = abbreviate_hashes(full_hashes)
+        candidates = []
+
+        for entry, full_hash in zip(entries, full_hashes):
+            if not full_hash.startswith(incomplete):
+                continue
+
+            prefix = full_hash[:max(
+                len(abbreviations[full_hash]),
+                len(incomplete),
+            )]
+            labels = get_labels_display(entry.labels)
+            summary = (
+                f"{entry.start_time:%Y-%m-%d %H:%M}"
+                f"\u2013{entry.end_time:%H:%M}  "
+                f"{labels}  [{entry.who}]"
+            )
+            candidates.append((prefix, summary))
+
+        return candidates
+    except:
+        return []
+@
+
+We define the argument once so the help text and completion behavior stay
+consistent across all three commands:
 
 <<argument and option definitions>>=
 entry_hash_arg = typer.Argument(
-    ..., help="Tracking entry hash prefix")
+    ..., help="Tracking entry hash prefix",
+    autocompletion=complete_entry_hashes)
 @
 
 <<show command>>=
@@ -10017,6 +10065,7 @@ from nytid.cli.track import (
     parse_tmux_socket_path,
     get_current_tmux_server_key,
     sanitize_who, complete_workers,
+    complete_entry_hashes,
     should_auto_suspend,
     suspend_state_path,
     write_suspend_state,
@@ -11275,4 +11324,54 @@ def test_complete_workers(temp_tracking_dir):
     workers = complete_workers(None, None, "")
     assert default_username in workers
     assert "dan-claude" in workers or "Dan-Claude" in workers
+
+def test_complete_entry_hashes(temp_tracking_dir):
+  """Entry-hash completion offers every matching hash and no others."""
+  today = datetime.datetime.now().date().isoformat()
+  # Seventeen distinct entries guarantee, by the pigeonhole
+  # principle, that at least two content hashes share their first
+  # hex character (only sixteen are possible).  That forced
+  # collision is what gives the completeness check below teeth: a
+  # one-character prefix then resolves to more than one entry.
+  for i in range(17):
+      runner.invoke(cli, [
+          "add", f"task{i}", "--duration", "1",
+          "--at", f"{today} {i:02d}:00"
+      ])
+
+  entries = load_tracking_data()
+  full_hashes = [entry.content_hash() for entry in entries]
+
+  candidates = complete_entry_hashes(None, None, "")
+  assert len(candidates) == len(entries)
+  values = [candidate[0] for candidate in candidates]
+  assert all(
+      full_hash.startswith(value)
+      for full_hash, value in zip(full_hashes, values)
+  )
+
+  # Find the one-character prefix shared by at least two entries.
+  from collections import Counter
+  first_chars = Counter(full_hash[0] for full_hash in full_hashes)
+  prefix = next(
+      char for char, count in first_chars.items() if count >= 2
+  )
+  expected = [
+      full_hash for full_hash in full_hashes
+      if full_hash.startswith(prefix)
+  ]
+  assert len(expected) >= 2
+
+  filtered = complete_entry_hashes(None, None, prefix)
+  filtered_values = [candidate[0] for candidate in filtered]
+  # Completeness: one candidate per matching entry, none dropped.
+  assert len(filtered_values) == len(expected)
+  # Soundness: each candidate is a prefix of a genuinely matching
+  # hash, so nothing spurious slipped in.
+  assert all(
+      any(full_hash.startswith(value) for full_hash in expected)
+      for value in filtered_values
+  )
+
+  assert complete_entry_hashes(None, None, "zzzz") == []
 @


### PR DESCRIPTION
The show/edit/rm commands identify an entry by a short hash prefix, but
the entry_hash argument had no completion, forcing users to run
`track ls --id` and type the prefix by hand.

Add complete_entry_hashes, which derives candidates from the same
abbreviate_hashes rule as the list view (so offered prefixes resolve
unambiguously) and returns Click's annotated (value, help) form with an
ls-style time/label/who summary, since bare hashes are unrecognizable at
the prompt. Wiring it onto the shared entry_hash_arg gives completion to
show, edit, and rm at once.

The test forces a one-character prefix collision via the pigeonhole
principle (17 entries over 16 hex buckets) so the completeness check
exercises a genuine multi-match.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
