### PR TITLE
fix/track hash prefix min length

### DIFF
--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -490,13 +490,12 @@ We need some utility functions for formatting, display, and autocompletion.
 
 When displaying labels in different contexts, we use consistent separators.
 For CSV export (where labels appear in a single cell), we use a hierarchical
-separator that clearly distinguishes label boundaries while remaining 
+separator that clearly distinguishes label boundaries while remaining
 human-readable.
 
 <<constants>>=
 # Label display separators
 LABEL_SEPARATOR = " > "
-TRACKING_HASH_PREFIX_MIN_LENGTH = 1
 
 # Default time limits for work-life balance warnings
 DEFAULT_WEEKLY_LIMIT_HOURS = 40.0  # Standard full-time work week
@@ -520,7 +519,34 @@ def format_duration(duration: datetime.timedelta) -> str:
 def get_labels_display(labels: list[str]) -> str:
     """Get a display string for labels (as comma-separated tags)"""
     return ", ".join(sorted(labels)) if labels else "No labels"
+@
 
+\subsubsection{Abbreviating Content Hashes}
+
+The [[track ls --id]] view names each entry by a Git-style prefix of its
+SHA256 [[content_hash()]].  We want the shortest prefix that still uniquely
+identifies every displayed entry, so we start at a minimum length and widen
+only when two prefixes collide.
+
+The minimum matters more than it first appears.  A pure
+shortest-unique-prefix rule would collapse to a \emph{single character}
+whenever the first hex digits already differ---which is the common case with
+only a handful of entries, and especially right after an edit changes the set
+of hashes.  A one-character id is unreadable and feels unstable: it changes
+length as entries come and go.  We therefore floor the prefix at six
+characters, matching Git's default abbreviation, which is long enough to read
+and re-type while the collision loop below still widens further on the rare
+occasions six is not enough.
+
+<<constants>>=
+TRACKING_HASH_PREFIX_MIN_LENGTH = 6
+@
+
+Because [[resolve_tracking_entry]] matches any prefix with [[startswith]],
+widening the displayed id never invalidates a shorter prefix a user may have
+already copied---display length and lookup length are independent.
+
+<<helper functions>>=
 def abbreviate_hashes(full_hashes: list[str]) -> dict[str, str]:
     """Return unique short prefixes for full content hashes."""
     if not full_hashes:


### PR DESCRIPTION
- **Updates poetry.lock**
- **Adds timesheets/init.tex to doc/Makefile**
- **Floor track id hash prefix at six characters**
