### PR TITLE
Fix seven bugs in the track module

### DIFF
--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -5270,13 +5270,19 @@ def run_tmux_command(
     focus_labels: list[str] | None = None,
     focus_who: str | None = None,
     focus_window: bool = False,
+    auto_suspend: bool = True,
 ) -> int | None:
     """Run a command in tmux and optionally wait for exit.
 
-    When ``focus_labels`` is set, auto-suspend hooks are
-    installed.  Pane launches suspend directly on pane focus
-    changes, while window launches synchronize against the
-    authoritative tmux selected window.
+    When ``focus_labels`` is set, they are published as the new
+    pane's or window's tracked context, which is what lets
+    nested commands discover the labels they run under.
+
+    ``auto_suspend`` additionally arms the hooks that stop and
+    restart those labels when attention moves.  Pane launches
+    suspend directly on pane focus changes, while window
+    launches synchronize against the authoritative tmux
+    selected window.
     """
     ready_channel = make_tmux_channel("ready")
     wait_channel = None
@@ -5437,11 +5443,12 @@ state of its own.
 source_window_id = None
 source_window_labels = None
 needs_window_sync = False
+published_window_labels = False
 
 def launch_and_publish_state():
     nonlocal pane_id, window_id, session_id
     nonlocal source_window_id, source_window_labels
-    nonlocal needs_window_sync
+    nonlocal needs_window_sync, published_window_labels
 
     result = subprocess.run(
         tmux_args,
@@ -5460,7 +5467,7 @@ def launch_and_publish_state():
     if focus_labels and focus_who:
         if not tmux_server_key:
             raise RuntimeError(
-                "tmux server key missing for auto-suspend launch"
+                "tmux server key missing for tracked launch"
             )
         if focus_window and window_id and session_id:
             write_window_labels(
@@ -5469,25 +5476,27 @@ def launch_and_publish_state():
                 tmux_server_key,
                 focus_labels,
             )
-            prev_wid = read_last_selected_window(
-                focus_who,
-                tmux_server_key,
-                session_id,
-            )
-            source_window_id = prev_wid
-            if prev_wid is not None:
-                source_window_labels = read_window_labels(
-                    prev_wid,
+            published_window_labels = True
+            if auto_suspend:
+                prev_wid = read_last_selected_window(
                     focus_who,
                     tmux_server_key,
+                    session_id,
                 )
+                source_window_id = prev_wid
+                if prev_wid is not None:
+                    source_window_labels = read_window_labels(
+                        prev_wid,
+                        focus_who,
+                        tmux_server_key,
+                    )
+                needs_window_sync = True
             write_last_selected_window(
                 focus_who,
                 tmux_server_key,
                 session_id,
                 window_id,
             )
-            needs_window_sync = True
         else:
             write_pane_labels(
                 pane_id,
@@ -5495,11 +5504,12 @@ def launch_and_publish_state():
                 tmux_server_key,
                 focus_labels,
             )
-            install_tmux_focus_hooks(
-                pane_id,
-                focus_who,
-                tmux_server_key,
-            )
+            if auto_suspend:
+                install_tmux_focus_hooks(
+                    pane_id,
+                    focus_who,
+                    tmux_server_key,
+                )
             install_tmux_suspend_cleanup_hook(
                 pane_id,
                 focus_who,
@@ -5548,6 +5558,8 @@ if needs_window_sync:
         focus_who,
         tmux_server_key,
     )
+
+if published_window_labels:
     install_tmux_window_cleanup_hook(
         pane_id,
         window_id,
@@ -5556,6 +5568,24 @@ if needs_window_sync:
         focus_labels,
     )
 @
+
+Note which steps hang off which condition.  Publishing the labels and
+installing the cleanup hook that eventually removes them are two halves
+of the same act, so they follow \emph{publication}: leaving them coupled
+to auto-suspend would let a labels file outlive the pane that owned it
+and make every later command believe that window is still tracked.
+
+The transition itself---suspending the window we came from, restarting
+the labels of the one we arrived at, and arming the session hook that
+repeats this on every subsequent switch---is the auto-suspend behaviour
+proper, so it follows [[auto_suspend]].
+
+[[write_last_selected_window]] stays unconditional because it is a
+statement of fact about tmux, not a policy: some \emph{other} tracked
+window in this session may already have armed the session hook, and that
+hook compares against this file.  Leaving it pointing at the window we
+just left would make the next real switch compute its transition from a
+window nobody is in.
 
 When [[--no-block]] is used, the tmux pane needs to call
 [[nytid track stop]] after the child exits.  The
@@ -8638,16 +8668,25 @@ else:
     )
 @
 
+The pane and window labels files answer two questions that happen to
+share a storage location.  Auto-suspend asks \enquote{which labels
+should I stop when attention moves away from here?}, but every nested
+command asks a different one: \enquote{what am I working on right
+now?}---[[--inherit-labels]] to branch off the current context,
+[[register_tmux_context_labels]] to join it, and the ID-less [[todo]]
+commands to know which task they refer to.
+
+Only the first question is about suspending.  Withholding the labels
+when the user passes [[--no-auto-suspend]] therefore disabled a set of
+features that have nothing to do with suspension, and did so silently:
+[[--inherit-labels]] simply inherited nothing.  We publish the context
+for every tracked launch and let [[auto_suspend]] decide only whether
+the suspend machinery is armed on top of it.
+
 <<run launched process>>=
-focus_labels_for_tmux = (
-    tracking_labels if use_auto_suspend else None
-)
-focus_who_for_tmux = (
-    who if use_auto_suspend else None
-)
-focus_window_for_tmux = (
-    bool(window and use_auto_suspend)
-)
+focus_labels_for_tmux = tracking_labels
+focus_who_for_tmux = who
+focus_window_for_tmux = bool(window)
 try:
     if pane or window:
         if block:
@@ -8660,6 +8699,7 @@ try:
                 focus_labels=focus_labels_for_tmux,
                 focus_who=focus_who_for_tmux,
                 focus_window=focus_window_for_tmux,
+                auto_suspend=use_auto_suspend,
             )
         else:
             <<set up non-blocking tmux launch>>
@@ -8736,6 +8776,7 @@ run_tmux_command(
     focus_labels=focus_labels_for_tmux,
     focus_who=focus_who_for_tmux,
     focus_window=focus_window_for_tmux,
+    auto_suspend=use_auto_suspend,
 )
 exit_code = None
 @
@@ -11916,6 +11957,145 @@ def test_build_tmux_hook_command_uses_guarded_run_shell():
     assert "#{pane_dead_signal}" in hook
     assert "cleanup-command" in hook
     assert "tmux wait-for -S done-chan" in hook
+
+def test_start_publishes_context_without_auto_suspend(
+  temp_tracking_dir,
+):
+  """--no-auto-suspend still hands the launch its context labels."""
+  with patch.dict(
+    os.environ, {"TMUX": "session"}, clear=True,
+  ), patch(
+    "nytid.cli.track.run_tmux_command",
+    return_value=0,
+  ) as mock_tmux:
+    result = runner.invoke(
+      cli,
+      ["start", "work", "--pane", "--no-auto-suspend"],
+    )
+
+  assert result.exit_code == 0
+  call_kwargs = mock_tmux.call_args.kwargs
+  assert call_kwargs["focus_labels"] == ["work"]
+  assert call_kwargs["focus_who"] == default_username
+  assert call_kwargs["auto_suspend"] is False
+
+
+def test_start_window_publishes_context_without_auto_suspend(
+  temp_tracking_dir,
+):
+  """A --window launch publishes window labels either way."""
+  with patch.dict(
+    os.environ, {"TMUX": "session"}, clear=True,
+  ), patch(
+    "nytid.cli.track.run_tmux_command",
+    return_value=0,
+  ) as mock_tmux:
+    result = runner.invoke(
+      cli,
+      ["start", "work", "--window", "--no-auto-suspend"],
+    )
+
+  assert result.exit_code == 0
+  call_kwargs = mock_tmux.call_args.kwargs
+  assert call_kwargs["focus_window"] is True
+  assert call_kwargs["focus_labels"] == ["work"]
+  assert call_kwargs["auto_suspend"] is False
+
+
+def test_run_tmux_command_publishes_pane_labels_unsuspended(
+  temp_tracking_dir,
+):
+  """Pane labels are written even when the focus hooks stay off."""
+  events = []
+
+  def fake_subprocess_run(args, **kwargs):
+    class Result:
+      stdout = "%42 @7 $9\n"
+    return Result()
+
+  with patch(
+    "nytid.cli.track.subprocess.run",
+    side_effect=fake_subprocess_run,
+  ), patch(
+    "nytid.cli.track.install_tmux_exit_hooks",
+  ), patch(
+    "nytid.cli.track.build_tmux_server_key",
+    return_value=TEST_SERVER_KEY,
+  ), patch(
+    "nytid.cli.track.install_tmux_focus_hooks",
+    side_effect=lambda *a, **k: events.append("focus-hooks"),
+  ), patch(
+    "nytid.cli.track.install_tmux_suspend_cleanup_hook",
+    side_effect=lambda *a, **k: events.append("cleanup-hook"),
+  ):
+    run_tmux_command(
+      ["/bin/sh"],
+      cwd="/tmp",
+      env={"TMUX": "/tmp/tmux.sock,1,0"},
+      block=False,
+      focus_labels=["work"],
+      focus_who=default_username,
+      auto_suspend=False,
+    )
+
+  assert read_pane_labels(
+    "%42", default_username, TEST_SERVER_KEY,
+  ) == ["work"]
+  assert "focus-hooks" not in events
+  assert "cleanup-hook" in events
+
+
+def test_run_tmux_command_publishes_window_labels_unsuspended(
+  temp_tracking_dir,
+):
+  """Window labels are published without arming the transition."""
+  events = []
+
+  def fake_subprocess_run(args, **kwargs):
+    class Result:
+      stdout = "%42 @7 $9\n"
+    return Result()
+
+  with patch(
+    "nytid.cli.track.subprocess.run",
+    side_effect=fake_subprocess_run,
+  ), patch(
+    "nytid.cli.track.install_tmux_exit_hooks",
+  ), patch(
+    "nytid.cli.track.build_tmux_server_key",
+    return_value=TEST_SERVER_KEY,
+  ), patch(
+    "nytid.cli.track.stop_tracking_labels",
+    side_effect=lambda *a, **k: events.append("stop"),
+  ), patch(
+    "nytid.cli.track.install_tmux_window_sync_hooks",
+    side_effect=lambda *a, **k: events.append("sync-hooks"),
+  ), patch(
+    "nytid.cli.track.install_tmux_window_cleanup_hook",
+    side_effect=lambda *a, **k: events.append("cleanup-hook"),
+  ):
+    run_tmux_command(
+      ["/bin/sh"],
+      cwd="/tmp",
+      env={"TMUX": "/tmp/tmux.sock,1,0"},
+      window=True,
+      block=False,
+      focus_labels=["work"],
+      focus_who=default_username,
+      focus_window=True,
+      auto_suspend=False,
+    )
+
+  assert read_window_labels(
+    "@7", default_username, TEST_SERVER_KEY,
+  ) == ["work"]
+  assert read_last_selected_window(
+    default_username, TEST_SERVER_KEY, "$9",
+  ) == "@7"
+  assert "stop" not in events
+  assert "sync-hooks" not in events
+  assert "cleanup-hook" in events
+
 
 def test_make_tmux_completion_guard_without_status_file():
   """A launch with no status file still gets a unique guard."""

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -4279,19 +4279,26 @@ def status(
         <<show all workers status>>
 @
 
-<<show single worker status>>=
-session = load_active_session(who)
+Rendering one worker's active labels is needed in three places---the
+single-worker view, the per-worker loop below, and the
+backward-compatibility path that follows it.  Keeping three copies is
+how the three views drift apart, so we write it once as a function.  A
+function rather than a chunk: the three call sites live in different
+scopes, and a parameter list makes the inputs explicit where a shared
+chunk would silently depend on whatever names happen to be bound.
 
-if not session.is_active():
-    typer.echo(f"No active tracking for {who}")
-    return
-
-typer.echo(f"Currently tracking ({who}):")
-current_time = datetime.datetime.now()
-
-for label in session.get_active_labels():
-    info = session.get_label_info(label)
-    if info:
+<<helper functions>>=
+def echo_worker_status(
+    display_name: str,
+    session: "ActiveSession",
+) -> None:
+    """Print one worker's active labels with their durations."""
+    typer.echo(f"Currently tracking ({display_name}):")
+    current_time = datetime.datetime.now()
+    for label in session.get_active_labels():
+        info = session.get_label_info(label)
+        if info is None:
+            continue
         start_time, notes, batch_id = info
         duration = current_time - start_time
         notes_display = f" - {notes}" if notes else ""
@@ -4302,13 +4309,38 @@ for label in session.get_active_labels():
         )
 @
 
+<<show single worker status>>=
+session = load_active_session(who)
+
+if not session.is_active():
+    typer.echo(f"No active tracking for {who}")
+    return
+
+echo_worker_status(who, session)
+@
+
 When no [[--who]] is specified, we discover all active workers by
 globbing for session files in the tracking directory. This gives a
 quick overview of who is currently tracking time.
 
+The glob deliberately cannot match the pre-multi-worker
+[[current_session.json]], whose name carries no worker suffix.  That
+file therefore needs its own pass, and the question that pass must ask
+is narrow: \emph{was the default worker already shown?}  Asking the
+broader question---was \emph{anything} shown---hides an unmigrated
+user's own session as soon as any other worker (an agent, say) is
+tracking, which is precisely when a stale timer is easiest to miss.
+
+We answer it by recording which session files the loop actually
+rendered.  Comparing paths rather than worker names is what makes this
+robust: [[get_current_session_file]] is the single authority on which
+file a worker's session lives in, including its own fallback to the
+legacy name, so a path already in the set means the same session, no
+matter which spelling of the worker got us there.
+
 <<show all workers status>>=
 tracking_dir = get_tracking_dir()
-found_any = False
+rendered_session_files = set()
 
 if tracking_dir.exists():
     for session_file in sorted(
@@ -4319,48 +4351,22 @@ if tracking_dir.exists():
         )
         session = load_active_session(worker)
         if session.is_active():
-            found_any = True
-            typer.echo(f"Currently tracking ({worker}):")
-            current_time = datetime.datetime.now()
-            for label in session.get_active_labels():
-                info = session.get_label_info(label)
-                if info:
-                    start_time, notes, batch_id = info
-                    duration = current_time - start_time
-                    notes_display = (
-                        f" - {notes}" if notes else ""
-                    )
-                    typer.echo(
-                        f"  {label}: "
-                        f"{format_duration(duration)}"
-                        f"{notes_display}"
-                    )
+            rendered_session_files.add(session_file)
+            echo_worker_status(worker, session)
 
 # Also check old unsuffixed file for backward compat
 old_session_file = tracking_dir / "current_session.json"
 if old_session_file.exists():
     session = load_active_session(default_username)
-    if session.is_active() and not found_any:
-        found_any = True
-        typer.echo(
-            f"Currently tracking ({default_username}):"
-        )
-        current_time = datetime.datetime.now()
-        for label in session.get_active_labels():
-            info = session.get_label_info(label)
-            if info:
-                start_time, notes, batch_id = info
-                duration = current_time - start_time
-                notes_display = (
-                    f" - {notes}" if notes else ""
-                )
-                typer.echo(
-                    f"  {label}: "
-                    f"{format_duration(duration)}"
-                    f"{notes_display}"
-                )
+    already_shown = (
+        get_current_session_file(default_username)
+        in rendered_session_files
+    )
+    if session.is_active() and not already_shown:
+        rendered_session_files.add(old_session_file)
+        echo_worker_status(default_username, session)
 
-if not found_any:
+if not rendered_session_files:
     typer.echo("No active tracking")
 @
 
@@ -4447,6 +4453,58 @@ def test_status_tuple_unpacking_regression(temp_tracking_dir):
     # Should not see any error messages
     assert "ValueError" not in result.stdout
     assert "too many values to unpack" not in result.stdout
+
+def test_status_shows_legacy_session_beside_other_workers(
+  temp_tracking_dir,
+):
+  """An unmigrated session stays visible when another worker tracks."""
+  legacy_file = temp_tracking_dir / "current_session.json"
+
+  def legacy_aware_session_file(who=None):
+    if who is None:
+      who = default_username
+    per_worker = temp_tracking_dir / (
+      f"current_session_{sanitize_who(who)}.json"
+    )
+    if (who == default_username
+        and not per_worker.exists()
+        and legacy_file.exists()):
+      return legacy_file
+    return per_worker
+
+  legacy_session = ActiveSession()
+  legacy_session.start_labels(["mine"], datetime.datetime.now())
+  temp_tracking_dir.mkdir(parents=True, exist_ok=True)
+  legacy_file.write_text(json.dumps(legacy_session.to_dict()))
+
+  with patch(
+    "nytid.cli.track.get_current_session_file",
+    side_effect=legacy_aware_session_file,
+  ), patch(
+    "nytid.cli.track.get_current_session_lock_file",
+    side_effect=lambda who=None:
+      legacy_aware_session_file(who).with_suffix(".lock"),
+  ):
+    runner.invoke(cli, ["start", "theirs", "--who", "Agent"])
+    result = runner.invoke(cli, ["status"])
+
+  assert result.exit_code == 0
+  assert "mine" in result.stdout
+  assert "theirs" in result.stdout
+
+def test_status_does_not_repeat_migrated_worker(temp_tracking_dir):
+  """A worker with both file names is rendered exactly once."""
+  runner.invoke(cli, ["start", "work"])
+  legacy_file = temp_tracking_dir / "current_session.json"
+  legacy_file.write_text(
+    (temp_tracking_dir / (
+      f"current_session_{sanitize_who(default_username)}.json"
+    )).read_text()
+  )
+
+  result = runner.invoke(cli, ["status"])
+  assert result.exit_code == 0
+  assert result.stdout.count("Currently tracking") == 1
 
 def test_status_with_batch_tracking(temp_tracking_dir):
     """Test status command with labels from different batches"""

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -504,23 +504,53 @@ DEFAULT_WEEKLY_LIMIT_HOURS = 40.0  # Standard full-time work week
 DEFAULT_DAILY_LIMIT_HOURS = 8.0    # Standard work day
 @
 
+Durations are normally positive, but they must never be \emph{rendered}
+as positive when they are not.  Python's [[divmod]] floors towards
+negative infinity, so splitting a raw negative second count into hours,
+minutes and seconds yields components that read as a plausible positive
+duration: $-30$~minutes becomes [[30m 0s]], and so does $-90$~minutes.
+A corrupt entry would then be indistinguishable from a healthy one in
+[[status]], [[ls]], and [[stats]] output.
+
+We therefore split the magnitude and carry the sign as an explicit
+prefix.  This is a display safeguard rather than a licence to store
+negative durations---the commands that build entries reject inverted
+intervals---but a formatter that cannot lie is what makes such a bug
+visible instead of silent.
+
 <<helper functions>>=
 def format_duration(duration: datetime.timedelta) -> str:
-    """Format a duration in a human-readable way"""
+    """Format a duration in a human-readable way.
+
+    Negative durations keep a leading minus sign so an
+    inverted interval can never be displayed as a
+    positive one.
+    """
     total_seconds = int(duration.total_seconds())
-    hours, remainder = divmod(total_seconds, 3600)
+    sign = "-" if total_seconds < 0 else ""
+    hours, remainder = divmod(abs(total_seconds), 3600)
     minutes, seconds = divmod(remainder, 60)
-    
+
     if hours > 0:
-        return f"{hours}h {minutes}m {seconds}s"
+        return f"{sign}{hours}h {minutes}m {seconds}s"
     elif minutes > 0:
-        return f"{minutes}m {seconds}s"
+        return f"{sign}{minutes}m {seconds}s"
     else:
-        return f"{seconds}s"
+        return f"{sign}{seconds}s"
 
 def get_labels_display(labels: list[str]) -> str:
     """Get a display string for labels (as comma-separated tags)"""
     return ", ".join(sorted(labels)) if labels else "No labels"
+@
+
+<<test functions>>=
+def test_format_duration_is_sign_aware():
+  """Negative durations must not render as positive ones."""
+  assert format_duration(datetime.timedelta(minutes=30)) == "30m 0s"
+  assert format_duration(datetime.timedelta(minutes=-30)) == "-30m 0s"
+  assert format_duration(datetime.timedelta(minutes=-90)) == "-1h 30m 0s"
+  assert format_duration(datetime.timedelta(seconds=-5)) == "-5s"
+  assert format_duration(datetime.timedelta()) == "0s"
 @
 
 \subsubsection{Abbreviating Content Hashes}
@@ -1228,6 +1258,10 @@ class ActiveSession:
 
         Returns:
             List of TrackingEntry objects for the stopped labels
+
+        Raises:
+            ValueError: if `end_time` is not after the start time of
+                every label that would be stopped
         """
         if who is None:
             who = default_username
@@ -1257,7 +1291,39 @@ class ActiveSession:
             # Stop the N most recently started labels
             labels = self.label_order[-count:] if self.label_order else []
         # else: use the provided labels list
+
+        inverted = sorted(
+            label for label in labels
+            if label in self.active_labels
+            and end_time <= self.active_labels[label][0]
+        )
+        if inverted:
+            raise ValueError(
+                "End time must be after start time for: "
+                + ", ".join(inverted)
+            )
 @
+
+The check above belongs here, before anything is popped, because this is
+the last point at which the session is still untouched.  Every caller
+reaches [[stop_labels]] through [[mutate_worker_tracking_state]], which
+persists whatever the callback returns; raising once the labels have
+already been removed would leave the on-disk session inconsistent with
+the error the user sees.
+
+The rule is the same one [[edit]] enforces on historical entries: an
+entry's end must come after its start.  Only [[stop]] could break it,
+because [[--at]] and [[--offset]] let the user name an end time
+independently of when tracking began.  An inverted entry is not merely
+displayed wrongly---it is stored, and a negative interval subtracts from
+every aggregate built on top of it: the merged wall-clock totals,
+[[stats]], the exports, and the times [[nytid todo]] derives from
+tracking history.
+
+We name the offending labels rather than failing anonymously.  A
+[[stop --all]] can span labels started hours apart, so
+\enquote{which of them started after the end time you gave?} is exactly
+the question the user needs answered.
 
 At this point [[labels]] is only a \emph{request}.  The caller may have
 named a label that is not being tracked---most often a typo---and the
@@ -3602,16 +3668,7 @@ def stop(
             )
             raise typer.Exit(1)
 
-    try:
-        session, completed_entries = stop_tracking_labels(
-            who=who,
-            labels=labels,
-            all_labels=all_labels,
-            end_time=end_time,
-        )
-    except ValueError as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(1)
+    <<stop the requested labels or report why not>>
 
     # Display what was completed
     for entry in completed_entries:
@@ -3639,7 +3696,69 @@ def stop(
 
 @
 
+Two quite different things can go wrong once the end time is known, and
+both surface here as a [[ValueError]] carrying its own explanation:
+either none of the named labels are tracking, or the end time given by
+[[--at]]/[[--offset]] falls before some label started.  The command has
+nothing to add to either message, so it prints the exception verbatim
+and exits non-zero.
+
+What matters is that the exception reaches this point with the on-disk
+state untouched.  [[stop_labels]] validates before it pops anything, so
+a rejected [[stop]] leaves the session exactly as it was and the user
+can simply retry with a corrected time.
+
+<<stop the requested labels or report why not>>=
+try:
+    session, completed_entries = stop_tracking_labels(
+        who=who,
+        labels=labels,
+        all_labels=all_labels,
+        end_time=end_time,
+    )
+except ValueError as exc:
+    typer.echo(str(exc), err=True)
+    raise typer.Exit(1)
+@
+
 \subsubsection{Testing Stop Command}
+
+Let's verify that a backdated stop cannot invert an entry, and that the
+rejection is total---no entry written, no label stopped:
+
+<<test functions>>=
+def test_stop_rejects_end_before_start(temp_tracking_dir):
+  """A backdated stop must not record a negative interval."""
+  runner.invoke(cli, ["start", "A"])
+
+  result = runner.invoke(cli, ["stop", "--offset", "-30m"])
+  assert result.exit_code == 1
+  assert "End time must be after start time" in result.output
+  assert "A" in result.output
+
+  assert load_tracking_data() == []
+  assert load_active_session().get_active_labels() == ["A"]
+
+def test_stop_all_names_only_inverted_labels(temp_tracking_dir):
+  """The error names the labels that started after the end time."""
+  runner.invoke(cli, ["start", "old", "--offset", "-2h"])
+  runner.invoke(cli, ["start", "new"])
+
+  result = runner.invoke(cli, ["stop", "--all", "--offset", "-30m"])
+  assert result.exit_code == 1
+  assert "new" in result.output
+  assert "old" not in result.output
+
+def test_switch_rejects_end_before_start(temp_tracking_dir):
+  """A backdated switch fails instead of inverting the old context."""
+  runner.invoke(cli, ["start", "A"])
+
+  result = runner.invoke(cli, ["switch", "B", "--offset", "-30m"])
+  assert result.exit_code == 1
+  assert "End time must be after start time" in result.output
+
+  assert load_tracking_data() == []
+  assert load_active_session().get_active_labels() == ["A"]
 
 <<test functions>>=
 def test_stop_batch_behavior(temp_tracking_dir):
@@ -3840,6 +3959,52 @@ elif offset is not None:
         raise typer.Exit(1)
 @
 
+\subsubsection{Closing the Current Context}
+
+Both switch directions begin identically: whatever is running must be
+stopped at [[switch_time]] before the new context starts.  We name that
+step once so the forward and reverse directions cannot drift apart, and
+so the error handling below exists in exactly one place.
+
+A backdated [[--at]] or [[--offset]] may name a moment before one of the
+active labels began.  [[stop_tracking_labels]] rejects that rather than
+recording an inverted interval, and there is nothing sensible to do with
+the rest of the switch: starting the new context while the old one is
+still open would leave both running.  We therefore report the problem
+and stop.
+
+<<stop current context at switch time>>=
+if session.is_active():
+    try:
+        session, completed = stop_tracking_labels(
+            who=who,
+            all_labels=all_labels,
+            end_time=switch_time,
+        )
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1)
+    session = load_active_session(who)
+    for entry in completed:
+        typer.echo(
+            f"Stopped: "
+            f"{get_labels_display(entry.labels)}"
+            f" ({format_duration(entry.duration())})"
+        )
+    stopped_labels = [
+        label
+        for entry in completed
+        for label in entry.labels
+    ]
+else:
+    stopped_labels = []
+@
+
+The chunk expects [[session]], [[who]], [[all_labels]] and
+[[switch_time]] to be in scope, and leaves behind a refreshed
+[[session]] plus the [[stopped_labels]] both directions need for the
+toggle bookkeeping.
+
 \subsubsection{Switching to New Labels}
 
 The key question when labels are given is whether the current context
@@ -3855,26 +4020,7 @@ so a subsequent bare [[switch]] correctly restores the idle state.
 
 <<switch to new labels>>=
 session = load_active_session(who)
-if session.is_active():
-    session, completed = stop_tracking_labels(
-        who=who,
-        all_labels=all_labels,
-        end_time=switch_time,
-    )
-    session = load_active_session(who)
-    for entry in completed:
-        typer.echo(
-            f"Stopped: "
-            f"{get_labels_display(entry.labels)}"
-            f" ({format_duration(entry.duration())})"
-        )
-    stopped_labels = [
-        label
-        for entry in completed
-        for label in entry.labels
-    ]
-else:
-    stopped_labels = []
+<<stop current context at switch time>>
 previous_switch_other = session.switch_other
 if not pop:
     update_switch_other_labels(stopped_labels, who=who)
@@ -3920,26 +4066,7 @@ if session.switch_other is None:
         "only one label set in play."
     )
     raise typer.Exit(0)
-if session.is_active():
-    session, completed = stop_tracking_labels(
-        who=who,
-        all_labels=all_labels,
-        end_time=switch_time,
-    )
-    session = load_active_session(who)
-    for entry in completed:
-        typer.echo(
-            f"Stopped: "
-            f"{get_labels_display(entry.labels)}"
-            f" ({format_duration(entry.duration())})"
-        )
-    stopped_labels = [
-        label
-        for entry in completed
-        for label in entry.labels
-    ]
-else:
-    stopped_labels = []
+<<stop current context at switch time>>
 if session.switch_other is None:
     typer.echo(
         "Nothing to switch back to: "
@@ -10539,6 +10666,7 @@ from nytid.cli.track import (
     AUTO_SUSPEND_CONFIG,
     TRACK_DEBUG_CONFIG,
     load_tracking_data, load_active_session,
+    format_duration,
     filter_entries, filter_entries_for_stats_window,
     normalize_tracking_entries,
     merge_duplicate_tracking_entries,

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -10301,10 +10301,33 @@ def stats(
       nytid track stats -n 7 --summary
       nytid track stats --who Dan-Claude
     """
+    <<reject a window shorter than a day>>
     <<resolve stats limits>>
     <<load and filter entries for stats>>
     <<display stats summary when requested>>
     <<display grouped daily breakdown>>
+@
+
+A report needs at least one calendar day to describe.  Zero days yields
+no dates, hence no rows, and the two output paths then fail in different
+ways: the summary divides the total by the window length, and the
+plain-text table takes the [[max]] over an empty sequence of rows.
+Neither failure is caught anywhere, so the user gets a traceback.
+
+Rejecting the input is better than clamping it because the value can
+come from [[track.stats.days]] as easily as from [[-n]].  A clamp would
+leave a nonsensical configuration in place and quietly report something
+the user did not ask for, every time; an error names the setting that
+needs fixing.
+
+<<reject a window shorter than a day>>=
+if days < 1:
+    typer.echo(
+        f"Error: --days must be at least 1, got {days} "
+        f"(check {TRACK_STATS_DAYS_CONFIG} in your config)",
+        err=True,
+    )
+    raise typer.Exit(1)
 @
 
 The [[--weekly-limit]] and [[--daily-limit]] flags are optional because
@@ -10488,12 +10511,20 @@ for row in rows:
 console.print(table)
 @
 
+Each column must be at least as wide as its own header, so we simply
+measure the header row alongside the data rows.  Treating the header as
+one more row also makes the computation total: [[max]] over an empty
+sequence raises, and the old spelling---[[max]] of the header width
+\emph{unpacked} together with the row widths---turned an empty report
+into a [[TypeError]] rather than a header with no rows under it.
+
 <<render stats table as plain columns>>=
 headers = ("Date", "Total", "Labels", "Time")
-date_width = max(len(headers[0]), *(len(row[0]) for row in rows))
-total_width = max(len(headers[1]), *(len(row[1]) for row in rows))
-labels_width = max(len(headers[2]), *(len(row[2]) for row in rows))
-time_width = max(len(headers[3]), *(len(row[3]) for row in rows))
+measured_rows = [headers] + rows
+date_width = max(len(row[0]) for row in measured_rows)
+total_width = max(len(row[1]) for row in measured_rows)
+labels_width = max(len(row[2]) for row in measured_rows)
+time_width = max(len(row[3]) for row in measured_rows)
 
 typer.echo(
     f"{headers[0]:<{date_width}}  "
@@ -10514,6 +10545,43 @@ for date, total, labels_text, labels_time in rows:
         f"{labels_text:<{labels_width}}  "
         f"{labels_time:>{time_width}}".rstrip()
     )
+@
+
+Let's verify that a degenerate window is refused rather than crashing,
+whichever way it arrives and whichever output path would have rendered
+it:
+
+<<test functions>>=
+def test_stats_rejects_window_shorter_than_a_day(temp_tracking_dir):
+  """A zero or negative window is an error, not a traceback."""
+  runner.invoke(cli, ["add", "work", "--duration", "1"])
+
+  for args in (
+    ["stats", "-n", "0"],
+    ["stats", "-n", "0", "--summary"],
+    ["stats", "-n", "-3"],
+  ):
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(
+      result.exception, SystemExit
+    )
+    assert "--days must be at least 1" in result.output
+    assert TRACK_STATS_DAYS_CONFIG in result.output
+
+def test_stats_plain_table_survives_empty_rows(temp_tracking_dir):
+  """The plain-text table renders headers even with no rows."""
+  runner.invoke(cli, ["add", "work", "--duration", "1"])
+
+  with patch(
+    "nytid.cli.track.make_stats_dates",
+    return_value=[],
+  ):
+    result = runner.invoke(cli, ["stats"])
+
+  assert result.exit_code == 0
+  assert "Date" in result.stdout
+  assert "Labels" in result.stdout
 @
 
 \subsection{Export Command}
@@ -10901,6 +10969,7 @@ sys.path.insert(0, '../src')
 from nytid.cli.track import (
     cli, TrackingEntry, ActiveSession,
     TRACKING_HASH_PREFIX_MIN_LENGTH,
+    TRACK_STATS_DAYS_CONFIG,
     AUTO_SUSPEND_CONFIG,
     TRACK_DEBUG_CONFIG,
     load_tracking_data, load_active_session,

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -5020,6 +5020,16 @@ child needs an atomic guard file so completion is recorded exactly once
 even if multiple cleanup paths race.  The helper functions below provide
 those two mechanisms.
 
+The guard is a \emph{directory}, because [[mkdir]] is the one filesystem
+operation every POSIX shell can perform atomically: it either creates
+the directory or fails, and exactly one racer sees success.  Deriving
+its path from the status file is what makes it disarmable.  A launch
+whose parent does not stick around to clean up puts both files in one
+throwaway directory; when the detached cleanup removes that directory,
+a later [[mkdir]] of the guard fails with [[ENOENT]] rather than
+succeeding on a fresh path---so releasing the guard and closing it
+permanently are the same act.
+
 <<helper functions>>=
 def make_tmux_channel(prefix: str) -> str:
     """Return a unique tmux wait-for channel name."""
@@ -5031,10 +5041,18 @@ def make_tmux_channel(prefix: str) -> str:
 
 def make_tmux_completion_guard(
     status_file: str | None,
-) -> str | None:
-    """Return the atomic completion guard path."""
+) -> str:
+    """Return the atomic completion guard path.
+
+    Derived from the status file when there is one, so that
+    removing the directory holding the status file also
+    removes -- and disarms -- the guard.
+    """
     if status_file is None:
-        return None
+        return os.path.join(
+            tempfile.gettempdir(),
+            f"nytid-guard-{os.getpid()}-{time.time_ns()}",
+        )
     return status_file + ".guard"
 
 
@@ -5279,6 +5297,7 @@ def run_tmux_command(
         remove_status_file = True
     if block:
         wait_channel = make_tmux_channel("done")
+    if status_file is not None or on_exit_shell is not None:
         completion_guard = make_tmux_completion_guard(
             status_file
         )
@@ -5363,12 +5382,34 @@ def run_tmux_command(
                 os.unlink(status_file)
             except OSError:
                 pass
-        if completion_guard is not None:
+        if block and completion_guard is not None:
             try:
                 os.rmdir(completion_guard)
             except OSError:
                 pass
 @
+
+Two details of the setup above are easy to get wrong, and getting either
+wrong breaks the exactly-once invariant.
+
+The guard is built whenever there is a status file \emph{or} an
+[[on_exit_shell]], not only when we block.  Both the pane wrapper and
+the [[pane-exited]]/[[pane-died]] hooks are handed the same
+[[completion_guard]], and [[build_tmux_completion_shell]] emits an
+unguarded body when it is [[None]].  Tying the guard to [[block]] left
+detached launches---every [[--no-block]] pane or window, and every
+detached [[todo start]]---running their finalize command twice: once
+from the wrapper as the child exits, once again from the hook after the
+pane dies.  [[_stop-detached]] tolerates that, but the todo finalize
+does not.
+
+The parent only tears the guard down when it blocked.  Having waited for
+the completion signal, it knows the guard has served its purpose.  A
+detached parent knows nothing of the sort: it returns while the pane is
+still alive, so removing the guard then would simply hand the later
+hooks a clean slate to re-claim.  Detached launches instead let their
+own cleanup remove the throwaway directory that holds guard and status
+alike (see \cref{track:detached-launch-dir}).
 
 Tracked window launches need one stronger serialization guarantee than
 steady-state hooks.  The [[tmux new-window]] command itself may spawn a
@@ -8649,23 +8690,39 @@ finally:
     )
 @
 
+\label{track:detached-launch-dir}
 For the non-blocking case, we create a temporary file for exit status
 and set up a finalize command that calls [[track stop]] when the pane
 exits.  The [[run_tmux_command]] function installs tmux hooks that
 execute the command automatically.
 
+That file lives in a directory of its own rather than directly in
+[[/tmp]], and the choice is load-bearing rather than tidiness.  The
+completion guard is derived from the status file's path, so it lands in
+the same directory; removing the directory as the finalize command's
+last step therefore deletes the status file, deletes the guard, and---
+because [[mkdir]] does not create intermediate directories---makes every
+subsequent attempt to claim the guard fail outright.  Nothing is left
+behind, and no late [[pane-died]] hook can re-run the finalize on a
+launch that has already finished.
+
+The ordering inside the finalize command matters: the directory must go
+last, after the tracking state has been updated, since removing it is
+what closes the launch.
+
 <<set up non-blocking tmux launch>>=
-exit_fd, exit_code_file = tempfile.mkstemp(
+launch_state_dir = tempfile.mkdtemp(
     prefix="nytid-track-",
-    suffix=".status",
 )
-os.close(exit_fd)
+exit_code_file = os.path.join(
+    launch_state_dir, "status",
+)
 finalize_cmd = \
     build_detached_track_finalize_command(
         launch_cleanup_labels, who
     )
 finalize_cmd += (
-    f"; rm -f {shlex.quote(exit_code_file)}"
+    f"; rm -rf {shlex.quote(launch_state_dir)}"
 )
 run_tmux_command(
     command_args,
@@ -11859,6 +11916,90 @@ def test_build_tmux_hook_command_uses_guarded_run_shell():
     assert "#{pane_dead_signal}" in hook
     assert "cleanup-command" in hook
     assert "tmux wait-for -S done-chan" in hook
+
+def test_make_tmux_completion_guard_without_status_file():
+  """A launch with no status file still gets a unique guard."""
+  first = make_tmux_completion_guard(None)
+  second = make_tmux_completion_guard(None)
+  assert first and second
+  assert first != second
+  assert make_tmux_completion_guard(
+    "/tmp/nytid.status"
+  ) == "/tmp/nytid.status.guard"
+
+
+def test_run_tmux_command_guards_detached_completion(
+  temp_tracking_dir,
+):
+  """A detached launch guards the wrapper and the exit hooks alike."""
+  observed = {}
+
+  def fake_subprocess_run(args, **kwargs):
+    if args[:2] == ["tmux", "split-window"]:
+      observed["argv"] = args
+      class Result:
+        stdout = "%42 @7 $9\n"
+      return Result()
+    class Result:
+      stdout = ""
+    return Result()
+
+  with patch(
+    "nytid.cli.track.subprocess.run",
+    side_effect=fake_subprocess_run,
+  ), patch(
+    "nytid.cli.track.install_tmux_exit_hooks",
+    side_effect=lambda pane_id, hook_command:
+      observed.__setitem__("hook", hook_command),
+  ):
+    result = run_tmux_command(
+      ["/bin/sh"],
+      cwd="/tmp",
+      env={},
+      block=False,
+      exit_status_file="/tmp/nytid-detached/status",
+      on_exit_shell="finalize-command",
+    )
+
+  assert result is None
+  guard = "mkdir /tmp/nytid-detached/status.guard"
+  wrapper = observed["argv"][-1]
+  assert guard in wrapper
+  assert "finalize-command" in wrapper
+  assert guard in observed["hook"]
+  assert "finalize-command" in observed["hook"]
+
+
+def test_start_no_block_finalize_disarms_guard(
+  temp_tracking_dir,
+):
+  """Detached cleanup removes the directory holding guard and status."""
+  with patch.dict(
+    os.environ, {"TMUX": "session"}, clear=True,
+  ), patch(
+    "nytid.cli.track.run_tmux_command",
+    return_value=None,
+  ) as mock_tmux:
+    result = runner.invoke(
+      cli, ["start", "grading", "--pane", "--no-block"],
+    )
+
+  assert result.exit_code == 0
+  call_kwargs = mock_tmux.call_args[1]
+  status_file = call_kwargs["exit_status_file"]
+  launch_dir = os.path.dirname(status_file)
+
+  assert make_tmux_completion_guard(status_file).startswith(
+    launch_dir + os.sep
+  )
+  assert "rm -rf" in call_kwargs["on_exit_shell"]
+  assert launch_dir in call_kwargs["on_exit_shell"]
+  assert call_kwargs["on_exit_shell"].index(
+    "_stop-detached"
+  ) < call_kwargs["on_exit_shell"].index("rm -rf")
+
+  os.rmdir(launch_dir)
+
 
 def test_install_tmux_exit_hooks_guards_pane_id():
     """Hooks use pane-existence guard to prevent

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -4525,6 +4525,44 @@ def test_status_with_batch_tracking(temp_tracking_dir):
 
 The notes command allows adding or updating notes/descriptions for any active label.
 
+Annotating a label is a read-modify-write of the session file, so it
+belongs behind [[mutate_worker_tracking_state]] like every other
+mutation.  Loading and saving directly would take a snapshot outside any
+lock and write it back later, and auto-suspend makes a competing writer
+ordinary rather than exotic: a [[pane-focus-out]] hook firing in between
+would have its work overwritten by a snapshot that still lists the
+suspended labels as active with their original start times.  The next
+stop would then record an interval overlapping the one the suspend
+already wrote---the same wall-clock time counted twice.
+
+The callback shape also gives us the answer we need: whether the label
+was active is decided inside the critical section, on state nobody else
+can be halfway through changing, so the message we print cannot describe
+a session that no longer exists.
+
+<<session management>>=
+def add_session_notes(
+    label: str,
+    notes: str,
+    *,
+    who: str = None,
+) -> tuple[bool, list[str]]:
+    """Annotate one active label under the tracking locks.
+
+    Returns whether the label was active, together with the
+    labels that were active at that moment.
+    """
+    outcome = {}
+
+    def update(session, history_entries):
+        outcome["added"] = session.add_notes(label, notes)
+        outcome["active"] = session.get_active_labels()
+        return session, history_entries
+
+    mutate_worker_tracking_state(update, who)
+    return outcome["added"], outcome["active"]
+@
+
 <<argument and option definitions>>=
 notes_label_arg = typer.Argument(
     ..., help="Label to add notes to",
@@ -4551,16 +4589,17 @@ def notes(
       nytid track notes DD1310 "Discussing course structure with TA"
       nytid track notes email "Answered student questions about lab 2"
     """
-    session = load_active_session(who)
+    added, active = add_session_notes(
+        label, note_text, who=who,
+    )
 
-    if not session.is_active():
+    if not active:
         typer.echo(
             "No active tracking session", err=True
         )
         raise typer.Exit(1)
 
-    if session.add_notes(label, note_text):
-        save_active_session(session, who)
+    if added:
         typer.echo(
             f"Added notes to '{label}': {note_text}"
         )
@@ -4569,12 +4608,55 @@ def notes(
             f"Label '{label}' is not currently "
             f"being tracked", err=True
         )
-        active = session.get_active_labels()
-        if active:
-            typer.echo(
-                f"Active labels: {', '.join(active)}"
-            )
+        typer.echo(
+            f"Active labels: {', '.join(active)}"
+        )
         raise typer.Exit(1)
+@
+
+The property worth pinning down is structural rather than observable
+from outside: the read and the write must happen inside one critical
+section.  We assert it where it is decided, by checking that the command
+reaches the session through [[mutate_worker_tracking_state]] at all---a
+future refactoring that reintroduces a bare load/save pair would fail
+here rather than in a rare interleaving nobody can reproduce:
+
+<<test functions>>=
+def test_notes_mutates_under_tracking_locks(temp_tracking_dir):
+  """Annotating goes through the shared locked mutation path."""
+  runner.invoke(cli, ["start", "A"])
+
+  real_mutate = mutate_worker_tracking_state
+  observed_workers = []
+
+  def recording_mutate(callback, who=None, post_update=None):
+    observed_workers.append(who)
+    return real_mutate(callback, who, post_update=post_update)
+
+  with patch(
+    "nytid.cli.track.mutate_worker_tracking_state",
+    side_effect=recording_mutate,
+  ):
+    result = runner.invoke(cli, ["notes", "A", "under lock"])
+
+  assert result.exit_code == 0
+  assert observed_workers == [default_username]
+  assert load_active_session().get_label_info("A")[1] == "under lock"
+
+def test_notes_rejects_inactive_label(temp_tracking_dir):
+  """Annotating an untracked label lists what is actually active."""
+  runner.invoke(cli, ["start", "A"])
+
+  result = runner.invoke(cli, ["notes", "B", "text"])
+  assert result.exit_code == 1
+  assert "not currently being tracked" in result.output
+  assert "Active labels: A" in result.output
+
+def test_notes_without_session_fails(temp_tracking_dir):
+  """Annotating with nothing active reports the empty session."""
+  result = runner.invoke(cli, ["notes", "A", "text"])
+  assert result.exit_code == 1
+  assert "No active tracking session" in result.output
 @
 
 \subsection{Tmux-Managed Commands}
@@ -10822,6 +10904,7 @@ from nytid.cli.track import (
     AUTO_SUSPEND_CONFIG,
     TRACK_DEBUG_CONFIG,
     load_tracking_data, load_active_session,
+    mutate_worker_tracking_state,
     format_duration,
     filter_entries, filter_entries_for_stats_window,
     normalize_tracking_entries,

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -1257,26 +1257,50 @@ class ActiveSession:
             # Stop the N most recently started labels
             labels = self.label_order[-count:] if self.label_order else []
         # else: use the provided labels list
-        
-        # Remember stopped labels for resume functionality
-        self.last_stopped = labels.copy() if labels else []
-            
-        # Group labels that share the same start time and
-        # batch into a single entry, so that concurrent labels
-        # do not produce duplicate wall-clock intervals.
+@
+
+At this point [[labels]] is only a \emph{request}.  The caller may have
+named a label that is not being tracked---most often a typo---and the
+loop below simply skips such names.  The resume set must therefore be
+derived from what we actually stop, not from what was asked for.
+
+Recording the request instead is not a cosmetic slip: the caller
+[[stop_tracking_labels]] reports \enquote{none of the specified labels
+are currently tracking} by raising \emph{after}
+[[mutate_worker_tracking_state]] has already persisted the session.  A
+mistyped [[track stop]] would exit non-zero and \emph{still} leave
+[[last_stopped]] naming the phantom label, so the next bare
+[[track start]] would resume a label that never existed and the real
+previous context would be gone.
+
+We also leave [[last_stopped]] untouched when nothing was stopped.  A
+failed stop should be a no-op, and clearing the resume set would throw
+away the still-valid answer to \enquote{what did I stop last?}.
+
+Labels that share both a start time and a batch collapse into one
+entry.  Two labels started together cover the same wall-clock interval,
+so emitting them separately would double-count that time in every
+downstream total.
+
+<<active session class>>=
         groups = {}
+        stopped = []
         for label in labels:
             if label in self.active_labels:
                 start_time, notes, batch_id = (
                     self.active_labels.pop(label)
                 )
                 self.label_order.remove(label)
+                stopped.append(label)
                 key = (start_time, batch_id)
                 if key not in groups:
                     groups[key] = (
                         start_time, [], notes
                     )
                 groups[key][1].append(label)
+
+        if stopped:
+            self.last_stopped = stopped
 
         entries = []
         for key, (st, grp_labels, notes) in (
@@ -1289,6 +1313,37 @@ class ActiveSession:
             entries.append(entry)
 
         return entries
+@
+
+Let's verify that a stop naming an unknown label leaves the resume set
+alone---first at the class level, then end-to-end through the CLI, where
+the failing exit code and the surviving resume set must coexist:
+
+<<test functions>>=
+def test_failed_stop_keeps_last_stopped(temp_tracking_dir):
+  """A stop that matches nothing must not rewrite the resume set."""
+  session = ActiveSession()
+  session.start_labels(["A", "B"], datetime.datetime.now())
+  session.stop_labels()
+  assert set(session.last_stopped) == {"A", "B"}
+
+  assert session.stop_labels(["TYPO"]) == []
+  assert set(session.last_stopped) == {"A", "B"}
+
+def test_failed_stop_does_not_break_resume(temp_tracking_dir):
+  """A mistyped stop must not make bare start resume a phantom label."""
+  runner.invoke(cli, ["start", "A", "B"])
+  runner.invoke(cli, ["stop"])
+
+  result = runner.invoke(cli, ["stop", "TYPO"])
+  assert result.exit_code == 1
+
+  assert set(load_active_session().last_stopped) == {"A", "B"}
+
+  result = runner.invoke(cli, ["start"])
+  assert result.exit_code == 0
+  assert "TYPO" not in result.stdout
+  assert set(load_active_session().get_active_labels()) == {"A", "B"}
 @
 
 \subsubsection{Discarding an Active Session}


### PR DESCRIPTION
Seven bugs found during a project-wide review of
`src/nytid/cli/track.nw`, each verified against the code before being
fixed.  Every fix is one atomic commit with a regression test colocated
after the feature it verifies.  Only `track.nw` is touched.

Test count: 663 before, 683 after; `cd tests && make test` is green.

## Failed `stop` destroyed the resume set

`ActiveSession.stop_labels` recorded the *requested* labels as
`last_stopped` before filtering them against `active_labels`, and
`stop_tracking_labels` persists the session before raising its
"none of the specified labels are currently tracking" error.  A mistyped
`track stop` exited non-zero and still left the resume set naming a
phantom label, so the next bare `track start` resumed a label that never
existed.

The resume set is now built from the labels actually popped, and left
untouched when nothing was stopped.

Closes #375

## `stop --at/--offset` accepted an end time before the start

No ordering check existed, so a backdated stop wrote an entry with
`end_time < start_time`; `format_duration` then hid it, because `divmod`
floors negatives and rendered `-30m` as `30m 0s`.  The inverted interval
was persisted and subtracted from every downstream aggregate.

`stop_labels` now validates the end time against every affected label
before popping anything, mirroring the check `edit` already performs, and
`format_duration` carries an explicit sign.

**Behavioral change:** `track stop`/`track switch` with `--at` or
`--offset` now exit 1 with `End time must be after start time for: <labels>`
instead of recording an inverted entry.  Nothing is written when they do.
The two `switch` directions were duplicating the stop block verbatim and
now share one chunk.

Closes #378

## `status` hid the default worker's legacy session

The all-workers view globs `current_session_*.json`, which never matches
the pre-multi-worker `current_session.json`.  The compatibility pass for
that file was gated on "nothing rendered yet", so an unmigrated user's
own session vanished from `track status` as soon as any other worker was
tracking.

The gate now asks whether the *default worker's* session file was
rendered, tracked by path so `get_current_session_file` stays the single
authority on where a worker's session lives.  The label-rendering loop
existed in three copies and is now one helper.

Closes #380

## Non-blocking tmux launches ran their exit cleanup twice

`run_tmux_command` built the atomic completion guard only when blocking,
so every detached launch handed both the pane wrapper and the
`pane-exited`/`pane-died` hooks an unguarded body — violating the
invariant the module documents.  `_stop-detached` tolerates the repeat;
the todo finalize does not, and re-finalized the hierarchy.

The guard is now built whenever there is a status file or an exit shell.

**Behavioral change:** a detached launch's status file moves into a
throwaway directory that the finalize command removes as its last step.
Because `mkdir` creates no intermediate directories, that removal also
permanently disarms any later hook rather than handing it a clean slate
to re-claim.

Closes #381

## `--no-auto-suspend` disabled tmux label context entirely

The pane and window labels files answer two questions that merely share a
file: which labels auto-suspend should stop, and what the pane or window
is working on.  `track start` withheld both when auto-suspend was off, so
`--inherit-labels` silently inherited nothing, later `track start` calls
never joined the pane context, and ID-less `todo` commands could not
resolve their target inside such a shell.

**Behavioral change:** every tracked launch now publishes its pane or
window labels.  A new `auto_suspend` parameter on `run_tmux_command`
gates only the focus hooks, the window stop/start transition, and the
session sync hook; cleanup hooks follow publication so the files cannot
outlive the pane that owns them.  The parameter defaults to `True`, so
`cli.todo`'s existing calls are unaffected.

Closes #383

## `notes` wrote the session outside the lock discipline

The command loaded, annotated and saved a snapshot taken outside any
lock, while every other mutation goes through
`mutate_worker_tracking_state`.  A `pane-focus-out` hook committing in
between had its work overwritten by a snapshot still listing the
suspended labels as active, so the next stop recorded an interval
overlapping the one the suspend already wrote.

New `add_session_notes` performs the annotation inside a
`mutate_worker_tracking_state` callback and reports both whether the
label was active and what was active at that moment, so the command's
messages describe the same state it wrote.

Closes #385

## `stats -n 0` crashed with an unhandled exception

A zero-day window produced no rows; the summary then divided by zero and
the plain-text table took `max` over an empty sequence.  Since the value
can come from `track.stats.days`, one bad configuration entry crashed
every subsequent bare `track stats`.

**Behavioral change:** `--days` below 1 now exits 1 with an error naming
the config key, instead of raising.  Column widths are computed by
measuring the header row alongside the data rows, which makes the
computation total.

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136fb1QAY29rDDLkELhZEpK
