### PR TITLE
Schedule todos from now onwards; add --no-todo to schedule show

### DIFF
--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -868,16 +868,28 @@ so that every task occupies at least a minimal slot.
 DEFAULT_ESTIMATED_HOURS = 1.0
 @
 
+Scheduling always starts from \emph{now}, never from the start of the
+shown date range.
+This makes the schedule a single stable plan that the shown range is
+merely a window onto: showing next week or the week after slides the
+window over the same plan, instead of re-anchoring all todos at
+whichever week we happen to look at.
+Two consequences fall out for free.
+A range entirely in the past contains no part of the plan, so no todos
+appear there---we never pretend we can do work in the past.
+And a future range shows exactly the todos that overflow into it once
+the free slots between now and then are consumed.
 <<helper functions>>=
-def schedule_todo_events(user, start, end, occupied):
+def schedule_todo_events(user, end, occupied):
   """
-  Returns VEVENTs for scheduled todos.
+  Returns VEVENTs for todos scheduled from now until `end`.
   """
   <<load and filter todos>>
   if not todos:
     return []
 
-  free_slots = compute_free_slots(occupied, start, end)
+  now = datetime.datetime.now()
+  free_slots = compute_free_slots(occupied, now, end)
   if not free_slots:
     return []
 
@@ -907,8 +919,9 @@ if user:
 
 Sorting by effective priority means high-urgency items claim the
 earliest available slots.
+We reuse the [[now]] that anchors the scheduling range, so priorities
+are evaluated at the same instant the plan starts.
 <<sort todos by priority>>=
-now = datetime.datetime.now()
 todos.sort(
   key=lambda t: todocli.effective_priority(t, now),
   reverse=True,
@@ -962,6 +975,75 @@ while hours_needed > 0 and remaining_slots:
   scheduled_events.append(event)
 @
 
+\paragraph{Testing [[schedule_todo_events]]}
+
+The defining property of the design is that scheduling anchors at now,
+not at the shown range.
+We verify both consequences: an [[end]] in the past yields no events at
+all, and with free time available the first event starts exactly at the
+frozen now.
+We fake the todo store and the clock so the tests are independent of
+the user's real todos and of when they run.
+<<test functions>>=
+def make_fake_todo():
+  import types
+  return types.SimpleNamespace(
+    status="open", who=None, estimated=1.0,
+    title="task", description="", labels=[],
+  )
+
+def freeze_schedule_now(monkeypatch, now):
+  monkeypatch.setattr(
+    "nytid.cli.schedule.datetime",
+    type("dt", (), {
+      "datetime": type("inner", (), {
+        "now": staticmethod(lambda: now),
+        "combine": datetime.datetime.combine,
+      }),
+      "timedelta": datetime.timedelta,
+      "time": datetime.time,
+      "date": datetime.date,
+    }),
+  )
+
+def test_schedule_todo_events_empty_for_past_end(monkeypatch):
+  monkeypatch.setattr(
+    "nytid.cli.todo.load_todos",
+    lambda: (None, [make_fake_todo()]),
+  )
+  monkeypatch.setattr(
+    "nytid.cli.schedule.work_window",
+    lambda: ("09:00", "12:00", ["mon"]),
+  )
+  # 2024-01-08 is a Monday, a week after 2024-01-01.
+  freeze_schedule_now(monkeypatch,
+                      datetime.datetime(2024, 1, 8, 10, 30))
+
+  end = datetime.datetime(2024, 1, 1, 23, 59)
+  assert schedule_todo_events(None, end, []) == []
+
+def test_schedule_todo_events_starts_from_now(monkeypatch):
+  monkeypatch.setattr(
+    "nytid.cli.todo.load_todos",
+    lambda: (None, [make_fake_todo()]),
+  )
+  monkeypatch.setattr(
+    "nytid.cli.todo.effective_priority",
+    lambda t, now: 1.0,
+  )
+  monkeypatch.setattr(
+    "nytid.cli.schedule.work_window",
+    lambda: ("09:00", "12:00", ["mon"]),
+  )
+  now = datetime.datetime(2024, 1, 8, 10, 30)
+  freeze_schedule_now(monkeypatch, now)
+
+  end = datetime.datetime(2024, 1, 15, 23, 59)
+  events = schedule_todo_events(None, end, [])
+  assert len(events) == 1
+  assert events[0].begin == arrowlib.get(now, local_tz)
+@
+
 Once we have the course schedule, we merge external calendars and then
 schedule todos into the remaining free slots.
 The order matters: external calendar events must be merged \emph{before}
@@ -986,15 +1068,22 @@ if not user or user == default_username:
 With all occupied time now in [[schedule]], we extract the busy intervals
 and greedily fill the remaining work-hour slots with todos, sorted by
 effective priority.
+Note that [[start]] plays no role here: todos are scheduled from now
+until [[end]], and the print-time filtering
+(\cref{cli.schedule.filter-events}) trims any todo events that fall
+before the shown range.
+[[schedule.events]] holds the \emph{complete} sign-up and external
+calendars---range filtering happens only at print time---so the busy
+intervals between now and a future [[end]] are all known here.
 <<add scheduled todo events to [[schedule]]>>=
 occupied = event_bounds(schedule.events)
 schedule.events.update(schedule_todo_events(user,
-                                            start,
                                             end,
                                             occupied))
 @
 
 \subsection{Filter events based on start--end time}
+\label{cli.schedule.filter-events}
 
 Before output, we keep only events overlapping the chosen interval.
 <<set [[events]] to filtered timeline>>=

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -669,9 +669,12 @@ within configured work hours.
 The algorithm is a day-by-day sweep: for each work day in the range it
 clips the work window to the search bounds, subtracts the occupied
 intervals (sorted by start), and appends any remaining gaps.
-We clip to \emph{now} on the current day so that past time is never
-offered as available---a todo scheduled in a slot that has already
-passed would be confusing.
+The function never reads the clock: it is a pure function of its
+arguments, so keeping past time out of the slots is the caller's
+job---[[schedule_todo_events]] does this by anchoring [[start]] at
+now.
+Purity is what lets the tests below feed in fixed dates without
+faking the clock.
 <<helper functions>>=
 def compute_free_slots(occupied, start, end):
   """
@@ -679,14 +682,13 @@ def compute_free_slots(occupied, start, end):
   """
   <<parse work hours>>
   day_names = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
-  now = datetime.datetime.now()
   free_slots = []
 
   date = start.date()
   while date <= end.date():
     <<skip non-work days>>
     <<build work window for this day>>
-    <<clip work window to search range and today>>
+    <<clip work window to search range>>
     if day_start >= day_end:
       date += datetime.timedelta(days=1)
       continue
@@ -725,15 +727,12 @@ day_end = datetime.datetime.combine(
 )
 @
 
-Three constraints shrink the work window: the overall search [[start]]
-and [[end]] bounds, and the current time on today's date so we never
-schedule in the past.
-<<clip work window to search range and today>>=
+The overall search [[start]] and [[end]] bounds shrink the work
+window---on the first and last day of the range only part of the
+window may fall inside the bounds.
+<<clip work window to search range>>=
 day_start = max(day_start, start)
 day_end = min(day_end, end)
-
-if date == now.date() and now > day_start:
-  day_start = now.replace(second=0, microsecond=0)
 @
 
 We clip each event to the current day's window, sort by start time,
@@ -764,7 +763,9 @@ if cursor < day_end:
 Free-slot computation is the core scheduling algorithm.
 Given a set of occupied intervals and a date range, it returns the
 gaps during work hours.
-We test with a fixed work window to avoid dependency on configuration.
+We test with a fixed work window to avoid dependency on configuration;
+since the function never reads the clock, fixed dates need no further
+setup.
 <<test functions>>=
 def test_compute_free_slots_no_events(monkeypatch):
   monkeypatch.setattr(
@@ -774,21 +775,6 @@ def test_compute_free_slots_no_events(monkeypatch):
   # 2024-01-01 is a Monday
   start = datetime.datetime(2024, 1, 1, 0, 0)
   end = datetime.datetime(2024, 1, 1, 23, 59)
-
-  # Freeze "now" to the start of the day so it doesn't
-  # clip the work window.
-  monkeypatch.setattr(
-    "nytid.cli.schedule.datetime",
-    type("dt", (), {
-      "datetime": type("inner", (), {
-        "now": staticmethod(lambda: start),
-        "combine": datetime.datetime.combine,
-      }),
-      "timedelta": datetime.timedelta,
-      "time": datetime.time,
-      "date": datetime.date,
-    }),
-  )
 
   slots = compute_free_slots([], start, end)
   assert len(slots) == 1
@@ -804,19 +790,6 @@ def test_compute_free_slots_with_event(monkeypatch):
   )
   start = datetime.datetime(2024, 1, 1, 0, 0)
   end = datetime.datetime(2024, 1, 1, 23, 59)
-
-  monkeypatch.setattr(
-    "nytid.cli.schedule.datetime",
-    type("dt", (), {
-      "datetime": type("inner", (), {
-        "now": staticmethod(lambda: start),
-        "combine": datetime.datetime.combine,
-      }),
-      "timedelta": datetime.timedelta,
-      "time": datetime.time,
-      "date": datetime.date,
-    }),
-  )
 
   occupied = [
     (datetime.datetime(2024, 1, 1, 10, 0),
@@ -841,19 +814,6 @@ def test_compute_free_slots_skips_non_work_days(monkeypatch):
   # 2024-01-02 is a Tuesday
   start = datetime.datetime(2024, 1, 2, 0, 0)
   end = datetime.datetime(2024, 1, 2, 23, 59)
-
-  monkeypatch.setattr(
-    "nytid.cli.schedule.datetime",
-    type("dt", (), {
-      "datetime": type("inner", (), {
-        "now": staticmethod(lambda: start),
-        "combine": datetime.datetime.combine,
-      }),
-      "timedelta": datetime.timedelta,
-      "time": datetime.time,
-      "date": datetime.date,
-    }),
-  )
 
   slots = compute_free_slots([], start, end)
   assert slots == []
@@ -880,6 +840,14 @@ A range entirely in the past contains no part of the plan, so no todos
 appear there---we never pretend we can do work in the past.
 And a future range shows exactly the todos that overflow into it once
 the free slots between now and then are consumed.
+
+The anchor read here is the only clock in the scheduling
+pipeline---[[compute_free_slots]] is a pure function of its
+arguments---so anchoring the plan at now is entirely this function's
+responsibility.
+We round the anchor down to the whole minute so the synthesized events
+get tidy start times; the up to 59 seconds of \enquote{past} this
+admits are harmless.
 <<helper functions>>=
 def schedule_todo_events(user, end, occupied):
   """
@@ -889,7 +857,7 @@ def schedule_todo_events(user, end, occupied):
   if not todos:
     return []
 
-  now = datetime.datetime.now()
+  now = datetime.datetime.now().replace(second=0, microsecond=0)
   free_slots = compute_free_slots(occupied, now, end)
   if not free_slots:
     return []

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -1058,8 +1058,9 @@ DEFAULT_SHOW_TODO = default(SCHEDULE_SHOW_TODO_CONFIG, True, bool)
 Let's verify that the option is wired into the command and that an
 unset config means todos are scheduled.
 For the latter we reload the module under a fake empty config, the
-same technique as for the output-format fallback, so we exercise the
-code path that normal use takes at import time.
+same technique as for the output-format fallback
+(\cref{cli.schedule.test-setup}), so we exercise the code path that
+normal use takes at import time.
 <<test functions>>=
 def test_show_todo_option_defaults_to_scheduling(monkeypatch):
   import inspect
@@ -1294,6 +1295,7 @@ output_opt = typer.Option("--output", "-o",
 
 
 \section{Test setup}
+\label{cli.schedule.test-setup}
 
 We test the pure helper functions in this module.
 The CLI commands themselves depend on course configuration and sign-up

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -315,6 +315,7 @@ def show(<<argument for matching courses>> = ".*",
          <<option for username to filter for>>,
          <<default arguments for start and end dates>>,
          <<options for external calendar sources>>,
+         <<option for scheduling todos>>,
          <<printing control options>>):
   """
   Shows schedule for courses, external calendars and scheduled todos.
@@ -1065,9 +1066,52 @@ if not user or user == default_username:
   schedule.events.update(external_calendar.events)
 @
 
+\paragraph{Opting out of todo scheduling}
+
+Sometimes the synthesized todo events are noise rather than help---for
+instance when checking what is actually booked, or when producing
+output for someone else.
+The [[--no-todo]] flag suppresses todo scheduling entirely.
+Whether to include todos is the kind of preference a user settles on
+once, so like the printing switches the default is read from the
+configuration.
+<<option for scheduling todos>>=
+todo: Annotated[bool, todo_opt] = DEFAULT_SHOW_TODO
+<<argument and option definitions>>=
+todo_opt = typer.Option(help="Schedule todos into free slots. "
+                             "[config: schedule.show.todo]")
+<<constants>>=
+SCHEDULE_SHOW_TODO_CONFIG = "schedule.show.todo"
+DEFAULT_SHOW_TODO = default(SCHEDULE_SHOW_TODO_CONFIG, True, bool)
+@
+
+Let's verify that the option is wired into the command and that an
+unset config means todos are scheduled.
+For the latter we reload the module under a fake empty config, the
+same technique as for the output-format fallback, so we exercise the
+code path that normal use takes at import time.
+<<test functions>>=
+def test_show_todo_option_defaults_to_scheduling(monkeypatch):
+  import inspect
+  params = inspect.signature(show).parameters
+  assert "todo" in params
+  assert params["todo"].default == DEFAULT_SHOW_TODO
+
+  fake = MagicMock()
+  fake.get.side_effect = KeyError
+  monkeypatch.setattr(defaults.typerconf, "Config", lambda: fake)
+  defaults._reset_cache()
+  reloaded = importlib.reload(schedule_module)
+  try:
+    assert reloaded.DEFAULT_SHOW_TODO is True
+  finally:
+    defaults._reset_cache()
+    importlib.reload(schedule_module)
+@
+
 With all occupied time now in [[schedule]], we extract the busy intervals
 and greedily fill the remaining work-hour slots with todos, sorted by
-effective priority.
+effective priority---unless the user opted out with [[--no-todo]].
 Note that [[start]] plays no role here: todos are scheduled from now
 until [[end]], and the print-time filtering
 (\cref{cli.schedule.filter-events}) trims any todo events that fall
@@ -1076,10 +1120,11 @@ before the shown range.
 calendars---range filtering happens only at print time---so the busy
 intervals between now and a future [[end]] are all known here.
 <<add scheduled todo events to [[schedule]]>>=
-occupied = event_bounds(schedule.events)
-schedule.events.update(schedule_todo_events(user,
-                                            end,
-                                            occupied))
+if todo:
+  occupied = event_bounds(schedule.events)
+  schedule.events.update(schedule_todo_events(user,
+                                              end,
+                                              occupied))
 @
 
 \subsection{Filter events based on start--end time}

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -955,6 +955,7 @@ We fake the todo store and the clock so the tests are independent of
 the user's real todos and of when they run.
 <<test functions>>=
 def make_fake_todo():
+  """Returns a minimal open todo for scheduling tests."""
   import types
   return types.SimpleNamespace(
     status="open", who=None, estimated=1.0,
@@ -962,6 +963,7 @@ def make_fake_todo():
   )
 
 def freeze_schedule_now(monkeypatch, now):
+  """Patches schedule's datetime so now() returns `now`."""
   monkeypatch.setattr(
     "nytid.cli.schedule.datetime",
     type("dt", (), {


### PR DESCRIPTION
## Summary

- Todo scheduling in `schedule show` now always anchors at *now* instead of the start of the shown date range. The schedule becomes one stable plan and the shown range is just a window onto it: a past range shows no todos, and a future range shows exactly the todos that overflow into it once the free slots between now and then are consumed. Fixes #344.
- New `--todo/--no-todo` option for `schedule show` to opt out of todo scheduling entirely, with a configurable default (`schedule.show.todo`, defaults to scheduling). Fixes #343.

## Test plan

- New tests: `test_schedule_todo_events_empty_for_past_end`, `test_schedule_todo_events_starts_from_now`, `test_show_todo_option_defaults_to_scheduling` (all in `src/nytid/cli/schedule.nw`, tangled into `tests/test_clischedule.py`).
- Full suite: 612 passed.
- Verified `nytid schedule show --help` lists `--todo/--no-todo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)