### PR TITLE
feature/keep window tracked on stop all

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -12,6 +12,7 @@ nytid.pdf: ../src/nytid/cli/signupsheets.tex
 nytid.pdf: ../src/nytid/cli/hr.tex
 nytid.pdf: ../src/nytid/cli/track.tex
 nytid.pdf: ../src/nytid/cli/todo.tex
+nytid.pdf: ../src/nytid/cli/zulip.tex
 nytid.pdf: ../tests/conftest.tex
 nytid.pdf: ../src/nytid/cli/utils/init.tex
 nytid.pdf: ../src/nytid/cli/utils/defaults.tex

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -5569,6 +5569,14 @@ We reuse the same absent-versus-empty distinction as for panes:
 [[None]] means the window is not tracked, while an empty visible label
 set means the tracked file exists but currently has no labels.
 
+Preserving that distinction is what keeps a window tracked across a full
+stop.  When the user stops every label in a still-open window the count
+dict drains to empty, but the window has not gone away: the file must
+survive as an empty marker so a later resume re-attaches its labels to
+the window instead of starting them as global, window-less labels.  We
+therefore return the empty dict verbatim and reserve [[None]] for a
+genuinely absent file.
+
 Unlike pane state, window state may receive overlapping contributions.
 Two panes in the same tracked window can both contribute [[work]], and a
 single pane exit must not delete [[work]] globally while the other pane
@@ -5604,7 +5612,7 @@ def read_window_label_counts(
         for label, count in data.items():
             if isinstance(count, int) and count > 0:
                 counts[label] = count
-        return counts or None
+        return counts
 
     return None
 
@@ -5685,7 +5693,15 @@ def add_window_labels(
 
 Removing labels decrements the corresponding reference counts and only
 drops a visible label once the last contributing pane has gone away.
-The file is deleted entirely when the final count disappears.
+Draining the dict to empty is deliberately \emph{not} a deletion: an
+empty count dict means \enquote{no labels are active right now}, which is
+not the same fact as \enquote{this window is gone}.  A user can stop
+every label in a window that is still open and expect to resume them
+there later, so we always write the (possibly empty) dict back and leave
+the file in place as the window's tracked marker.  Genuine teardown ---
+deleting the file once the window itself disappears --- lives in the
+pane-exit cleanup command, which can ask tmux whether the window still
+exists (see \cref{track:detached-finalize}).
 
 <<helper functions>>=
 def remove_window_labels(
@@ -5708,15 +5724,16 @@ def remove_window_labels(
             del existing[label]
         else:
             existing[label] = count - 1
-    if existing:
-        write_window_label_counts(
-            window_id, who, tmux_server_key, existing,
-        )
-    else:
-        delete_window_labels(
-            window_id, who, tmux_server_key,
-        )
+    write_window_label_counts(
+        window_id, who, tmux_server_key, existing,
+    )
 @
+
+Because [[remove_window_labels]] no longer deletes, the only caller that
+removes a window file outright is the pane-exit cleanup command, once it
+has confirmed the window itself is gone.  We keep that unlink in its own
+idempotent helper so the cleanup path can call it unconditionally without
+caring whether the file was already absent.
 
 <<helper functions>>=
 def delete_window_labels(
@@ -6186,6 +6203,41 @@ def get_tmux_selected_window_id(
     return window_id
 @
 
+The pane-exit cleanup needs to tell two situations apart: a window whose
+last pane has just died (the file should go) versus a window that still
+has other live panes (the file must stay, even with no labels left).  A
+reference count cannot distinguish them, so we ask tmux directly.
+Querying the [[window_id]] target succeeds only while the window still
+exists; tmux exits non-zero once it is gone, which [[check=True]] turns
+into the [[CalledProcessError]] we map to [[False]].  We accept
+[[tmux_server_key]] for symmetry with the other window helpers even
+though [[display-message]] resolves the id within the ambient server.
+
+<<helper functions>>=
+def tmux_window_exists(
+    window_id: str,
+    tmux_server_key: str,
+) -> bool:
+    """Return whether ``window_id`` still exists in tmux."""
+    try:
+        result = subprocess.run(
+            [
+                "tmux",
+                "display-message",
+                "-p",
+                "-t",
+                window_id,
+                "#{window_id}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return False
+    return bool(result.stdout.strip())
+@
+
 Because tmux's [[$0:!]] target is unreliable in [[run-shell]]
 subprocesses (see the [[last_selected_window_path]] discussion above),
 the switch command reads the source window from our self-managed state
@@ -6587,6 +6639,7 @@ def install_tmux_window_sync_hooks(
 @
 
 \subsubsection{Cleaning Up Suspend State on Pane Exit}
+\label{track:detached-finalize}
 
 When a pane exits while unfocused, the focus-out hook has already
 written a suspend state file that no focus-in will ever read.  Rather
@@ -6737,6 +6790,15 @@ already died, so there is no live [[TMUX_PANE]] from which to recover the
 window identity.  It receives the explicit [[window_id]] and decrements
 only the given label names in that shared window file.
 
+This command is also the one place that may delete the window file, and
+it does so on the right signal.  After decrementing this pane's
+contribution it asks tmux whether the window still exists.  A surviving
+sibling pane keeps the window alive, so we leave the (possibly empty)
+file as the window's tracked marker; only when tmux reports the window
+gone do we unlink it.  Both steps run under [[with_tmux_context_lock]] so
+the decrement, the liveness check, and the conditional delete are atomic
+with respect to other context mutations.
+
 <<detached finalize command>>=
 @cli.command(name="_cleanup-window-detached", hidden=True)
 def cleanup_window_detached(
@@ -6746,14 +6808,16 @@ def cleanup_window_detached(
     who: Annotated[str, who_opt] = default_username,
 ):
     """Remove one pane's labels from tracked window state."""
-    with_tmux_context_lock(
-        lambda: remove_window_labels(
-            window_id,
-            who,
-            tmux_server_key,
-            list(labels),
+    def cleanup():
+        remove_window_labels(
+            window_id, who, tmux_server_key, list(labels),
         )
-    )
+        if not tmux_window_exists(window_id, tmux_server_key):
+            delete_window_labels(
+                window_id, who, tmux_server_key,
+            )
+
+    with_tmux_context_lock(cleanup)
 @
 
 \subsubsection{Focus-Events Validation}
@@ -6999,21 +7063,52 @@ def test_remove_window_labels_preserves_shared_label(
     assert read_window_labels(
         window_id, who, TEST_SERVER_KEY,
     ) == ["shared", "y"]
+@
 
-def test_remove_window_labels_deletes_when_empty(
-    temp_tracking_dir,
+Emptying a window's labels is not the same as untracking the window.
+Stopping the last label must leave the file behind --- now reading as an
+empty list rather than [[None]] --- so the window stays tracked and can
+still accept labels when work resumes there.
+
+<<test functions>>=
+def test_remove_window_labels_keeps_empty_file(
+  temp_tracking_dir,
 ):
-    """Removing all window labels deletes the file."""
-    window_id, who = "@42", "me"
-    write_window_labels(
-        window_id, who, TEST_SERVER_KEY, ["a"],
-    )
-    remove_window_labels(
-        window_id, who, TEST_SERVER_KEY, ["a"],
-    )
-    assert read_window_labels(
-        window_id, who, TEST_SERVER_KEY,
-    ) is None
+  """Removing all window labels keeps the file as a marker."""
+  window_id, who = "@42", "me"
+  write_window_labels(
+    window_id, who, TEST_SERVER_KEY, ["a"],
+  )
+  remove_window_labels(
+    window_id, who, TEST_SERVER_KEY, ["a"],
+  )
+  assert read_window_labels(
+    window_id, who, TEST_SERVER_KEY,
+  ) == []
+  assert read_window_label_counts(
+    window_id, who, TEST_SERVER_KEY,
+  ) == {}
+
+def test_remove_window_labels_empty_then_re_add(
+  temp_tracking_dir,
+):
+  """An emptied window file still accepts new labels."""
+  window_id, who = "@42", "me"
+  write_window_labels(
+    window_id, who, TEST_SERVER_KEY, ["a"],
+  )
+  remove_window_labels(
+    window_id, who, TEST_SERVER_KEY, ["a"],
+  )
+  assert read_window_labels(
+    window_id, who, TEST_SERVER_KEY,
+  ) == []
+  add_window_labels(
+    window_id, who, TEST_SERVER_KEY, ["a"],
+  )
+  assert read_window_labels(
+    window_id, who, TEST_SERVER_KEY,
+  ) == ["a"]
 
 def test_install_tmux_window_sync_hooks_register_session_hooks():
     """Window sync installs only the authoritative session hook."""
@@ -7486,6 +7581,26 @@ def test_get_tmux_selected_window_id_reads_live_tmux_state():
         text=True,
         check=True,
     )
+@
+
+The liveness probe reports a window as present only when tmux answers
+with a non-empty id, and treats tmux's non-zero exit for a missing
+window as absence rather than letting the error escape.
+
+<<test functions>>=
+def test_tmux_window_exists_true_for_live_window():
+  """A live window id makes tmux echo it back as present."""
+  with patch("nytid.cli.track.subprocess.run") as mock_run:
+    mock_run.return_value.stdout = "@42\n"
+    assert tmux_window_exists("@42", TEST_SERVER_KEY) is True
+
+def test_tmux_window_exists_false_when_window_gone():
+  """A missing window makes tmux exit non-zero, read as absent."""
+  with patch(
+    "nytid.cli.track.subprocess.run",
+    side_effect=subprocess.CalledProcessError(1, "tmux"),
+  ):
+    assert tmux_window_exists("@99", TEST_SERVER_KEY) is False
 
 def test_last_selected_window_round_trip(temp_tracking_dir):
     """Write and read the last-selected window state file."""
@@ -10167,6 +10282,7 @@ import json
 import logging
 import os
 import socket
+import subprocess
 import tempfile
 import pytest
 from typer.testing import CliRunner
@@ -10212,6 +10328,7 @@ from nytid.cli.track import (
     unregister_tmux_context_labels,
     window_labels_path,
     read_window_labels,
+    read_window_label_counts,
     write_window_labels,
     add_window_labels,
     remove_window_labels,
@@ -10224,6 +10341,7 @@ from nytid.cli.track import (
     emit_window_event_debug,
     get_tmux_window_id_for_pane,
     get_tmux_selected_window_id,
+    tmux_window_exists,
     last_selected_window_path,
     read_last_selected_window,
     write_last_selected_window,
@@ -11043,22 +11161,161 @@ def test_cleanup_window_detached_preserves_other_labels(
         ["shared"],
     )
 
-    result = runner.invoke(
-        cli,
-        [
-            "_cleanup-window-detached",
-            "X",
-            "shared",
-            "--window-id",
-            window_id,
-            "--server-key",
-            TEST_SERVER_KEY,
-        ],
-    )
+    with patch(
+        "nytid.cli.track.tmux_window_exists",
+        return_value=True,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "_cleanup-window-detached",
+                "X",
+                "shared",
+                "--window-id",
+                window_id,
+                "--server-key",
+                TEST_SERVER_KEY,
+            ],
+        )
     assert result.exit_code == 0
     assert read_window_labels(
         window_id, default_username, TEST_SERVER_KEY,
     ) == ["shared", "Y"]
+@
+
+The cleanup command is also the sole owner of window-file deletion, and
+it keys that on tmux liveness rather than on the label count.  When a
+pane dies but a sibling keeps the window open, tmux still reports the
+window, so even an emptied file survives as the tracked marker.  Only
+when tmux confirms the window is gone does the file disappear.
+
+<<test functions>>=
+def test_cleanup_window_detached_keeps_file_when_window_alive(
+  temp_tracking_dir,
+):
+  """A live window keeps its file even after the last label."""
+  window_id = "@42"
+  add_window_labels(
+    window_id, default_username, TEST_SERVER_KEY, ["X"],
+  )
+
+  with patch(
+    "nytid.cli.track.tmux_window_exists",
+    return_value=True,
+  ):
+    result = runner.invoke(
+      cli,
+      [
+        "_cleanup-window-detached",
+        "X",
+        "--window-id",
+        window_id,
+        "--server-key",
+        TEST_SERVER_KEY,
+      ],
+    )
+  assert result.exit_code == 0
+  assert read_window_labels(
+    window_id, default_username, TEST_SERVER_KEY,
+  ) == []
+
+def test_cleanup_window_detached_deletes_when_window_gone(
+  temp_tracking_dir,
+):
+  """A vanished window has its labels file unlinked."""
+  window_id = "@42"
+  add_window_labels(
+    window_id, default_username, TEST_SERVER_KEY, ["X"],
+  )
+
+  with patch(
+    "nytid.cli.track.tmux_window_exists",
+    return_value=False,
+  ):
+    result = runner.invoke(
+      cli,
+      [
+        "_cleanup-window-detached",
+        "X",
+        "--window-id",
+        window_id,
+        "--server-key",
+        TEST_SERVER_KEY,
+      ],
+    )
+  assert result.exit_code == 0
+  assert not window_labels_path(
+    window_id, default_username, TEST_SERVER_KEY,
+  ).exists()
+@
+
+The empty marker file is what lets a window survive a full stop.  Its
+payoff is in [[get_current_tracked_window_id]]: an emptied-but-present
+file must still resolve to the window id, otherwise the window would
+read as untracked and a resume would start its labels globally.
+
+<<test functions>>=
+def test_get_current_tracked_window_id_with_empty_file(
+  temp_tracking_dir,
+):
+  """An empty-but-present window file still counts as tracked."""
+  window_id = "@42"
+  add_window_labels(
+    window_id, default_username, TEST_SERVER_KEY, ["X"],
+  )
+  remove_window_labels(
+    window_id, default_username, TEST_SERVER_KEY, ["X"],
+  )
+  assert read_window_labels(
+    window_id, default_username, TEST_SERVER_KEY,
+  ) == []
+  with patch.dict(
+    os.environ, {"TMUX_PANE": "%99"},
+  ), patch(
+    "nytid.cli.track.get_tmux_window_id_for_pane",
+    return_value=window_id,
+  ):
+    assert get_current_tracked_window_id(
+      default_username, TEST_SERVER_KEY,
+    ) == window_id
+@
+
+This is the end-to-end guarantee the change exists for.  After stopping
+every label in a still-open tracked window, the window stays tracked, so
+re-registering those labels --- the path a resume takes --- attaches them
+back to the window rather than starting them as window-less globals.
+
+<<test functions>>=
+def test_stop_all_keeps_window_tracked_and_resume_reassociates(
+  temp_tracking_dir,
+):
+  """Stopping all labels keeps the window so resume re-ties them."""
+  window_id = "@42"
+  runner.invoke(cli, ["start", "X"])
+  write_window_labels(
+    window_id, default_username, TEST_SERVER_KEY, ["X"],
+  )
+  env = {
+    "TMUX_PANE": "%99",
+    "TMUX": "/tmp/tmux.sock,123,0",
+  }
+  with patch.dict(os.environ, env), patch(
+    "nytid.cli.track.get_tmux_window_id_for_pane",
+    return_value=window_id,
+  ):
+    stop_result = runner.invoke(
+      cli, ["_stop-detached", "X"],
+    )
+    assert read_window_labels(
+      window_id, default_username, TEST_SERVER_KEY,
+    ) == []
+    register_tmux_context_labels(
+      ["X"], default_username,
+    )
+  assert stop_result.exit_code == 0
+  assert read_window_labels(
+    window_id, default_username, TEST_SERVER_KEY,
+  ) == ["X"]
 @
 
 The [[--timeout]] option only applies to direct subprocesses, not


### PR DESCRIPTION
- **Bumps version**
- **Keep tracked tmux window after stopping all labels**
- **Adds missing zulip.tex prereq**
