### PR TITLE
Fix duplicate LaTeX labels across woven chapters

### DIFF
--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -1,5 +1,5 @@
 \chapter{The \texttt{cli.courses} module and the \texttt{courses} subcommands}%
-\label{courses}\label{cli.courses}
+\label{cli.courses}
 
 In this chapter we cover the [[nytid.cli.courses]] module and the subcommands 
 of the [[courses]] command.
@@ -95,14 +95,14 @@ courses, we call this a register (or directory of courses).
 This way, we can access all existing courses through this directory.
 These configurations will point to the course data directories, \ie where the 
 actual course data is located.
-\Cref{storage-overview} gives an overview of a config using two courses 
+\Cref{cli.storage-overview} gives an overview of a config using two courses
 directories, one on AFS and one on GitHub.
 We note that the locations can be mixed: root on AFS, data on GitHub and the 
 other way around.
 
 \begin{figure}
   \includegraphics[width=\columnwidth]{figs/nytid-storage.pdf}
-  \caption{\label{storage-overview}%
+  \caption{\label{cli.storage-overview}%
     An overview of the storage structure.
     The config points to different course root directories (one on AFS, 
     basename [[nytid]]; one on GitHub, basename [[nytid.git]]).

--- a/src/nytid/cli/hr.nw
+++ b/src/nytid/cli/hr.nw
@@ -1,6 +1,6 @@
 \chapter{The \texttt{cli.hr} module and
          the \texttt{hr} subcommands}%
-\label{cli.signupsheets}
+\label{cli.hr}
 %\chnote{%
 %  Part of this chapter was developed in collaboration with GitHub Copilot.
 %  It provided autocompletion of text and code that I intended to write (mostly

--- a/src/nytid/courses/init.nw
+++ b/src/nytid/courses/init.nw
@@ -85,7 +85,7 @@ the function head, this is due to there being enough commas in [[<<new args>>]]
 due to it not knowing what is the last argument---so it terminates with a 
 comma.)
 
-\subsection{Creating the course}\label{CreatingTheCourse}
+\subsection{Creating the course}\label{courses.CreatingTheCourse}
 
 To create a course, we need a name for the course.
 <<new args>>=


### PR DESCRIPTION
Four labels were defined in two .nw files each, making every \cref to
them ambiguous:

- cli/hr.nw carried \label{cli.signupsheets}, copy-pasted from
  signupsheets.nw; it now matches its chapter as \label{cli.hr}.
- cli/courses.nw duplicated the courses library chapter's
  \label{courses}; the redundant label is dropped (\label{cli.courses}
  remains, and is the only one referenced).
- The "Creating the course" subsections in courses/init.nw and
  cli/courses.nw shared \label{CreatingTheCourse}; the library one is
  now courses.CreatingTheCourse. The sole \cref intends the CLI one
  ("from earlier" in the same file), which keeps its name.
- Both storage-overview figures (courses/registry.nw and
  cli/courses.nw) shared one label; the CLI copy is now
  cli.storage-overview, with its local \Cref updated.

The documentation now builds with no multiply-defined and no
undefined labels.

Co-Authored-By: Claude <noreply@anthropic.com>
