### PR TITLE
Fix six bugs in the HR and sign-up modules

### DIFF
--- a/src/nytid/cli/hr.nw
+++ b/src/nytid/cli/hr.nw
@@ -3217,20 +3217,116 @@ generate it.
 We will store the diffs ([[added_events]] and [[removed_events]]), that way 
 we'll build up the set of all events by adding them.
 
-For each time sheet we'll store [[added_events]] and [[removed_events]] in a 
+For each time sheet we'll store [[added_events]] and [[removed_events]] in a
 JSON file.
 This is similar to how we store the amanuensis contracts.
 <<store [[added_events]], [[removed_events]] for [[user]] as reported>>=
-timesheets_dir = pathlib.Path(typerconf.get(TIMESHEETS_DIR_PATH))
-filename = f"{user}.{datetime.datetime.now().isoformat()}.json"
-with open(timesheets_dir / filename, "w") as outfile:
-  json.dump({"user": user,
-             "added_events": added_events,
-             "removed_events": removed_events},
-            outfile,
-            indent=2)
+store_timesheet(timesheets_dir, user, added_events, removed_events)
+@
+
+The write has to create the directory first, and that is not a nicety.
+The [[if store:]] block runs \emph{after} the xlsx files have been
+generated, so a missing directory raises [[FileNotFoundError]] at the one
+moment when the time sheets already exist on disk but nothing records
+that they were reported.
+The next run then recomputes the very same events as [[added_events]] and
+generates the same time sheets over again---a double-payment hazard, and
+exactly what storing the events was introduced to prevent.
+The sibling that stores amanuensis contracts calls [[mkdir]] for this
+reason; there is no reason for the two to differ.
+<<helper functions>>=
+def store_timesheet(timesheets_dir, user, added_events, removed_events):
+  """
+  Records `added_events` and `removed_events` for `user` as reported, in a
+  JSON file under `timesheets_dir`. Creates the directory if it doesn't
+  already exist. Returns the path written.
+  """
+  timesheets_dir.mkdir(parents=True, exist_ok=True)
+
+  filename = f"{user}.{datetime.datetime.now().isoformat()}.json"
+  path = timesheets_dir / filename
+
+  with open(path, "w") as outfile:
+    json.dump({"user": user,
+               "added_events": added_events,
+               "removed_events": removed_events},
+              outfile,
+              indent=2)
+
+  return path
+@
+
+The directory that receives them is a configuration key, so it can be
+absent.
+[[typerconf.get]] answers an unset key with [[KeyError]], which on a
+fresh install turns the first run of both [[generate]] and [[show]] into
+a traceback over something the user could trivially fix.
+The amanuensis commands earlier in this file already settled how to
+handle that: warn, quote the [[nytid config]] invocation that sets the
+key, and fall back to the working directory.
+We do the same here.
+
+We put it in a function rather than a chunk because three separate code
+paths need the value---storing, reading back, and the [[show]]
+command---and a function makes that dependency a visible argument-free
+call at each of them, whereas a shared chunk could silently be left out
+of one path.
+<<helper functions>>=
+def timesheets_directory():
+  """
+  Returns the configured directory for time sheet data as a pathlib.Path.
+  Falls back to `./` with a warning when the key isn't configured.
+  """
+  try:
+    return pathlib.Path(typerconf.get(TIMESHEETS_DIR_PATH))
+  except KeyError:
+    logging.warning(f"Can't find {TIMESHEETS_DIR_PATH} in config, "
+                    f"using `./`. Set by running "
+                    f"`nytid config {TIMESHEETS_DIR_PATH} -s <path>`.")
+    return pathlib.Path("./")
 <<constants>>=
 TIMESHEETS_DIR_PATH = "hr.timesheets.timesheets_dir"
+@
+
+The value is the same for every TA, so we look it up once, before the
+loop over the users, instead of once per TA.
+<<timesheet generation user iteration variables>>=
+timesheets_dir = timesheets_directory()
+@
+
+Let's verify both halves.
+The fallback must survive an unconfigured key, and the store must survive
+a directory that doesn't exist yet.
+<<test functions>>=
+def test_timesheets_directory_falls_back_when_unconfigured(monkeypatch):
+  import typerconf
+
+  def unset(key):
+    raise KeyError(key)
+
+  monkeypatch.setattr(typerconf, "get", unset)
+
+  assert timesheets_directory() == pathlib.Path("./")
+
+def test_timesheets_directory_uses_config(monkeypatch, tmp_path):
+  import typerconf
+  monkeypatch.setattr(typerconf, "get", lambda key: str(tmp_path))
+
+  assert timesheets_directory() == tmp_path
+
+def test_store_timesheet_creates_missing_directory(tmp_path):
+  target = tmp_path / "does" / "not" / "exist"
+
+  path = store_timesheet(target, "alice", [{"belopp": 1}], [])
+
+  assert path.parent == target
+
+  with open(path) as infile:
+    stored = json.load(infile)
+
+  assert stored["user"] == "alice"
+  assert stored["added_events"] == [{"belopp": 1}]
+  assert stored["removed_events"] == []
 @
 
 This means that we can read the data back as follows.
@@ -3240,8 +3336,9 @@ We simply read each time sheet file and add [[added_events]] to
 This way [[all_prev_events]] represents the correctly reported history.
 We must filter these events by the same date range as the current events to
 avoid falsely marking future events as \enquote{removed}.
+This chunk reads [[timesheets_dir]] from the iteration variables above,
+so it only works in a code path that includes them.
 <<add [[user]]'s previously reported events to [[all_prev_events]]>>=
-timesheets_dir = pathlib.Path(typerconf.get(TIMESHEETS_DIR_PATH))
 for timesheet_file in timesheets_dir.glob(f"{user}.*.json"):
   try:
     with open(timesheet_file) as infile:
@@ -3274,7 +3371,7 @@ def cli_show_timesheets(<<argument [[user_regex]] to match TAs>> = ".*",
   """
   Shows stored time sheets for TAs.
   """
-  timesheets_dir = pathlib.Path(typerconf.get(TIMESHEETS_DIR_PATH))
+  timesheets_dir = timesheets_directory()
 
   <<timesheets iteration variables>>
   <<set [[timesheets]] depending on [[all]]>>

--- a/src/nytid/signup/hr/hr.nw
+++ b/src/nytid/signup/hr/hr.nw
@@ -947,6 +947,26 @@ def test_compute_amanuensis_data_periods_are_per_TA():
 @
 
 The [[compute_percentage]] function simply computes the average working time.
+
+A period of no days is not an exotic input here.
+[[sheet_date]] deliberately truncates the sheet's times to local
+midnight, so a TA booked on a single day arrives with
+[[earliest_date == latest_date]]; the caller can also force
+[[begin_date]] and [[end_date]] to the same day from [[--start]] and
+[[--end]].
+The division would then raise [[ZeroDivisionError]] from inside the
+[[elif]]-chain above---which runs \emph{before} the [[min_days]] check
+that was meant to reject such a period in the first place.
+
+We report such a period as zero rather than raising.
+An employment has day resolution, so a period spanning no days cannot
+express any working time at all, and reporting zero lets the
+[[elif]]-chain reject it the way it rejects every other period that is
+too thin: the TA falls through to [[continue]] and is left out.
+Raising would instead force a [[try]]/[[except]] on every caller,
+including the two in the CLI that print the percentage.
+The same reasoning covers an inverted period, so we guard on
+[[days <= 0]].
 <<functions>>=
 def compute_percentage(start, end, hours):
   """
@@ -954,8 +974,14 @@ def compute_percentage(start, end, hours):
     hours as a float.
 
   Output: a float in the interval [0, 1], which is the percentage of full time.
+  A period covering no days yields 0.0, since a contract cannot express
+  any working time over no days.
   """
   days = (end - start).total_seconds()/60/60/24
+
+  if days <= 0:
+    return 0.0
+
   return (hours / 1600) * (365 / days)
 @
 
@@ -971,6 +997,28 @@ def test_compute_percentage():
   result = compute_percentage(start, end, hours)
   expected = (160 / 1600) * (365 / 366)
   assert abs(result - expected) < 0.001
+@
+
+The degenerate periods must be answered, not raised on---both directly
+and through the amanuensis computation that forces a single-day period.
+<<test functions>>=
+def test_compute_percentage_same_day():
+  day = datetime.datetime(2024, 1, 1)
+  assert compute_percentage(day, day, 10) == 0.0
+
+def test_compute_percentage_inverted():
+  start = datetime.datetime(2024, 2, 1)
+  end = datetime.datetime(2024, 1, 1)
+  assert compute_percentage(start, end, 10) == 0.0
+
+def test_compute_amanuensis_data_single_day_period():
+  rows = [make_row(start="2024-09-02 10:00", end="2024-09-02 12:00",
+                   tas=["alice"])]
+  day = datetime.datetime(2024, 9, 2).astimezone()
+
+  data = compute_amanuensis_data(rows, begin_date=day, end_date=day)
+
+  assert data == {}
 @
 
 

--- a/src/nytid/signup/hr/hr.nw
+++ b/src/nytid/signup/hr/hr.nw
@@ -297,13 +297,38 @@ string, so that a change to the sheet format cannot silently desynchronize
 the writer and this reader.
 
 We start with a function to compute the number of hours spent per student.
+
+A row of the sign-up sheet is not the same thing as a session, and this
+is where the distinction bites.
+When [[generate_signup_sheet]] meets a hybrid event---one whose location
+includes a digital room---it writes the event out \emph{twice}, once for
+the physical rooms and once for the digital room, so that TAs can sign up
+separately for each.
+The two rows carry the same [[Event]], [[Start]] and [[End]]; only the
+[[Rooms]] column differs.
+Summing rows would therefore report a two-hour hybrid lab as four hours
+per student.
+
+We assume that a figure labelled \enquote{per student} describes what a
+single student is scheduled for, and a student cannot attend the campus
+half and the digital half of one session at the same time---so a session
+counts once however many rows it was split into.
+That is precisely what separates this function from [[hours_per_event]]
+below, which sums the same rows to describe the total supervision effort
+and \emph{should} count both halves.
+Without this distinction the two functions compute the same thing, and
+one of them is redundant.
+
+We identify a session by the three columns that [[generate_signup_sheet]]
+leaves untouched when it splits an event, and count each identity once.
 <<functions>>=
 def hours_per_student(csv_rows, round_time=round_time):
   """
   Input: The schedule as rows of CSV data as from csv.reader.
 
-  Output: A dictionary mapping event type to the total number of hours per 
-  student.
+  Output: A dictionary mapping event type to the total number of hours per
+  student. Sessions split across several rows (e.g. a hybrid event with
+  separate physical and digital rows) count once.
   """
 
   start_index = SIGNUP_SHEET_HEADER.index("Start")
@@ -311,8 +336,16 @@ def hours_per_student(csv_rows, round_time=round_time):
   event_index = SIGNUP_SHEET_HEADER.index("Event")
 
   event_hours = dict()
+  counted_sessions = set()
 
   for row in csv_rows:
+    session = (row[event_index], row[start_index], row[end_index])
+
+    if session in counted_sessions:
+      continue
+
+    counted_sessions.add(session)
+
     time = round_time(
       datetime.datetime.strptime(row[end_index], STRPTIME_FORMAT)
       - datetime.datetime.strptime(row[start_index], STRPTIME_FORMAT))
@@ -348,6 +381,36 @@ def test_hours_per_student_multiple():
   result = hours_per_student(rows)
   assert "Laboration" in result
   assert "Övning" in result
+@
+
+The rows below are shaped exactly as [[generate_signup_sheet]] emits them
+for one hybrid two-hour lab.
+The student-facing figure stays at two hours, while [[hours_per_event]]
+still sees both halves.
+Two genuinely distinct sessions of the same type must of course still
+add up.
+<<test functions>>=
+def test_hours_per_student_hybrid_counted_once():
+  rows = [
+    make_row(event="Laboration", rooms="D1"),
+    make_row(event="Laboration", rooms="Digital"),
+  ]
+
+  assert hours_per_student(rows)["Laboration"] \
+           == datetime.timedelta(hours=2)
+  assert hours_per_event(rows)["Laboration"] \
+           == datetime.timedelta(hours=4)
+
+def test_hours_per_student_distinct_sessions_add_up():
+  rows = [
+    make_row(event="Laboration",
+             start="2024-09-02 10:00", end="2024-09-02 12:00"),
+    make_row(event="Laboration",
+             start="2024-09-03 10:00", end="2024-09-03 12:00"),
+  ]
+
+  assert hours_per_student(rows)["Laboration"] \
+           == datetime.timedelta(hours=4)
 @
 
 Now we can compute the hours per TA.

--- a/src/nytid/signup/hr/hr.nw
+++ b/src/nytid/signup/hr/hr.nw
@@ -713,20 +713,37 @@ def test_sheet_date():
   assert date.hour == 0 and date.minute == 0
 @
 
-We start by finding all start and end dates for every TA.
+We start by finding the earliest start and the latest end among the
+rows.
+
+The names we give the row-local variables matter more than they look.
+This chunk and [[<<expand earliest and latest dates if beneficial>>]]
+below are written a page apart, but [[notangle]] splices both into the
+same function body, so every name introduced here is still live down
+there.
+The parameters [[begin_date]] and [[end_date]] are exactly such names.
+An earlier version of this chunk stored the row's end date in a variable
+called [[end_date]], which silently overwrote the caller's \emph{forced}
+end date before the code below ever got to read it---so a contract's end
+date became whatever the last row of the sheet happened to say, and the
+result depended on the order of the CSV rows.
+The start side survived by luck alone: its parameter is spelled
+[[begin_date]], so the row-local [[start_date]] happened not to collide.
+We therefore prefix both row-local names with [[row_]], which puts them
+in a namespace the function signature cannot reach.
 <<compute the earliest and latest dates for each TA>>=
 for ta in ta_hours.keys():
   earliest_date = sheet_date(csv_rows[0][start_index])
   latest_date = sheet_date(csv_rows[0][end_index])
 
   for row in csv_rows:
-    start_date = sheet_date(row[start_index])
-    end_date = sheet_date(row[end_index])
+    row_start = sheet_date(row[start_index])
+    row_end = sheet_date(row[end_index])
 
-    if start_date < earliest_date:
-      earliest_date = start_date
-    if end_date > latest_date:
-      latest_date = end_date
+    if row_start < earliest_date:
+      earliest_date = row_start
+    if row_end > latest_date:
+      latest_date = row_end
 
   hours = ta_hours[ta].total_seconds()/60/60
 
@@ -830,6 +847,52 @@ elif compute_percentage(earliest_date, latest_date, hours) >= low_percentage:
   pass
 else:
   continue # skip to next TA
+@
+
+Both halves of the computation are now in view, so we can check the
+property that ties them together: what the caller forces must reach the
+output untouched.
+The TA below works in September and December, so the row scan would
+otherwise leave December behind as the end date.
+We drop [[low_percentage]] to zero to isolate the date handling from the
+percentage thresholds.
+<<test functions>>=
+def test_compute_amanuensis_data_honours_forced_dates():
+  rows = [
+    make_row(start="2024-09-02 10:00", end="2024-09-02 12:00",
+             tas=["alice"]),
+    make_row(start="2024-12-10 10:00", end="2024-12-10 12:00",
+             tas=["alice"]),
+  ]
+  begin = datetime.datetime(2024, 8, 1).astimezone()
+  end = datetime.datetime(2025, 1, 31).astimezone()
+
+  data = compute_amanuensis_data(rows, low_percentage=0,
+                                 begin_date=begin, end_date=end)
+
+  assert data["alice"][0] == begin
+  assert data["alice"][1] == end
+@
+
+The forced dates must also be independent of the order of the rows,
+which is the symptom a leaked row-local produces.
+<<test functions>>=
+def test_compute_amanuensis_data_forced_end_ignores_row_order():
+  rows = [
+    make_row(start="2024-09-02 10:00", end="2024-09-02 12:00",
+             tas=["alice"]),
+    make_row(start="2024-12-10 10:00", end="2024-12-10 12:00",
+             tas=["alice"]),
+  ]
+  end = datetime.datetime(2025, 1, 31).astimezone()
+
+  forwards = compute_amanuensis_data(rows, low_percentage=0,
+                                     end_date=end)
+  backwards = compute_amanuensis_data(list(reversed(rows)),
+                                      low_percentage=0, end_date=end)
+
+  assert forwards["alice"][1] == end
+  assert forwards == backwards
 @
 
 The [[compute_percentage]] function simply computes the average working time.

--- a/src/nytid/signup/hr/hr.nw
+++ b/src/nytid/signup/hr/hr.nw
@@ -713,8 +713,21 @@ def test_sheet_date():
   assert date.hour == 0 and date.minute == 0
 @
 
-We start by finding the earliest start and the latest end among the
-rows.
+We start by finding the earliest start and the latest end among the rows
+the TA is actually booked on.
+
+Restricting the scan to the TA's own rows is what makes the period
+personal.
+Were we to scan the whole sheet, the inner loop would not mention [[ta]]
+anywhere---it would be loop-invariant, and every TA would come out with
+the same period, namely the span of the entire course.
+That is not a cosmetic difference, because the two halves of the
+contract would then be measured over different populations: the hours
+come from the TA's own bookings, but the days would come from everyone's.
+A TA who only works in December would be handed an August start date and
+their hours would be spread over five months instead of one, which can
+push a genuinely over-cap appointment below the 50 percent ceiling of the
+Higher Education Ordinance without anyone noticing.
 
 The names we give the row-local variables matter more than they look.
 This chunk and [[<<expand earliest and latest dates if beneficial>>]]
@@ -733,10 +746,12 @@ We therefore prefix both row-local names with [[row_]], which puts them
 in a namespace the function signature cannot reach.
 <<compute the earliest and latest dates for each TA>>=
 for ta in ta_hours.keys():
-  earliest_date = sheet_date(csv_rows[0][start_index])
-  latest_date = sheet_date(csv_rows[0][end_index])
+  <<let [[ta_rows]] be the rows where [[ta]] is booked>>
 
-  for row in csv_rows:
+  earliest_date = sheet_date(ta_rows[0][start_index])
+  latest_date = sheet_date(ta_rows[0][end_index])
+
+  for row in ta_rows:
     row_start = sheet_date(row[start_index])
     row_end = sheet_date(row[end_index])
 
@@ -755,7 +770,20 @@ for ta in ta_hours.keys():
   ta_data[ta] = (earliest_date, latest_date, hours)
 @
 
-Now we want to try to use different start and end dates to optimize the period 
+We select the TA's rows with the same membership test that
+[[hours_per_TA]] uses (\cref{HoursPerTA}), rather than a private one, so
+that the period and the hours are always derived from the identical set
+of bookings---a row where the TA is only a reserve contributes to
+neither.
+Indexing [[ta_rows[0] ]] needs no emptiness check: [[ta_hours]] contains
+a TA precisely when [[hours_per_TA]] found that TA booked on at least one
+row, so the list is guaranteed non-empty for every key we iterate over.
+<<let [[ta_rows]] be the rows where [[ta]] is booked>>=
+ta_rows = [row for row in csv_rows
+           if ta in sheets.get_booked_TAs_from_csv(row)[0]]
+@
+
+Now we want to try to use different start and end dates to optimize the period
 for the student.
 We first try with the start and end dates expanded to the semester, then the 
 first and last of the months, finally the exact dates.
@@ -893,6 +921,29 @@ def test_compute_amanuensis_data_forced_end_ignores_row_order():
 
   assert forwards["alice"][1] == end
   assert forwards == backwards
+@
+
+The per-TA scan is visible in the same output.
+Alice works one day in February and Bob one day in September, which puts
+them in different semesters, so rounding to the semester must send them
+to different periods.
+A scan over the whole sheet would instead give both of them February as
+the earliest date, and both would be rounded into the spring semester.
+<<test functions>>=
+def test_compute_amanuensis_data_periods_are_per_TA():
+  rows = [
+    make_row(start="2024-02-10 10:00", end="2024-02-10 12:00",
+             tas=["alice"]),
+    make_row(start="2024-09-02 10:00", end="2024-09-02 12:00",
+             tas=["bob"]),
+  ]
+
+  data = compute_amanuensis_data(rows, low_percentage=0, min_days=1)
+
+  assert data["alice"][0].date() == datetime.date(2024, 1, 1)
+  assert data["alice"][1].date() == datetime.date(2024, 6, 30)
+  assert data["bob"][0].date() == datetime.date(2024, 8, 1)
+  assert data["bob"][1].date() == datetime.date(2025, 1, 31)
 @
 
 The [[compute_percentage]] function simply computes the average working time.

--- a/src/nytid/signup/utils.nw
+++ b/src/nytid/signup/utils.nw
@@ -18,16 +18,33 @@ type ([[VEVENT]]), so matching against it would silently never
 recognize a lab or tutorial.
 The base algorithm counts on one TA per group.
 If there are no groups, we use one TA per room.
+
+[[DESCRIPTION]] and [[LOCATION]] are optional iCalendar properties, and
+[[icalendar]] reports an absent one as [[None]] rather than as the empty
+string.
+Calling [[.split()]] on that raises [[AttributeError]], which aborts the
+whole [[nytid signupsheets generate]] run over a single bare calendar
+entry, with nothing in the traceback to say which entry it was.
+We therefore substitute the empty string, which is not merely a way to
+avoid the crash but the correct reading of an absent property: an event
+with no description mentions no groups, and [["".split(",")]] is a
+one-element list, so an event with no stated location is treated as one
+room.
+Both are exactly what the fallbacks below already do for an event whose
+description and location are present but say nothing useful.
 <<functions>>=
 def needed_TAs(event, <<[[needed_TAs]] args>>):
   """
   Takes an event and returns the number of TAs needed
   """
-  num_groups = event.description.split().count("grupp")
-  if num_groups == 0:
-    num_groups = event.description.split().count("group")
+  description = event.description or ""
+  location = event.location or ""
 
-  num_rooms = len(event.location.split(","))
+  num_groups = description.split().count("grupp")
+  if num_groups == 0:
+    num_groups = description.split().count("group")
+
+  num_rooms = len(location.split(","))
 
   if "laboration" in event.summary or "Laboration" in event.summary:
     <<compute [[num_TAs]] for lab>>
@@ -163,4 +180,28 @@ def test_needed_TAs_english_groups():
   event = make_event(name="Laboration",
                      description="group A group B")
   assert needed_TAs(event) == 2
+@
+
+\subsection{Events missing optional properties}
+
+An event without a [[DESCRIPTION]] or without a [[LOCATION]] must not
+abort the sign-up-sheet generation.
+These are the cases where [[icalendar]] hands us [[None]], so they are
+the ones a mock cannot exercise---the real [[icalendar.Event]] built by
+[[make_event]] can.
+<<test functions>>=
+def test_needed_TAs_no_description():
+  event = make_event(name="Laboration", location="D1",
+                     description=None)
+  assert needed_TAs(event) == 1
+
+def test_needed_TAs_no_location():
+  event = make_event(name="Övning", location=None,
+                     description="grupp 1")
+  assert needed_TAs(event) == 1
+
+def test_needed_TAs_no_description_no_location():
+  event = make_event(name="Seminarium", location=None,
+                     description=None)
+  assert needed_TAs(event) == 1
 @


### PR DESCRIPTION
Six verified bugs in `nytid.signup.hr`, `nytid.signup.utils` and
`nytid.cli.hr`, each with its own issue, its own commit, and a
regression test that fails before the fix.

Four of them affect numbers that end up on signed employment paperwork
(contract dates, percentage, reported hours); one aborts sign-up-sheet
generation outright; one risks paying a TA twice for the same events.

Test suite: 663 passing before, 677 after (14 new tests). Only `.nw`
sources are touched.

## Contract end date silently ignored — Closes #368

`compute_amanuensis_data`'s row scan assigned the row's end date to
`end_date`, the same name as the parameter that *forces* the contract
end date. The chunk that consumes that parameter is written a page
further down but tangles into the same function body, so the caller's
value was gone by the time it was read — and the contract ended on
whatever the last CSV row happened to say, making the result depend on
row order.

The start side escaped only because its parameter is spelled
`begin_date`, so this was a copy-paste asymmetry rather than a design.
The row-locals are now prefixed `row_`, and the prose explains the
noweb chunk-composition hazard: two chunks that never meet in the source
still share one namespace after tangling.

## Every TA got the same contract dates — Closes #370

The same scan walked the entire sign-up sheet, so it never mentioned the
TA it was running for. Being loop-invariant, it handed every TA the span
of the whole course.

The hours are per-TA, so the percentage was divided by the wrong number
of days: a December-only TA got an August start and five months to
spread three weeks of work over, which can push a genuinely over-cap
appointment below the 50 % ceiling of the Higher Education Ordinance
without anyone noticing. The scan now filters rows through the same
`sheets.get_booked_TAs_from_csv` membership test that `hours_per_TA`
already uses, so period and hours come from identical bookings.

## `needed_TAs` crashed on incomplete calendar entries — Closes #372

`DESCRIPTION` and `LOCATION` are optional iCalendar properties, and
icalendar 7.x reports an absent one as `None`. `needed_TAs` called
`.split()` on both unguarded, so a single bare entry in the TimeEdit
export aborted the whole `nytid signupsheets generate` run with an
`AttributeError` naming neither the event nor the property.

Both now fall back to the empty string, which is also the correct
reading: no description means no groups, no location means one room —
the same answers the existing fallbacks already give for an
uninformative description or location.

## `ZeroDivisionError` on single-day periods — Closes #376

`compute_percentage` divided by the period length unguarded. Since
`sheet_date` truncates to local midnight, a TA booked on one day — or a
caller passing `--start` equal to `--end` — produced a zero-length period
and crashed, from inside the `elif`-chain that runs *before* the
`min_days` check meant to reject exactly that period.

It now returns `0.0` for a period of no days, and for an inverted one. A
contract has day resolution, so no days can express no working time, and
zero lets the chain reject the period the way it rejects every other one
that is too thin — without forcing a `try`/`except` on the two CLI
callers that print the percentage.

## Hybrid sessions double-counted per student — Closes #384

`generate_signup_sheet` writes a hybrid event as two rows, physical and
digital, differing only in the `Rooms` column. `hours_per_student`
summed rows, so `nytid hr` reported a two-hour hybrid lab as
4.0 h/student — and the function was the same computation as
`hours_per_event`.

**Stated assumption:** a figure labelled *per student* describes what one
student is scheduled for, and a student cannot attend the campus half
and the digital half at once, so a session counts once however many rows
it was split into. That is also what now distinguishes this function
from `hours_per_event`, which still counts both halves because it
measures supervision effort. **If the double counting was in fact
intended, the right change is to delete `hours_per_student` in favour of
`hours_per_event` instead of deduplicating** — please say so and I'll
swap the fix.

Deduplication keys on `(Event, Start, End)`, the columns
`generate_signup_sheet` leaves untouched when it splits an event.

## Timesheet storage unusable on a fresh install, and a double-payment hazard — Closes #390

Two problems, both fixed by extracting functions rather than chunks so
the call sites cannot drift apart:

- The configured directory was read with a bare
  `typerconf.get(TIMESHEETS_DIR_PATH)` in three places, so on a fresh
  install both `generate` and `show` died with a `KeyError` traceback.
  `timesheets_directory()` now warns, quotes the `nytid config` command
  that fixes it, and falls back to `./` — matching what the amanuensis
  commands in the same file already do. `generate` calls it once before
  the per-user loop instead of once per TA.
- `--store` wrote into that directory with no `mkdir`. Because it runs
  *after* the xlsx files are generated, a missing directory raised
  `FileNotFoundError` at the exact point where the time sheets existed
  but nothing recorded them as reported — so the next run regenerated
  the same time sheets, risking double payment.
  `store_timesheet()` creates the directory first, as the amanuensis
  contract store already does.

## Needs maintainer decision — #382 (no code change here)

`prep_factor`'s 2022-10-01 policy boundary is dead code:

```python
date < datetime.date(2023, 1, 1)
or (date < datetime.date(2022, 10, 1) and not amanuensis)
```

The second disjunct is subsumed by the first, so the `amanuensis`
distinction never applies and the cutover is 2023-01-01 for both
employment types — contradicting this chapter's own prose, which says
the policy changed on 2022-10-01 and differs by employment type.

Whichever reading was intended, one employment type got the wrong
coefficient for Oct–Dec 2022; on one reading that is a full salary hour
per two-hour lab. **The correct transition dates are a policy question
only the maintainer can answer**, so #382 documents the options rather
than guessing. Once the policy is confirmed the fix is one line plus
tests pinning both employment types on both sides of each boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136fb1QAY29rDDLkELhZEpK
