### PR TITLE
Fix eight bugs in core infrastructure

### DIFF
--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -557,7 +557,8 @@ Hence, we need both the register name and its path.
 <<helper functions>>=
 def complete_course_name(ctx: typer.Context, incomplete: str):
   """
-  Returns a list of course names matching `incomplete`.
+  Yields (course name, register)-pairs matching `incomplete`,
+  across every register in scope.
   """
   <<populate [[registers]] with the registers to use>>
   for register, register_path in registers:
@@ -588,13 +589,53 @@ def register_pairs(register=None):
 @
 
 In the register, each course has its own subdirectory.
-So we simply need to return the subdirectories of [[register_path]] matching 
-[[incomplete]] together with [[register]].
+So we need the courses of [[register_path]] that match [[incomplete]],
+paired with [[register]] so that same-named courses from different
+registers stay distinguishable.
+
+We must \emph{yield} those pairs rather than return them.
+This chunk is expanded inside the loop over registers, so a [[return]]
+here ends the entire function on the very first register: the user is
+silently offered only that register's courses, and with no registers at
+all the function falls off the end and hands [[None]] to Click.
+The chunk's name says nothing about where it is expanded, which is what
+makes the distinction invisible at the definition site---the
+chunk-composition hazard that literate programs have to watch for.
+Yielding makes [[complete_course_name]] a generator, so it visits every
+register and produces an empty sequence when there are none.
 <<yield (course name, register name) tuples that matches [[incomplete]]>>=
 courses_in_reg = courses.all_courses(register_path)
 matching_courses = filter(lambda x: x.startswith(incomplete), courses_in_reg)
-return map(lambda x: (x, f"from {register}"),
-           matching_courses)
+yield from map(lambda x: (x, f"from {register}"),
+               matching_courses)
+@
+
+Let's check both halves of that claim.
+With two registers configured, completion must reach past the first
+one:
+<<test functions>>=
+def test_complete_course_name_spans_registers():
+  second_reg = "second register"
+  second_path = pathlib.Path(tempfile.mkdtemp())
+  runner.invoke(cli, ["registry", "add", second_reg, str(second_path)])
+  try:
+    runner.invoke(cli, ["new", "secondcourse", "--register", second_reg])
+    ctx = SimpleNamespace(params={})
+    names = [name for name, _ in complete_course_name(ctx, "")]
+    assert target_course in names
+    assert "secondcourse" in names
+  finally:
+    runner.invoke(cli, ["registry", "rm", second_reg])
+@
+
+And with no registers at all, completion must produce an empty
+sequence rather than [[None]]:
+<<test functions>>=
+def test_complete_course_name_without_registers(monkeypatch):
+  monkeypatch.setattr("nytid.cli.courses.register_pairs",
+                      lambda register=None: [])
+  ctx = SimpleNamespace(params={})
+  assert list(complete_course_name(ctx, "")) == []
 @
 
 Now let's turn back to the main problem:

--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -527,6 +527,7 @@ target_value = "Test Tester"
 
 runner.invoke(cli, ["new", target_course, "--register", register])
 <<test imports>>=
+import pathlib
 import tempfile
 from types import SimpleNamespace
 import pytest
@@ -1342,26 +1343,124 @@ courses rather than crashing.
 This design lets callers decide whether an empty result is fatal
 (like [[signupsheets]], which calls [[sys.exit(1)]]) or merely means
 there is nothing to show (like [[schedule]]).
+
+Honouring that contract takes more care than wrapping the
+config-reading call in a [[try]], because there are \emph{two} places
+that touch the file system, not one.
+Reading a course's config is the obvious one.
+The less obvious one is scanning a register for course names: that
+scan lives inside the [[courses_regex]] generator, and a generator's
+body runs when the loop \emph{advances} it---that is, in the [[for]]
+statement itself, outside any [[try]] in the loop body.
+A register whose directory has gone missing (a common state when AFS
+isn't mounted) therefore raises from a line that looks like plain
+iteration.
+So we drive the generator explicitly, with [[next]] inside the guarded
+region.
+
+We also scan one register at a time.
+A generator that raises is exhausted and can't be resumed, so a single
+[[courses_regex]] over every register would let one unreachable
+register hide the courses of every register after it.
+Giving each register its own generator confines the damage to that
+register.
 <<helper functions>>=
 def get_courses_configs(course_regex,
                         register=MINE):
   """Return {(course, register): config} for matching courses.
 
-  Logs warnings for KeyError and PermissionError,
-  skipping inaccessible courses.
+  Registers that can't be scanned and courses whose config
+  can't be read are skipped with a warning, so one broken
+  register or config never hides the healthy courses.
   """
-  regs = registers_regex(register)
   result = {}
-  for course_reg in courses_regex(course_regex, regs):
-    try:
-      result[course_reg] = courses.get_course_config(
-        *course_reg
-      )
-    except KeyError as err:
-      logging.warning(err)
-    except PermissionError as err:
-      c, r = course_reg
-      logging.warning(
-        f"You don't have access to {c} in {r}: {err}"
-      )
+  for reg in registers_regex(register):
+    <<add [[reg]]'s matching courses to [[result]]>>
   return result
+@
+
+The errors that mean \enquote{we can't get at this course} are the same
+at both sites, so we name them once.
+Beyond the [[KeyError]] and [[PermissionError]] the function already
+handled, a course directory can vanish or turn out not to be a
+directory, and [[typerconf]] reports a corrupt [[config.json]] as a
+[[ValueError]]---which is precisely the state a half-written config
+leaves behind.
+<<constants>>=
+COURSE_ACCESS_ERRORS = (KeyError, FileNotFoundError,
+                        NotADirectoryError, PermissionError,
+                        ValueError)
+@
+
+Exhausting the generator normally means we're done with the register;
+any other exception means the scan itself failed, and since we can't
+resume a generator that raised, we warn and move on to the next
+register.
+<<add [[reg]]'s matching courses to [[result]]>>=
+matches = courses_regex(course_regex, [reg])
+while True:
+  try:
+    course_reg = next(matches)
+  except StopIteration:
+    break
+  except COURSE_ACCESS_ERRORS as err:
+    logging.warning(f"Can't list the courses in {reg}: {err}")
+    break
+  <<read [[course_reg]]'s config into [[result]]>>
+@
+
+Reading the config keeps the tailored message for [[PermissionError]],
+since \enquote{you don't have access} tells the user what to do about
+it, whereas the remaining errors are best reported verbatim.
+The specific clause has to come first: [[PermissionError]] is also a
+member of [[COURSE_ACCESS_ERRORS]], and Python takes the first clause
+that matches.
+<<read [[course_reg]]'s config into [[result]]>>=
+try:
+  result[course_reg] = courses.get_course_config(
+    *course_reg
+  )
+except PermissionError as err:
+  c, r = course_reg
+  logging.warning(
+    f"You don't have access to {c} in {r}: {err}"
+  )
+except COURSE_ACCESS_ERRORS as err:
+  logging.warning(err)
+@
+
+Let's verify both failure modes.
+A register pointing at a directory that was never created must yield
+nothing rather than a traceback.
+We remove the register again afterwards so that the shared test config
+stays healthy for the other tests.
+<<test functions>>=
+def test_get_courses_configs_skips_unreadable_register():
+  gone_reg = "goneregister"
+  gone_path = pathlib.Path(tempfile.mkdtemp()) / "never-created"
+  runner.invoke(cli, ["registry", "add", gone_reg, str(gone_path)])
+  try:
+    assert get_courses_configs(".*", f"^{gone_reg}$") == {}
+  finally:
+    runner.invoke(cli, ["registry", "rm", gone_reg])
+@
+
+A corrupt config must cost us that one course and no more---the point
+of the whole exercise is that the healthy course in the same register
+still comes back.
+<<test functions>>=
+def test_get_courses_configs_skips_corrupt_config():
+  broken_reg = "brokenregister"
+  broken_path = pathlib.Path(tempfile.mkdtemp())
+  runner.invoke(cli, ["registry", "add", broken_reg, str(broken_path)])
+  try:
+    runner.invoke(cli, ["new", "brokencourse", "--register", broken_reg])
+    runner.invoke(cli, ["new", "healthycourse", "--register", broken_reg])
+    (broken_path / "brokencourse" / "config.json").write_text("{not json")
+
+    configs = get_courses_configs(".*", f"^{broken_reg}$")
+    assert ("healthycourse", broken_reg) in configs
+    assert ("brokencourse", broken_reg) not in configs
+  finally:
+    runner.invoke(cli, ["registry", "rm", broken_reg])
+@

--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -527,6 +527,7 @@ target_value = "Test Tester"
 
 runner.invoke(cli, ["new", target_course, "--register", register])
 <<test imports>>=
+import logging
 import pathlib
 import tempfile
 from types import SimpleNamespace
@@ -1058,7 +1059,7 @@ def mine_add(course: Annotated[str, course_arg_autocomplete],
   if not alias:
     alias = course
 
-  <<set [[mine_path]] to the path of the mine register>>
+  mine_path = get_mine_path()
   <<exit if [[alias]] is already in [[mine_path]]>>
 
   <<set [[course_path]] to [[course]]'s path>>
@@ -1078,36 +1079,69 @@ except FileExistsError:
   sys.exit(1)
 @
 
-\subsection{Create the default mine register if it doesn't exist}
+\subsection{Getting at the mine register}
 
-When we attempt to get the [[mine_path]] from [[registry]], it might not exist 
-if it's the first time we use it.
-This means we want to create it in the default location.
-<<set [[mine_path]] to the path of the mine register>>=
-try:
-  mine_path = registry.get(MINE)
-except KeyError:
-  <<create the default mine register>>
-  mine_path = registry.get(MINE)
-@
+The [[mine]] register is unlike the others: nobody adds it deliberately,
+it appears the first time a course is added to it.
+That makes two states normal rather than exceptional---no register
+entry in the config, and an entry whose directory doesn't exist---and
+the register lives under the user's home directory, so both states
+arise routinely on a fresh machine or after dotfiles are restored
+without their data.
 
-Now, if the register doesn't exist, we want to create it in [[~/.nytid/mine]] 
-and add it to the registry.
-<<create the default mine register>>=
-home_path = pathlib.Path(os.environ["HOME"])
-registry.add(MINE, home_path / ".nytid/mine")
-mine_path = registry.get(MINE)
-os.makedirs(mine_path)
-logging.warning(f"Added register {MINE} and created its path {mine_path}.")
+All three [[mine]] subcommands need the same thing: a directory they
+can rely on.
+So rather than let each of them rediscover the register and each of
+them get the error handling slightly differently, we resolve it once,
+here.
+The function creates whatever is missing and, when it can't, reports it
+the way the rest of this module does---[[logging.error]] and
+[[sys.exit(1)]] rather than a traceback.
+We use [[pathlib.Path.home()]] instead of reading [[HOME]] directly, so
+that a process without that variable falls back to the password
+database rather than raising.
+<<helper functions>>=
+def get_mine_path():
+  """
+  Returns the path of the `mine` register, creating the register
+  entry and its directory if they don't exist.
+
+  Exits with an error message if the directory can't be created.
+  """
+  try:
+    mine_path = registry.get(MINE)
+  except KeyError:
+    mine_path = pathlib.Path.home() / ".nytid" / MINE
+    registry.add(MINE, mine_path)
+    logging.warning(f"Added register {MINE} at {mine_path}.")
+
+  try:
+    os.makedirs(mine_path, exist_ok=True)
+  except OSError as err:
+    logging.error(f"Can't use the {MINE} directory {mine_path}: {err}")
+    sys.exit(1)
+
+  return mine_path
 @
 
 \subsection{Check if the course is already among my courses}
 
-To check if the alias already exists among our courses, we simply iterate 
+To check if the alias already exists among our courses, we iterate
 through and look for such a filename.
+
+The comparison has to be against [[my_course.name]].
+[[registry.get]] returns a [[pathlib.Path]], so [[iterdir]] yields
+[[Path]] objects, and a [[Path]] never compares equal to a [[str]]---
+comparing them directly makes the check silently vacuous, which is what
+it used to be.
+The duplicate was then caught only by accident, further down, when
+[[os.symlink]] raised [[FileExistsError]]; that accident doesn't cover
+the case this check exists for, an [[alias]] that collides with a
+course added under a different name.
+The sibling [[mine_ls]] below already does it correctly.
 <<exit if [[alias]] is already in [[mine_path]]>>=
 for my_course in mine_path.iterdir():
-  if my_course == alias:
+  if my_course.name == alias:
     logging.error(f"{alias} is already among your courses.")
     sys.exit(1)
 @
@@ -1161,14 +1195,26 @@ course_path = registry.get(register) / course
 
 \subsection{Listing my courses}
 
+Listing goes through [[get_mine_path]] like the others, so an
+unconfigured or absent register is set up rather than reported as a
+[[KeyError]] traceback.
+That still leaves a directory that exists but can't be read---a
+permission problem the user has to fix themselves---so we say so
+plainly instead of letting the [[OSError]] surface raw.
 <<mine subcommands>>=
 @minecli.command(name="ls")
 def mine_ls():
   """
   Lists my courses.
   """
-  mine_path = registry.get(MINE)
-  for course in mine_path.iterdir():
+  mine_path = get_mine_path()
+  try:
+    my_courses = list(mine_path.iterdir())
+  except OSError as err:
+    logging.error(f"Can't list {mine_path}: {err}")
+    sys.exit(1)
+
+  for course in my_courses:
     print(course.name)
 @
 
@@ -1180,22 +1226,97 @@ def mine_rm(course: Annotated[str, my_course_arg]):
   """
   Removes a course from my courses.
   """
-  mine_path = registry.get(MINE)
+  mine_path = get_mine_path()
   try:
     os.unlink(mine_path / course)
   <<handle errors for trying to remove a course from mine>>
 <<argument and option definitions>>=
 my_course_arg = typer.Argument(help="The course in my courses.",
                                autocompletion=complete_my_course_arg)
+@
+
+Completion can't use [[get_mine_path]], even though it wants the same
+directory.
+A completer runs whenever the user presses \textsc{tab}, so it must
+neither create a register as a side effect nor call [[sys.exit]] in the
+middle of the shell's completion machinery.
+Instead it reads what is there and, if anything is missing or
+unreadable, offers nothing---the worst outcome being that the user
+types the name out in full.
+We materialise the courses inside the [[try]], because
+[[all_courses]] is a generator and would otherwise do its file-system
+work outside it (\cref{cli.courses}).
 <<helper functions>>=
 def complete_my_course_arg(incomplete: str) -> list[str]:
   """
-  Returns a list of courses in my courses that match `incomplete`.
+  Yields the courses in my courses that match `incomplete`.
+
+  Yields nothing when the `mine` register is missing or
+  unreadable; completion must never fail loudly.
   """
-  mine_path = registry.get(MINE)
-  for course in courses.all_courses(mine_path):
+  try:
+    my_courses = list(courses.all_courses(registry.get(MINE)))
+  except COURSE_ACCESS_ERRORS:
+    return
+
+  for course in my_courses:
     if course.startswith(incomplete):
       yield course
+@
+
+Let's verify the three claims above.
+Every test points [[HOME]] and the [[mine]] register at a temporary
+directory, and removes the register afterwards, so nothing here can
+reach the real [[~/.nytid]].
+
+The duplicate check must actually fire.
+We assert on the log rather than on the command output, because the
+module reports errors through [[logging]], which the Click runner does
+not capture:
+<<test functions>>=
+def test_mine_add_rejects_duplicate_alias(tmp_path, monkeypatch, caplog):
+  monkeypatch.setenv("HOME", str(tmp_path))
+  runner.invoke(cli, ["registry", "add", MINE, str(tmp_path / MINE)])
+  try:
+    assert runner.invoke(cli, ["mine", "add", target_course,
+                               register]).exit_code == 0
+
+    with caplog.at_level(logging.ERROR):
+      result = runner.invoke(cli, ["mine", "add", target_course, register])
+
+    assert result.exit_code == 1
+    assert "already among your courses" in caplog.text
+  finally:
+    runner.invoke(cli, ["registry", "rm", MINE])
+@
+
+A register whose directory was never created must be repaired by every
+subcommand rather than raising [[FileNotFoundError]]:
+<<test functions>>=
+def test_mine_commands_create_missing_directory(tmp_path, monkeypatch):
+  monkeypatch.setenv("HOME", str(tmp_path))
+  mine_dir = tmp_path / "never-created" / MINE
+  runner.invoke(cli, ["registry", "add", MINE, str(mine_dir)])
+  try:
+    assert runner.invoke(cli, ["mine", "ls"]).exit_code == 0
+    assert mine_dir.is_dir()
+
+    assert runner.invoke(cli, ["mine", "add", target_course,
+                               register]).exit_code == 0
+    assert (mine_dir / target_course).is_symlink()
+
+    assert runner.invoke(cli, ["mine", "rm", target_course]).exit_code == 0
+    assert not (mine_dir / target_course).exists()
+  finally:
+    runner.invoke(cli, ["registry", "rm", MINE])
+@
+
+Completion, by contrast, must stay silent and create nothing when the
+register isn't there at all:
+<<test functions>>=
+def test_complete_my_course_arg_without_register():
+  runner.invoke(cli, ["registry", "rm", MINE])
+  assert list(complete_my_course_arg("")) == []
 @
 
 There are several errors that can occur.

--- a/src/nytid/cli/init.nw
+++ b/src/nytid/cli/init.nw
@@ -2296,13 +2296,28 @@ import importlib
 @
 
 Files are modules, directories are packages.
-So for each file, we check if it is a module (by extension) and add it if it 
+So for each file, we check if it is a module (by extension) and add it if it
 is.
-If it's a directory, we recursively call the function to find all modules in 
+If it's a directory, we recursively call the function to find all modules in
 that directory.
+
+A set is the right thing to \emph{collect} into---a package that has
+both [[foo.py]] and a [[foo]] directory must yield one name---but it is
+the wrong thing to \emph{return}.
+The caller below registers one Typer group per name in iteration order,
+and that order is what Typer prints in [[nytid --help]].
+Neither [[os.scandir]] nor a set of strings gives a stable order:
+[[scandir]] follows the file system, and Python randomises string
+hashing per process.
+The observable effect is that [[nytid --help]] listed its subcommand
+groups in a different order on every invocation, which defeats muscle
+memory and makes the help output impossible to diff or snapshot.
+Sorting on the way out costs nothing and makes discovery deterministic
+for every caller---[[nytid.cli.utils]] uses this same helper
+(\cref{chap:utils}).
 <<helper functions>>=
 def package_contents(package_name, recurse=False):
-  """Return the set of module names directly inside ``package_name``.
+  """Return the sorted module names directly inside ``package_name``.
 
   If ``recurse`` is True, sub-packages are traversed depth-first;
   the default is False because sub-packages register their own Typer
@@ -2310,7 +2325,7 @@ def package_contents(package_name, recurse=False):
   """
   spec = importlib.util.find_spec(package_name)
   if spec is None:
-      return set()
+      return []
 
   pathname = pathlib.Path(spec.origin).parent
 
@@ -2327,12 +2342,26 @@ def package_contents(package_name, recurse=False):
       elif entry.is_dir():
         modules.add(current)
         if recurse:
-          modules |= package_contents(current, recurse=True)
+          modules.update(package_contents(current, recurse=True))
 
-  return modules
+  return sorted(modules)
 <<additional imports>>=
 import pathlib
 import os
+@
+
+Sortedness is the contract, so that is what we assert.
+Checking that the result equals its own sorted copy catches a
+regression to an unordered container, which a single-process
+equality check between two calls would not.
+<<test [[init.py]]>>=
+from nytid.cli import package_contents
+
+def test_package_contents_is_ordered():
+  """Module discovery must be deterministic."""
+  modules = package_contents("nytid.cli")
+  assert modules == sorted(modules)
+  assert "nytid.cli.courses" in modules
 @
 
 With the module names in hand, we can import and register each one

--- a/src/nytid/cli/zulip.nw
+++ b/src/nytid/cli/zulip.nw
@@ -212,6 +212,7 @@ def test_callback_hands_course_zuliprc_to_zulipcli(monkeypatch, tmp_path):
   import zulipcli
 
   (tmp_path / "prgi24").mkdir()
+  (tmp_path / "prgi24" / "config.json").write_text("{}")
   monkeypatch.setattr(zulip_module.registry, "get",
                       lambda name, config=None: tmp_path)
 
@@ -275,6 +276,7 @@ def test_course_zuliprc_in_course_dir(tmp_path):
   config = typerconf.Config()
   registry.add("reg", str(tmp_path), config=config)
   (tmp_path / "somecourse").mkdir()
+  (tmp_path / "somecourse" / "config.json").write_text("{}")
 
   path = course_zuliprc("somecourse", "reg", config=config)
   assert path == tmp_path / "somecourse" / ZULIPRC_FILENAME

--- a/src/nytid/courses/init.nw
+++ b/src/nytid/courses/init.nw
@@ -93,9 +93,37 @@ To create a course, we need a name for the course.
 <<new args>>=
 name: str,
 <<new doc>>=
-- `name` (mandatory), which is the human readable nickname of the course. This 
-  is used to refer to the course with other parts of nytid.
+- `name` (mandatory), which is the human readable nickname of the course. This
+  is used to refer to the course with other parts of nytid. It must be
+  non-empty, must not start with a period and must not contain a path
+  separator.
 
+@
+
+The name isn't only a label: we build the course's directory by
+appending it to the register's path, which makes it a path fragment.
+An unchecked path fragment can leave the register entirely.
+[[nytid courses new ../escaped]] would create the course in the
+register's \emph{parent}---where no register scan will ever find it,
+and where the shared directory's permissions, which are our entire
+access-control mechanism (\cref{cli.courses}), don't apply.
+A name containing a separator nests the course a level deeper than the
+scan looks, with the same effect.
+
+So we validate before creating anything.
+We reject a name that is empty, contains a path separator, or begins
+with a period.
+Rejecting the leading period is what rules out [[..]] and [[.]]
+themselves, and it also keeps course names clear of the hidden
+bookkeeping files that share these directories.
+[[registry.add]] validates register names for much the same reason
+(\cref{registry}); this brings courses into line with registers.
+<<check that [[name]] is a valid course name>>=
+if not name or name.startswith(".") \
+   or "/" in name or os.sep in name:
+  raise ValueError(f"`{name}` is not a valid course name: it must be "
+                   f"non-empty, must not start with a period and must "
+                   f"not contain a path separator.")
 @
 
 We will create the course by creating a directory in an available courses
@@ -105,6 +133,7 @@ Once the config is written the course exists; we log that at INFO,
 including which register it ended up in, since the register might
 have been selected automatically rather than by the user.
 <<new body>>=
+<<check that [[name]] is a valid course name>>
 <<determine which course register path [[register_path]] to use>>
 
 with storage.open_root(f"{register_path}/{name}") as root:
@@ -392,6 +421,23 @@ def test_new_leaves_no_config_on_failure():
 
   new(course_name, register, config=config)
   assert (reg_path / course_name / "config.json").exists()
+@
+
+The names that escape or hide the course must all be refused, and---
+just as importantly---refused before anything is written.
+We therefore assert on the register's contents rather than on the
+absence of one particular directory: the invariant is that a rejected
+name leaves the register exactly as it found it.
+<<test functions>>=
+def test_new_rejects_invalid_names():
+  import pytest
+  before = sorted(entry.name for entry in reg_path.iterdir())
+
+  for bad_name in ["../escaped", "a/b", "..", ".hidden", ""]:
+    with pytest.raises(ValueError):
+      new(bad_name, register, config=config)
+
+  assert sorted(entry.name for entry in reg_path.iterdir()) == before
 @
 
 

--- a/src/nytid/courses/init.nw
+++ b/src/nytid/courses/init.nw
@@ -20,6 +20,7 @@ manage courses found in the course registers.
 import typerconf
 
 import logging
+import os
 import pathlib
 from nytid.courses import registry
 from nytid import storage
@@ -117,10 +118,45 @@ with storage.open_root(f"{register_path}/{name}") as root:
                           f"{register_path}/{name}/config.json")
 
   <<add settings to [[course_conf]]>>
+  <<write [[course_conf]] to [[config.json]] atomically>>
 
-  with root.open("config.json", "w") as course_conf_file:
-    course_conf.write_config(course_conf_file)
   logging.info(f"Created course {name} in register {register}")
+@
+
+\subsection{Writing the config without risking corruption}
+
+Writing straight into [[config.json]] would make the file's contents
+depend on the serialisation succeeding.
+Opening for writing truncates the file immediately, whereas
+[[json.dump]] only discovers a value it can't serialise part-way
+through---leaving a half-written file that is neither absent nor
+readable.
+The course is then wedged: creating it again raises
+[[FileExistsError]] because a config exists, and reading it raises
+[[ValueError]] because the JSON is truncated.
+The only way out is to delete the course directory by hand.
+
+We avoid that by never letting a partial write reach [[config.json]].
+We serialise into a temporary file in the \emph{same} directory, then
+rename it over the target.
+Same directory means same file system, and that is precisely what makes
+[[os.replace]] atomic on POSIX: any reader sees either the old file or
+the complete new one, never a prefix of it.
+The temporary name carries the process id so that two concurrent
+creations can't corrupt each other's staging file, and we remove it on
+any failure so a crashed run leaves no debris in the course directory.
+<<write [[course_conf]] to [[config.json]] atomically>>=
+tmp_name = f".config.json.{os.getpid()}"
+try:
+  with root.open(tmp_name, "w") as course_conf_file:
+    course_conf.write_config(course_conf_file)
+  os.replace(root.path / tmp_name, root.path / "config.json")
+except BaseException:
+  try:
+    os.unlink(root.path / tmp_name)
+  except OSError:
+    pass
+  raise
 @
 
 Now we want to test the function~[[new]].
@@ -300,6 +336,14 @@ If the user didn't specify a data directory, then [[data_path]] will be
 In this case, we should update it with the default value.
 We get the default value from [[root.path]] (see
 [[<<new body>>]]).
+
+Whichever value we end up with, we store it as a string.
+The config is JSON, and the CLI declares its [[--data-path]] option as
+a [[pathlib.Path]] (\cref{cli.courses}), so Typer hands us a [[Path]]
+object that [[json.dump]] can't serialise.
+Coercing only inside the default branch would leave exactly the
+user-supplied case broken, so we convert once, after the default has
+been applied, and thereby cover both.
 <<process expected [[key]]s>>=
 try:
   data_path = kwdata["data_path"]
@@ -307,9 +351,9 @@ except KeyError:
   data_path = None
 
 if not data_path:
-  data_path = str(root.path / "data")
+  data_path = root.path / "data"
 
-kwdata["data_path"] = data_path
+kwdata["data_path"] = str(data_path)
 @
 
 \subsection{Testing the \texttt{new} function}
@@ -317,6 +361,37 @@ kwdata["data_path"] = data_path
 Now we can finally make the call to [[new]] to test it.
 <<call new to test>>=
 new(course, register, config=config)
+@
+
+The path the user supplies must survive the round trip through JSON.
+We read the written file directly rather than through
+[[get_course_config]], because what is under test is what [[new]]
+\emph{wrote}, not what the reader makes of it.
+<<test functions>>=
+def test_new_coerces_path_data_path():
+  import json
+  course_name = "pathcourse"
+  data_dir = pathlib.Path(tempfile.mkdtemp()) / "elsewhere"
+  new(course_name, register, {"data_path": data_dir}, config=config)
+  with open(reg_path / course_name / "config.json") as conf_file:
+    assert json.load(conf_file)["data_path"] == str(data_dir)
+@
+
+A failed serialisation must leave the course creatable.
+We provoke one with a value JSON can't represent and check that no
+config survives---and, crucially, that a subsequent honest attempt
+succeeds rather than tripping over the debris of the first.
+<<test functions>>=
+def test_new_leaves_no_config_on_failure():
+  import pytest
+  course_name = "failcourse"
+
+  with pytest.raises(TypeError):
+    new(course_name, register, {"unserialisable": object()}, config=config)
+  assert not (reg_path / course_name / "config.json").exists()
+
+  new(course_name, register, config=config)
+  assert (reg_path / course_name / "config.json").exists()
 @
 
 

--- a/src/nytid/courses/init.nw
+++ b/src/nytid/courses/init.nw
@@ -501,15 +501,36 @@ conf_path = None
 
 \subsection{Listing all courses in register}
 
-To list all the courses, we simply list all directories in the register's 
-directory.
+Every course is a directory in the register, but not every directory in
+the register is a course.
+A register is an ordinary shared directory, so it collects other
+things: a [[.git]] directory when the register is kept under version
+control, scratch directories, the remains of a course whose creation
+failed.
+
+Listing those as courses is not harmless.
+[[typerconf]] swallows the [[FileNotFoundError]] for a missing
+[[config.json]] and hands back an empty config, so a phantom course
+looks perfectly valid right up until someone reads a setting off it and
+gets a [[KeyError]] from what appears to be a real course.
+In the meantime it pads [[nytid courses ls]] and tab completion with
+entries the user never created.
+
+What makes a directory a course is the [[config.json]] that [[new]]
+writes into it (\cref{courses.CreatingTheCourse}), so that is what we
+test for.
+Asking whether that file exists also subsumes the directory test: a
+plain file has no [[config.json]] beneath it.
 <<functions>>=
 def all_courses(register_path: pathlib.Path) -> list[str]:
   """
   Returns a list (generator) of all courses found in `register_path`.
+
+  A subdirectory counts as a course only if it contains a
+  `config.json`.
   """
   for file in pathlib.Path(register_path).iterdir():
-    if file.is_dir():
+    if (file / "config.json").is_file():
       yield file.name
 @
 
@@ -594,4 +615,21 @@ def test_all_courses_empty():
   empty = pathlib.Path(tempfile.mkdtemp())
   courses_list = list(all_courses(empty))
   assert len(courses_list) == 0
+@
+
+The two kinds of clutter a register accumulates are a stray directory
+(here [[.git]], the one every version-controlled register has) and a
+stray file.
+Neither may appear as a course, and the real course must survive the
+filtering.
+<<test functions>>=
+def test_all_courses_skips_non_courses():
+  import os
+  os.makedirs(reg_path / ".git", exist_ok=True)
+  (reg_path / "stray.txt").write_text("not a course")
+
+  courses_list = list(all_courses(reg_path))
+  assert ".git" not in courses_list
+  assert "stray.txt" not in courses_list
+  assert course in courses_list
 

--- a/src/nytid/storage/init.nw
+++ b/src/nytid/storage/init.nw
@@ -121,6 +121,7 @@ def open_root(*args, **kwargs) -> StorageRoot:
 We also add the tests in a test file that will be used by [[pytest]].
 We need a temporary directory that we can use as the root.
 <<test [[storage.py]]>>=
+import os
 import pathlib
 import tempfile
 
@@ -152,15 +153,23 @@ def open(self, *args, **kwargs):
   return open(*args, **kwargs, opener=self.__opener)
 @
 
-The opener is a particular function that the [[open]] built-in will call to 
+The opener is a particular function that the [[open]] built-in will call to
 open the file.
 This opener will ensure that the filename is relative to the root.
 Now, this requires the directory to be opened.
 We will ensure it's opened.
+
+We ask whether the descriptor [[is None]] rather than whether it is
+false.
+A file descriptor is a small integer, and 0 is a perfectly legitimate
+one: a process whose standard input has been closed gets 0 for the next
+file it opens.
+A truthiness test would then read an open root as unopened and reopen
+it on every single file access.
 <<StorageRoot methods>>=
 def __opener(self, path, flags):
   """The opener, used internally"""
-  if not self.__dir_fd:
+  if self.__dir_fd is None:
     self.open_dir()
   return os.open(path, flags, dir_fd=self.__dir_fd)
 @
@@ -169,12 +178,24 @@ self.__dir_fd = None
 @
 
 We want to be able to open and close the directory file descriptor.
+
+Opening a root that is already open must not just overwrite the
+descriptor: the old one would never be closed, and the process would
+leak one descriptor per call until it hits its limit.
+A second open would only hand us another descriptor for the same
+directory, so there is nothing to gain from it; doing nothing is both
+the cheapest and the correct behaviour.
 <<StorageRoot methods>>=
 def open_dir(self):
   """
-  Open the storage root directory. Note that this is done automatically when 
+  Open the storage root directory. Note that this is done automatically when
   opening a file using the `open` method.
+
+  Opening a root that is already open is a no-op.
   """
+  if self.__dir_fd is not None:
+    return
+
   try:
     <<open root directory file descriptor>>
   except FileNotFoundError:
@@ -183,13 +204,66 @@ def open_dir(self):
 self.__dir_fd = os.open(self.path, os.O_RDONLY)
 @
 
-Since this causes the directory file descriptor to be open, we need some way to 
+Since this causes the directory file descriptor to be open, we need some way to
 close it as well.
+
+Closing has to tolerate a root that was never opened, and that is not a
+hypothetical case.
+[[open_root]] constructs without opening, so [[get_course_data]]
+(\cref{courses}) hands out exactly such roots; and [[__exit__]] calls
+[[close]] unconditionally, so a [[with]] block whose body failed before
+touching any file closes an unopened root on the way out.
+Handing [[None]] to [[os.close]] raises [[TypeError]], which would
+replace the error the user actually needs to see with a confusing one
+from the cleanup path.
+The same guard makes a repeated [[close]] harmless.
 <<StorageRoot methods>>=
 def close(self):
-  """Close the storage root"""
+  """Close the storage root.
+
+  Closing a root that is not open is a no-op, so repeated
+  closes are safe.
+  """
+  if self.__dir_fd is None:
+    return
+
   os.close(self.__dir_fd)
   self.__dir_fd = None
+@
+
+Both no-ops are worth asserting, since both used to raise:
+<<test functions>>=
+def test_close_without_open():
+  root = StorageRoot(root_dir.name)
+  root.close()
+
+def test_double_close():
+  root = StorageRoot(root_dir.name)
+  root.open_dir()
+  root.close()
+  root.close()
+@
+
+The leak is only observable by counting the process's open descriptors,
+which we can do on systems that expose [[/proc]]; elsewhere we skip
+rather than assert something weaker.
+<<test functions>>=
+def test_open_dir_does_not_leak_descriptors():
+  import pytest
+
+  fd_dir = pathlib.Path("/proc/self/fd")
+  if not fd_dir.is_dir():
+    pytest.skip("counting open descriptors needs /proc")
+
+  root = StorageRoot(root_dir.name)
+  root.open_dir()
+  before = len(os.listdir(fd_dir))
+  for _ in range(10):
+    root.open_dir()
+  after = len(os.listdir(fd_dir))
+  root.close()
+
+  assert after == before
 @
 
 We test this as follows.


### PR DESCRIPTION
Eight verified bugs in the core infrastructure — `nytid.courses`,
`nytid.cli.courses`, `nytid.storage` and `nytid.cli` — found in a
project-wide bug review. Every finding was reproduced against the code
before being fixed, and every fix ships with a regression test
colocated in its `.nw` file.

One atomic commit per finding. Test count: 663 → 678.

## Behavioral changes reviewers should note

- **Course names are now validated.** `courses new` rejects names that
  are empty, start with a period, or contain a path separator. Names
  that were silently accepted before (`../escaped`, `a/b`) now raise
  `ValueError`.
- **`courses ls` and completion list fewer things.** A directory
  without a `config.json` is no longer reported as a course.
- **`nytid --help` group order changed** — it is now alphabetical, and
  stable, rather than a different order on every run.

## Fix 1 — `courses new --data-path` corrupted the course it created

Typer declares `--data-path` as a `pathlib.Path`, but `courses.new`
coerced only the *default* branch to `str`, so a user-supplied `Path`
reached `json.dump` and raised `TypeError` — after
`root.open("config.json", "w")` had already truncated the file. The
14-byte remnant wedged the course permanently: retrying raised
`FileExistsError`, reading raised `ValueError`.

Both halves are fixed: `data_path` is coerced unconditionally, and the
config is now staged in a temporary file in the same directory and
`os.replace`d over `config.json`, so no serialisation failure can leave
a truncated config.

Closes #374

## Fix 2 — `get_courses_configs` crashed instead of warning

Its prose promises to warn rather than crash, but the `try` wrapped
only `get_course_config`. The register scan runs while the `for`
statement advances the `courses_regex` generator — outside the `try` —
so a missing register directory (AFS unmounted) or a permission-denied
register escaped. `ValueError` from a corrupt `config.json` was not
handled at all.

The generator is now driven with `next()` inside the guarded region,
one register at a time (an exhausted generator cannot be resumed, so a
single generator over all registers would let one bad register hide
every register after it), and `FileNotFoundError`,
`NotADirectoryError`, `PermissionError` and `ValueError` are handled at
both sites.

Closes #386

## Fix 3 — `all_courses` reported every subdirectory as a course

`typerconf` swallows the `FileNotFoundError` for a missing
`config.json` and returns an empty `Config`, so a phantom course
(`.git`, scratch directories) looked valid until a caller read a
setting off it and got a `KeyError`. Meanwhile it padded `courses ls`
and tab completion.

Only directories containing a `config.json` — the file that `new`
writes, and therefore what makes a directory a course — are listed now.

**Cross-file test impact:** this tightening exposed two stale fixtures
in the `zulip.nw` test chunks (`test_course_zuliprc_in_course_dir` and
`test_callback_hands_course_zuliprc_to_zulipcli`). Both built a fake
course directory with no `config.json`, contradicting their own prose
("A course directory holds config.json; the zuliprc is its sibling").
They now write one. **Test chunks only — no production chunk in
`zulip.nw` is touched**, and the change is in the same commit as the
`all_courses` fix.

Closes #387

## Fix 4 — `courses new` accepted names that escaped the register

The course directory was built by interpolating the name into an
f-string with no validation, making the name a path fragment rather
than a label. `nytid courses new ../escaped` created the course in the
register's *parent* — invisible to every register scan, and outside the
shared directory whose permissions are the entire access-control
mechanism. `a/b` nested it a level below where the scan looks.

Names are now validated before anything is written, mirroring the
validation `registry.add` already applies to register names.

Closes #389

## Fix 5 — completion only ever offered the first register's courses

The chunk producing the completions ended in `return map(...)`, and it
is expanded *inside* the loop over registers — so the function returned
during the first iteration. With no registers configured it fell off
the end and handed `None` to Click.

It now uses `yield from`, making `complete_course_name` a generator
that visits every register and yields nothing when there are none. The
prose names the chunk-composition hazard explicitly so it is not
reintroduced.

Closes #391

## Fix 6 — `StorageRoot` leaked and mishandled its directory descriptor

Three defects in one lifecycle:

- `close()` called `os.close` unguarded, so closing a root that was
  never opened — exactly what `get_course_data` hands out, and what
  `__exit__` does when a `with` body fails early — raised `TypeError`
  and masked the real error. A second `close()` did the same.
- `open_dir()` overwrote an open descriptor without closing it, leaking
  one per call (measured: 20 calls, 20 descriptors).
- `__opener` tested the descriptor for truth, and `0` is a legitimate
  descriptor.

`close()` is guarded, `open_dir()` is a no-op when already open, and
`__opener` tests `is None`.

Closes #392

## Fix 7 — `nytid --help` listed subcommand groups in random order

`package_contents` returned a `set`, and the registration loop iterates
it to add one Typer group per name. Python randomises string hashing
per process, so the group order differed on every invocation — five
consecutive runs gave five different orders. That defeats muscle memory
and makes the help output impossible to diff or snapshot.

It still collects into a set (`foo.py` and `foo/` must yield one name)
but returns `sorted()`. `nytid.cli.utils` reuses the helper and
benefits too.

Closes #393

## Fix 8 — `courses mine` had a dead check and raw tracebacks

- The duplicate-alias check compared a `pathlib.Path` from `iterdir()`
  to the `str` alias, which is never equal, so the check was dead. A
  duplicate was caught only by accident when `os.symlink` raised
  `FileExistsError` — which does not cover the case the check exists
  for, an alias colliding with a course added under another name.
- `mine_add`'s recovery caught only `KeyError`, so a
  configured-but-missing directory raised a raw `FileNotFoundError`.
  `mine_ls` and `mine_rm` had no error handling at all, and
  `complete_my_course_arg` called `registry.get(MINE)` unguarded — so
  pressing TAB could raise `KeyError`.

The comparison uses `my_course.name`, and a new `get_mine_path()`
helper registers `mine` if needed, `makedirs(exist_ok=True)` its
directory, and reports failures the way the rest of the module does
(`logging.error` + `sys.exit(1)`). `mine add/ls/rm` all use it.
Completion deliberately does not: a completer must create nothing and
never call `sys.exit`, so it reads defensively and degrades to no
suggestions.

Closes #394

## Verification

- `cd tests && make test` — 678 passed (baseline on `main`: 663).
- Clean rebuild (`make -C src/nytid clean all`, `make -C tests clean`)
  before the final run.
- No test touches real user data: the `mine` tests point `HOME` and the
  `mine` register at temporary directories and remove the register
  afterwards; `~/.nytid` was confirmed unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136fb1QAY29rDDLkELhZEpK
