### PR TITLE
Use tempdir path, not repr, in test_non_existing

### DIFF
--- a/src/nytid/storage/init.nw
+++ b/src/nytid/storage/init.nw
@@ -226,7 +226,7 @@ We also want to test when the storage root doesn't exist.
 <<test functions>>=
 def test_non_existing():
   test_string = "StorageRoot test"
-  new_root_dir = f"{root_dir}/non-existing-subdirectory"
+  new_root_dir = f"{root_dir.name}/non-existing-subdirectory"
 
   with StorageRoot(new_root_dir) as root:
     with root.open("test.txt", "w") as f:


### PR DESCRIPTION
## Problem

`test_non_existing` built its path with `f"{root_dir}/..."` where
`root_dir` is a `TemporaryDirectory` object, interpolating its repr.
Every test run created a literal `<TemporaryDirectory '/tmp/...'>`
tree under the CWD, and the test never exercised a path inside the
temporary directory as intended. See #359.

## Fix

Use `root_dir.name`, matching every sibling test in the file.

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136fb1QAY29rDDLkELhZEpK
