### PR TITLE
Warn when track start ignores --offset/--at

### DIFF
--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -22,7 +22,9 @@ independent tags that can be started and stopped individually:
 \item Each label tracks independently.
 \item Labels can be stopped in any order.
 \item A label already being tracked is silently continued rather than
-  duplicated when started again.
+  duplicated when started again.  If a start time was requested via
+  [[--offset]] or [[--at]], a warning notes that it was ignored
+  (use [[--replace]] to apply it).
 \item Labels can be combined for multi-dimensional categorization.
 \item Labels started together in one command form a \enquote{batch}
   that can be stopped as a unit.
@@ -2544,6 +2546,7 @@ if already_tracking:
         f"Already tracking: "
         f"{', '.join(sorted(already_tracking))}"
     )
+<<warn about ignored time options>>
 
 borrowed_launch_labels = [
     label for label in already_tracking
@@ -2615,6 +2618,31 @@ Without [[--replace]], re-issuing [[track start labelA]] when [[labelA]]
 is already active has no effect: the label is silently continued and
 reported as \enquote{Already tracking}.  This is the safe default---a
 typo does not corrupt history.
+
+That safe default becomes a trap when the user also passed
+[[--offset]] or [[--at]]: they explicitly asked for a different start
+time, so \enquote{Already tracking} alone reads as success while the
+requested backdate was quietly dropped.  We therefore warn on stderr
+whenever already-active labels kept their original start time despite
+an explicit time option, and point at [[--replace]] as the way to
+actually move the start time.  A
+warning rather than an error keeps the mixed case usable: when some
+labels start fresh and others are already active, the command still
+succeeds---and the time \emph{does} apply to the fresh ones.
+
+<<warn about ignored time options>>=
+if already_tracking and not replace \
+        and (offset is not None or at is not None):
+    ignored_opt = "--at" if at is not None else "--offset"
+    typer.echo(
+        f"Warning: {ignored_opt} ignored for already "
+        f"tracked labels: "
+        f"{', '.join(sorted(already_tracking))}. "
+        f"Use --replace to restart them at the "
+        f"given time.",
+        err=True,
+    )
+@
 
 With [[--replace]], the active session for the named labels is discarded
 first via [[discard_labels]], and those labels are then re-started at the
@@ -2923,10 +2951,18 @@ elif offset is not None:
         raise typer.Exit(1)
 @
 
-When the user specifies a custom start time, we report it for confirmation:
+When the user specifies a custom start time, we report it for
+confirmation---but only when some label actually started at that time.
+If every requested label was already active (and no [[--replace]] was
+given), the time applied to nothing, and printing it would falsely
+confirm a backdate that never happened; the warning from
+[[<<warn about ignored time options>>]] is the only honest output in
+that case.  Labels restarted by [[--replace]] reappear in [[started]],
+so checking [[started]] alone covers both the fresh-start and the
+replace case.
 
 <<report custom start time if used>>=
-if at is not None or offset is not None:
+if (at is not None or offset is not None) and started:
     typer.echo(f"Start time: {start_time.strftime('%Y-%m-%d %H:%M:%S')}")
 @
 
@@ -3044,6 +3080,55 @@ def test_start_without_replace_keeps_original(temp_tracking_dir):
     assert result.exit_code == 0
     assert "Already tracking: labelA" in result.stdout
     assert "Replaced" not in result.stdout
+
+def test_start_offset_ignored_warns(temp_tracking_dir):
+    """An --offset that applies to no label produces a warning."""
+    runner.invoke(cli, ["start", "labelA"])
+    result = runner.invoke(cli, [
+        "start", "labelA", "--offset", "-10m"
+    ])
+    assert result.exit_code == 0
+    assert "Warning: --offset ignored" in result.output
+    assert "--replace" in result.output
+    # The unapplied time must not be confirmed back to the user.
+    assert "Start time:" not in result.output
+
+def test_start_at_ignored_warns(temp_tracking_dir):
+    """An --at that applies to no label produces a warning."""
+    runner.invoke(cli, ["start", "labelA"])
+    result = runner.invoke(cli, [
+        "start", "labelA", "--at", "08:00"
+    ])
+    assert result.exit_code == 0
+    assert "Warning: --at ignored" in result.output
+    assert "Start time:" not in result.output
+
+def test_start_offset_warning_names_only_active_labels(temp_tracking_dir):
+    """The warning names only the labels whose time was ignored."""
+    runner.invoke(cli, ["start", "labelA"])
+    result = runner.invoke(cli, [
+        "start", "labelA", "labelB", "--offset", "-10m"
+    ])
+    assert result.exit_code == 0
+    assert (
+        "Warning: --offset ignored for already "
+        "tracked labels: labelA."
+    ) in result.output
+    # The offset did apply to the fresh label, so the start
+    # time is confirmed.
+    assert "Started tracking: labelB" in result.output
+    assert "Start time:" in result.output
+
+def test_start_offset_with_replace_does_not_warn(temp_tracking_dir):
+    """--replace applies the offset, so there is nothing to warn about."""
+    runner.invoke(cli, ["start", "labelA"])
+    result = runner.invoke(cli, [
+        "start", "labelA", "--offset", "-10m", "--replace"
+    ])
+    assert result.exit_code == 0
+    assert "Warning" not in result.output
+    assert "Replaced: labelA" in result.output
+    assert "Start time:" in result.output
 
 def test_start_launch_requires_replace_for_active_labels(
     temp_tracking_dir,


### PR DESCRIPTION
Re-starting an already-active label with --offset or --at silently
dropped the requested time while still printing "Start time: ...",
falsely confirming a backdate that never happened.

- Warn on stderr whenever already-active labels keep their original
  start time despite an explicit time option, pointing at --replace
  as the remedy.
- Only print "Start time:" when some label actually started at
  that time (replaced labels reappear in started, so they are
  covered).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
