### PR TITLE
Fix todo start crash from ctx default on Python <=3.10

### DIFF
--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -8672,6 +8672,11 @@ while plain launches default to blocking.  Resolving here avoids
 passing a [[None]] into [[start]], which would otherwise have to
 repeat the same defaulting logic.
 
+Because [[start]] now takes the click context as a required first
+parameter, [[next_cmd]] passes [[ctx=None]] explicitly: it has no
+context of its own to forward, and [[start]] tolerates a missing
+context (its [[resolve_command_argv]] guards on [[if ctx]]).
+
 <<argument and option definitions>>=
 headless_opt = typer.Option(
     "--headless",
@@ -8721,6 +8726,7 @@ def next_cmd(
         block = not (pane or window)
 
     start(
+        ctx=None,
         todo_id=target.id,
         headless=headless,
         pane=pane,
@@ -9195,12 +9201,25 @@ outside tmux it falls back to the worker's active-stack top.  This is
 useful when tracking stopped but the todo itself remains the current
 focus.
 
+Typer injects the click context into whichever parameter is annotated
+with [[typer.Context]], but only if its detection
+([[lenient_issubclass(annotation, click.Context)]]) sees a bare
+[[Context]] subclass.  A [[None]] default defeats this: on Python up to
+3.10, [[typing.get_type_hints]] rewrites [[ctx: typer.Context = None]]
+into [[Optional[typer.Context]]], a union that fails the subclass test,
+so Typer treats the context as an ordinary option and aborts with
+\enquote{Type not yet supported}.  Python 3.11 dropped that implicit
+[[Optional]], which is why the bug only surfaced on older interpreters.
+We therefore make [[ctx]] the first parameter with no default---matching
+[[add]] and [[edit]]---so the annotation stays a bare [[Context]]
+everywhere.
+
 <<start command>>=
 @cli.command(cls=PassThroughCommand)
 def start(
+    ctx: typer.Context,
     todo_id: Annotated[int | None,
                        todo_id_arg] = None,
-    ctx: typer.Context = None,
     <<start command options>>
 ):
     """Start tracking time for a todo item.
@@ -9234,6 +9253,31 @@ def start(
     )
 
     <<spawn subprocess when the todo has work to launch>>
+@
+
+The context-detection invariant above is easy to break by accident---a
+later edit that gives [[ctx]] a [[None]] default would reintroduce the
+crash, but only on Python up to 3.10, so a modern test run would not
+catch it.  We therefore assert the shape of the signature directly,
+which fails on every interpreter the moment [[ctx]] stops being a bare,
+undefaulted first parameter.
+
+<<test functions>>=
+def test_start_ctx_has_no_default():
+  """Guard Typer context detection for the start command.
+
+  A None default on the context parameter becomes Optional on
+  Python <= 3.10, which defeats Typer's context detection and
+  crashes CLI construction.  Keep ctx a bare, undefaulted first
+  parameter.
+  """
+  import inspect
+  from nytid.cli.todo import start
+  sig = inspect.signature(start)
+  assert list(sig.parameters)[0] == "ctx"
+  assert (
+    sig.parameters["ctx"].default is inspect.Parameter.empty
+  )
 @
 
 Detached tmux cleanup happens after the pane process exits, so it cannot


### PR DESCRIPTION
todo start declared ctx: typer.Context = None. On Python up to 3.10,
typing.get_type_hints rewrites a None-defaulted parameter to
Optional[...], so Typer's context detection
(lenient_issubclass(annotation, click.Context)) no longer matched and it
tried to build a CLI option from Context, raising "Type not yet
supported" and taking down the whole CLI at construction (even --help).
Python 3.11 dropped implicit Optional, hiding the bug on newer
interpreters.

Make ctx a bare, undefaulted first parameter (matching add/edit), pass
ctx=None from next_cmd, and add a signature-shape regression test that
fails on every interpreter if the default returns.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
