### PR TITLE
Fix eleven bugs in the scheduling domain

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1548,6 +1548,25 @@ files = [
 ]
 
 [[package]]
+name = "tzlocal"
+version = "5.4.4"
+description = "tzinfo object for the local timezone"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "tzlocal-5.4.4-py3-none-any.whl", hash = "sha256:aae09f0126a8a86fa736be266eb4a471380d26a0de3bc14844e7821fee3e2a15"},
+    {file = "tzlocal-5.4.4.tar.gz", hash = "sha256:8dbb8660838688a7b6ba4fed31d18dedf842afb4d47ca050d6d891c2c15f3be4"},
+]
+
+[package.dependencies]
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+devenv = ["zest.releaser"]
+testing = ["check_manifest", "pyroma", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "ruff"]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1657,4 +1676,4 @@ zulip = "*"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "3716863fc5ce1909a274101f7e8369aad40e321e7a591a4d5c457953fb4d7aa3"
+content-hash = "ac177a0c505ddeb673071f536d7dc1ef074743e7c3d3c9929b95f9945977e3c4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
   "cachetools>=5.3.1,<6.0.0",
   "rich>=13.0.0,<14.0.0",
   "weblogin (>=1.17,<2.0)",
-  "zulipcli (>=0.7,<1.0)"
+  "zulipcli (>=0.7,<1.0)",
+  "tzlocal (>=5.4.4,<6.0.0)"
 ]
 
 [project.scripts]

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -81,11 +81,23 @@ def ics_cmd(<<argument for matching courses>> = ".*",
             <<option for matching registers, default to mine>>,
             <<option for username to filter for>>):
   """
-  Prints ICS data to stdout. Redirect to a .ics file, preferably in 
+  Prints ICS data to stdout. Redirect to a .ics file, preferably in
   ~/public_html, and add it to your calendar.
   """
+  <<let [[course_window]] be the export horizon>>
   <<generate [[schedule]] from sign-up sheets for matching courses>>
   print(schedule.to_ical().decode())
+@
+
+The shared generation chunk expands the courses' recurring events, and
+that expansion has to be bounded (\cref{ExpandingRecurrences}), so
+whoever includes the chunk must first say over what range.
+An export has no range to speak of: nobody asked for a week, they asked
+for their calendar.
+We hand it the library's default horizon, which brackets any course
+without ever running away on an endless [[RRULE]].
+<<let [[course_window]] be the export horizon>>=
+course_window = schedutils.default_window()
 @
 
 RFC~5545 requires every serialized calendar to carry exactly one
@@ -146,16 +158,73 @@ if "docs.google.com" in url:
   url = sheets.google_sheet_to_csv_url(url)
 @
 
-We read the ICS URL from the course's config and then read it in and add it to 
+We read the ICS URL from the course's config and then read it in and add it to
 [[schedule]].
-We also run all the events from the schedule through a filter that removes 
+We also run all the events from the schedule through a filter that removes
 events that are uninteresting.
-For instance, we don't want to include events like holidays, exam weeks or 
+For instance, we don't want to include events like holidays, exam weeks or
 fairs like KTH Global.
+
+We pass [[course_window]] for the same reason the external feeds get
+one: a TimeEdit course schedule states a weekly lab once, as a single
+[[VEVENT]] with an [[RRULE]], and reading it without a window leaves
+the occurrences implicit.
+This path is the fallback for courses that have no sign-up sheet, which
+is exactly when the ICS \emph{is} the schedule---so collapsing it to
+first occurrences quietly emptied those courses of everything but their
+first week.
 <<read schedule from [[config]], add to [[schedule]]>>=
-course_schedule = schedutils.read_calendar(config.get("ics"))
+course_schedule = schedutils.read_calendar(config.get("ics"),
+                                           window=course_window)
 for event in schedutils.event_filter(course_schedule.events):
   schedule.add_component(event)
+@
+
+Both commands include this chunk, and each supplies its own window, so
+the test drives both and checks what the reader was handed.
+The course config has no sign-up sheet, which is what sends [[show]]
+and [[ics]] down this fallback path in the first place.
+[[show]] must ask for exactly its own range; [[ics]], having none, must
+still ask for something that brackets now.
+<<test functions>>=
+def capture_course_window(monkeypatch, argv):
+  """Runs a schedule command, returns the course ICS window."""
+  from typer.testing import CliRunner
+  import typerconf
+  captured = {}
+
+  def fake_read_calendar(source, cache=None, window=None):
+    captured["window"] = window
+    return icalendar.Calendar()
+
+  config = typerconf.Config({"ics": "https://example.com/course.ics"})
+  monkeypatch.setattr(
+    schedule_module.coursescli, "get_courses_configs",
+    lambda *a, **k: {("DD1310", "reg"): config})
+  monkeypatch.setattr(schedule_module, "get_external_sources",
+                      lambda cli_sources=None: [])
+  monkeypatch.setattr(schedule_module.schedutils, "read_calendar",
+                      fake_read_calendar)
+
+  result = CliRunner().invoke(schedule_module.cli, argv)
+  assert result.exit_code == 0, result.output
+  return captured["window"]
+
+def test_show_expands_course_recurrences_over_its_range(monkeypatch):
+  """show asks for exactly the range it will display."""
+  window = capture_course_window(
+    monkeypatch,
+    ["show", "--start", "2024-06-03", "--end", "2024-06-09",
+     "--no-todo"])
+  start, end = window
+  assert start.astimezone().date() == datetime.date(2024, 6, 3)
+  assert end.astimezone().date() == datetime.date(2024, 6, 9)
+
+def test_ics_expands_course_recurrences_over_a_horizon(monkeypatch):
+  """ics has no range, so it must still bracket now."""
+  start, end = capture_course_window(monkeypatch, ["ics"])
+  now = datetime.datetime.now().astimezone()
+  assert start < now < end
 @
 
 We need a username.
@@ -441,6 +510,7 @@ def show(<<argument for matching courses>> = ".*",
   Shows schedule for courses, external calendars and scheduled todos.
   """
   <<double check [[start]] and [[end]] dates>>
+  <<let [[course_window]] be the shown range>>
   <<generate [[schedule]] from sign-up sheets for matching courses>>
   <<add external calendar events to [[schedule]]>>
   <<add scheduled todo events to [[schedule]]>>
@@ -511,6 +581,15 @@ def end_of_day(when):
 <<double check [[start]] and [[end]] dates>>=
 end = update_end_date(start, end)
 end_of_range = end_of_day(end)
+@
+
+Unlike the export, [[show]] does have a range, and it is the one the
+user asked for---so the courses' recurrences are expanded over exactly
+what will be displayed rather than over a generic horizon.
+The bounds must be timezone aware, since the expansion compares them
+against aware event times.
+<<let [[course_window]] be the shown range>>=
+course_window = (start.astimezone(), end_of_range.astimezone())
 @
 
 \paragraph{Testing [[update_end_date]]}

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -190,13 +190,44 @@ for event in map_drop_exceptions(sheets.EventFromCSV, booked):
   schedule.add_component(event)
 <<imports>>=
 import functools
+@
+
+The point of [[map_drop_exceptions]] is that one malformed CSV row must
+not cost the user their whole schedule.
+The obvious implementation---a [[for]] loop with the call to [[func]]
+inside a [[try]]---only half delivers that, because a [[for]] statement
+advances the input iterator \emph{outside} the [[try]].
+With an eager list that distinction is invisible; with the lazy [[map]]
+above it decides whether the command works.
+[[add_reserve_to_title]] calls [[sheets.get_booked_TAs_from_csv]],
+which raises [[ValueError]] on a row whose \enquote{\#Needed TAs} cell
+is blank---the normal state of a sign-up sheet people are still filling
+in.
+Raised inside the [[map]], that exception is produced while the input
+is advanced, so it escapes the generator and aborts the command; and it
+does so only when [[--user]] is given, since that is the only path that
+wraps [[booked]] in a [[map]].
+Advancing the iterator inside the [[try]] ourselves removes the
+distinction: both the production of an item and its transformation are
+covered, so a bad row is dropped with a warning either way.
+[[StopIteration]] must be caught separately and turned into a
+[[return]], since a generator may not let it propagate.
 <<helper functions>>=
 def map_drop_exceptions(func, iterable):
   """
-  Same as map, but ignores exceptions from `func`.
-  Logs a warning when an item is dropped.
+  Same as map, but ignores exceptions from `func` and from producing
+  the items of `iterable`. Logs a warning when an item is dropped.
   """
-  for item in iterable:
+  items = iter(iterable)
+  while True:
+    try:
+      item = next(items)
+    except StopIteration:
+      return
+    except Exception as err:
+      logging.warning(f"Dropped an item: {err}")
+      continue
+
     try:
       yield func(item)
     except Exception as err:
@@ -242,6 +273,37 @@ def test_map_drop_exceptions_all_fail():
 def test_map_drop_exceptions_empty():
   result = list(map_drop_exceptions(int, []))
   assert result == []
+@
+
+The tests above all pass eager lists, where producing an item cannot
+fail, so they say nothing about the case that actually broke.
+Here the input is lazy and \emph{it} raises.
+The second test reproduces the original report end to end: a sign-up
+row with a blank \enquote{\#Needed TAs} cell, run through the same
+[[add_reserve_to_title]] mapping that [[--user]] installs.
+<<test functions>>=
+def test_map_drop_exceptions_lazy_input_raises():
+  """Exceptions raised while producing items are dropped too."""
+  def explode(value):
+    if value == "bad":
+      raise ValueError("boom")
+    return value
+
+  lazy = map(explode, ["1", "bad", "3"])
+  assert list(map_drop_exceptions(int, lazy)) == [1, 3]
+
+def test_map_drop_exceptions_survives_blank_needed_TAs():
+  """A blank '#Needed TAs' cell must not abort a --user export."""
+  rows = [
+    ["Lab", "2024-01-01 10:00", "2024-01-01 12:00",
+     "D1", "", "alice"],
+    ["Lab", "2024-01-02 10:00", "2024-01-02 12:00",
+     "D1", "1", "alice"],
+  ]
+  booked = map(functools.partial(add_reserve_to_title, "alice"),
+               rows)
+  events = list(map_drop_exceptions(sheets.EventFromCSV, booked))
+  assert len(events) == 1
 @
 
 \paragraph{Testing [[add_reserve_to_title]]}

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -476,8 +476,41 @@ def update_end_date(start, end):
   if end < start:
     return start + datetime.timedelta(weeks=1)
   return end
+@
+
+\paragraph{The end date is a day, not an instant}
+
+Both bounds are parsed with [[formats=["%Y-%m-%d"]]], so [[end]] is the
+\emph{midnight that starts} the end date.
+The user, however, said a date, and the print-time filter agrees with
+them: it keeps everything up to and including [[end.date()]].
+Anything that consumes [[end]] as an instant therefore stops a whole
+day short of what gets displayed.
+Three things did.
+The recurrence window never expanded external events on the last shown
+day, so the default seven-day view always lost day seven.
+[[compute_free_slots]] clipped that day's work window with
+[[min(day_end, end)]], collapsing it to nothing, so no todo was ever
+scheduled on the end date.
+And because those external events were missing, they were also missing
+from the occupied intervals, so a todo scheduled there would have
+double-booked.
+
+We fix all three at once by deriving the instant the user meant---the
+last moment of the end date---and passing \emph{that} wherever [[end]]
+is treated as a point in time.
+[[end]] itself stays as parsed, so the filter and the option's meaning
+are untouched.
+<<helper functions>>=
+def end_of_day(when):
+  """
+  Returns the last moment of `when`'s date.
+  """
+  return datetime.datetime.combine(when.date(),
+                                   datetime.time.max)
 <<double check [[start]] and [[end]] dates>>=
 end = update_end_date(start, end)
+end_of_range = end_of_day(end)
 @
 
 \paragraph{Testing [[update_end_date]]}
@@ -504,6 +537,42 @@ def test_update_end_date_equal():
   end = datetime.datetime(2024, 3, 1)
   result = update_end_date(start, end)
   assert result == end
+@
+
+\paragraph{Testing [[end_of_day]]}
+
+The helper itself is one line, so the test that matters is the one that
+shows what it buys us.
+We schedule a todo over a range whose only work day \emph{is} the end
+date: with the bare [[end]] the day collapses to a zero-length window
+and nothing is scheduled, while the end of that day leaves the whole
+work window available.
+<<test functions>>=
+def test_end_of_day_covers_the_whole_date():
+  end = datetime.datetime(2024, 1, 15)
+  assert end_of_day(end).date() == end.date()
+  assert end_of_day(end).hour == 23
+
+def test_todos_reach_the_last_shown_day(monkeypatch):
+  """The end date is a day the user can still work."""
+  monkeypatch.setattr(
+    "nytid.cli.todo.load_todos",
+    lambda: (None, [make_fake_todo()]),
+  )
+  monkeypatch.setattr(
+    "nytid.cli.schedule.work_window",
+    lambda: ("09:00", "12:00", ["mon"]),
+  )
+  # Friday; the only work day in range is Monday the 15th.
+  freeze_schedule_now(monkeypatch,
+                      datetime.datetime(2024, 1, 12, 10, 30))
+
+  end = datetime.datetime(2024, 1, 15)
+  assert schedule_todo_events(None, end, []) == []
+
+  events = schedule_todo_events(None, end_of_day(end), [])
+  assert len(events) == 1
+  assert events[0].start.date() == datetime.date(2024, 1, 15)
 @
 
 \subsection{Managing external calendars}
@@ -1360,22 +1429,58 @@ expanded into their occurrences (\cref{ExpandingRecurrences} in the
 schedules chapter).
 The window must cover both consumers of these events: the displayed
 range starts at [[start]], while todo scheduling treats events from
-\emph{now} until [[end]] as occupied time---so the window runs from
-the earlier of the two.
+\emph{now} until the end of the range as occupied time---so the window
+runs from the earlier of the two, and up to [[end_of_range]] so that
+the last shown day is included.
 The window bounds must be timezone aware (the expansion compares them
-against aware event times), whereas [[start]] and [[end]] arrive
-naive from the command line, hence the [[astimezone()]] calls.
+against aware event times), whereas the range bounds are naive, hence
+the [[astimezone()]] calls.
 <<add external calendar events to [[schedule]]>>=
 if not user or user == default_username:
   external_sources = get_external_sources(external)
   cache = build_calendar_cache(no_cache)
   now = datetime.datetime.now().astimezone()
-  window = (min(start.astimezone(), now), end.astimezone())
+  window = (min(start.astimezone(), now),
+            end_of_range.astimezone())
   external_calendar = schedutils.read_calendars(external_sources,
                                                 cache=cache,
                                                 window=window)
   for event in external_calendar.events:
     schedule.add_component(event)
+@
+
+The other consumer of [[end_of_range]] is worth pinning at the command
+level, since the window is assembled inline rather than in a helper we
+could call directly.
+We drive [[show]] with no courses and no todos, stubbing the calendar
+reader to capture the window it is handed.
+<<test functions>>=
+def test_show_window_covers_the_last_shown_day(monkeypatch):
+  """External recurrences must be expanded on the end date too."""
+  from typer.testing import CliRunner
+  captured = {}
+
+  def fake_read_calendars(sources, cache=None, window=None):
+    captured["window"] = window
+    return icalendar.Calendar()
+
+  monkeypatch.setattr(schedule_module.coursescli,
+                      "get_courses_configs", lambda *a, **k: {})
+  monkeypatch.setattr(schedule_module, "get_external_sources",
+                      lambda cli_sources=None: ["external.ics"])
+  monkeypatch.setattr(schedule_module.schedutils, "read_calendars",
+                      fake_read_calendars)
+
+  result = CliRunner().invoke(
+    schedule_module.cli,
+    ["show", "--start", "2024-06-03", "--end", "2024-06-09",
+     "--no-todo"])
+  assert result.exit_code == 0, result.output
+
+  _, window_end = captured["window"]
+  window_end = window_end.astimezone()
+  assert window_end.date() == datetime.date(2024, 6, 9)
+  assert window_end.hour == 23
 @
 
 \paragraph{Opting out of todo scheduling}
@@ -1427,17 +1532,49 @@ and greedily fill the remaining work-hour slots with todos, in the shared
 display order ([[todo ls]]'s ranked-first ordering)---unless the user
 opted out with [[--no-todo]].
 Note that [[start]] plays no role here: todos are scheduled from now
-until [[end]], and the print-time filtering
+until the end of the range, and the print-time filtering
 (\cref{cli.schedule.filter-events}) trims any todo events that fall
 before the shown range.
+We pass [[end_of_range]] for the same reason the recurrence window
+does---the last shown day is a day the user can work.
 [[schedule.events]] holds the \emph{complete} sign-up and external
 calendars---range filtering happens only at print time---so the busy
-intervals between now and a future [[end]] are all known here.
+intervals between now and the end of the range are all known here.
 <<add scheduled todo events to [[schedule]]>>=
 if todo:
   occupied = event_bounds(schedule.events)
-  for event in schedule_todo_events(user, end, occupied):
+  for event in schedule_todo_events(user, end_of_range, occupied):
     schedule.add_component(event)
+@
+
+Let's pin this wiring too, by stubbing the scheduler and inspecting the
+bound it is handed.
+Stubbing also keeps the test away from the running user's real todo
+store.
+<<test functions>>=
+def test_show_schedules_todos_to_the_last_shown_day(monkeypatch):
+  """Todo scheduling gets the same end-of-day bound."""
+  from typer.testing import CliRunner
+  captured = {}
+
+  def fake_schedule_todo_events(user, end, occupied):
+    captured["end"] = end
+    return []
+
+  monkeypatch.setattr(schedule_module.coursescli,
+                      "get_courses_configs", lambda *a, **k: {})
+  monkeypatch.setattr(schedule_module, "get_external_sources",
+                      lambda cli_sources=None: [])
+  monkeypatch.setattr(schedule_module, "schedule_todo_events",
+                      fake_schedule_todo_events)
+
+  result = CliRunner().invoke(
+    schedule_module.cli,
+    ["show", "--start", "2024-06-03", "--end", "2024-06-09",
+     "--todo"])
+  assert result.exit_code == 0, result.output
+  assert captured["end"].date() == datetime.date(2024, 6, 9)
+  assert captured["end"].hour == 23
 @
 
 \subsection{Filter events based on start--end time}

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -1111,6 +1111,18 @@ def schedule_todo_events(user, end, occupied):
 We import [[todo]] here rather than at the top of the file to avoid a
 circular import: [[todo]] imports [[schedule]] for scheduling its items,
 and [[schedule]] needs [[todo]] only for this helper.
+
+The owner test has to honour the convention [[todo]] established: an
+item with no [[who]] belongs to the default user.
+That is not a corner case---[[nytid todo add]] leaves [[who]] unset
+unless the user passes [[--who]], so it is the \emph{ordinary} way to
+record one's own task.
+Comparing [[t.who]] to [[user]] directly therefore filtered out
+precisely the todos most likely to be the user's own, and did so
+silently: they simply never appeared in the schedule.
+Every ownership test in [[todo]] spells the convention out the same
+way, and we match it here so the two views keep agreeing about what
+comes next---the reason the sort order is shared in the first place.
 <<load and filter todos>>=
 from nytid.cli import todo as todocli
 
@@ -1118,7 +1130,8 @@ _, todos = todocli.load_todos()
 todos = [t for t in todos if t.status != "done"]
 
 if user:
-  todos = [t for t in todos if t.who == user]
+  todos = [t for t in todos
+           if (t.who or default_username) == user]
 @
 
 High-urgency items should claim the earliest available slots, so we
@@ -1283,6 +1296,45 @@ def test_schedule_todo_events_mixed_ranked_unranked(monkeypatch):
   assert events[0].summary == "[TODO] ranked"
   assert events[0].start == now.astimezone()
   assert any(e.summary == "[TODO] unranked" for e in events)
+@
+
+The owner filter must read an unset [[who]] as the default user, the
+way the rest of [[todo]] does---otherwise the most ordinary kind of
+todo, added without [[--who]], never reaches the schedule.
+We pass the module's own [[default_username]] rather than a literal, so
+the tests hold for whoever runs them.
+The second test is the other half of the contract: honouring the
+default must not turn the filter into a no-op.
+<<test functions>>=
+def schedule_one_todo_for(monkeypatch, todo_item, user):
+  """Schedules `todo_item` for `user` at a frozen Monday now."""
+  monkeypatch.setattr(
+    "nytid.cli.todo.load_todos",
+    lambda: (None, [todo_item]),
+  )
+  monkeypatch.setattr(
+    "nytid.cli.schedule.work_window",
+    lambda: ("09:00", "12:00", ["mon"]),
+  )
+  freeze_schedule_now(monkeypatch,
+                      datetime.datetime(2024, 1, 8, 10, 30))
+  end = datetime.datetime(2024, 1, 15, 23, 59)
+  return schedule_todo_events(user, end, [])
+
+def test_schedule_todo_events_unset_who_is_default_user(monkeypatch):
+  """An unset owner means the default user, as in todo ls."""
+  events = schedule_one_todo_for(monkeypatch, make_fake_todo(),
+                                 schedule_module.default_username)
+  assert len(events) == 1
+  assert events[0].summary == "[TODO] task"
+
+def test_schedule_todo_events_excludes_other_owner(monkeypatch):
+  """Someone else's todos stay out of my schedule."""
+  item = make_fake_todo()
+  item.who = "somebody-else"
+  events = schedule_one_todo_for(monkeypatch, item,
+                                 schedule_module.default_username)
+  assert events == []
 @
 
 Once we have the course schedule, we merge external calendars and then

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -1444,14 +1444,67 @@ if todo:
 \label{cli.schedule.filter-events}
 
 Before output, we keep only events overlapping the chosen interval.
+
+Which \emph{date} an event falls on depends on the timezone one asks
+in, and the events reaching this filter do not agree on one:
+[[sheets.EventFromCSV]] stores sign-up bookings in UTC, external feeds
+keep whatever zone the publisher used, and the todo events carry the
+local zone.
+The [[start]] and [[end]] bounds, meanwhile, are local dates the user
+typed.
+So the comparison must first put both sides in the same
+timezone---and the right one is the local zone, because that is what
+the output shows: [[format_event_csv]] renders every timestamp through
+[[astimezone()]].
+Comparing in the event's own zone instead made the filter and the
+display disagree around midnight, dropping a booking at 00:30 local
+(22:30 UTC the day before) from a range it would have printed inside,
+and keeping one just past the end for the same reason.
 <<set [[events]] to filtered timeline>>=
 events = []
 for event in schedutils.timeline(schedule):
-  if event.end.date() < start.date():
+  if event.end.astimezone().date() < start.date():
     continue
-  if event.start.date() > end.date():
+  if event.start.astimezone().date() > end.date():
     continue
   events.append(event)
+@
+
+Let's pin the agreement between filter and display.
+The test drives the filter through a helper that reuses the very same
+chunk, so it cannot drift from what [[show]] runs.
+The event is a booking at half past midnight local time---the shape
+that goes wrong---stored in a zone ten hours behind the local one, so
+that its own date is the previous day.
+We derive that zone from the current local offset rather than naming
+UTC, because whether UTC is behind or ahead depends on where the test
+runs, and the assertion should not.
+<<test functions>>=
+def filter_events_for_range(schedule, start, end):
+  """Runs show's print-time range filter over `schedule`."""
+  <<set [[events]] to filtered timeline>>
+  return events
+
+def test_filter_keeps_event_shown_on_start_date():
+  """The range filter must agree with the local-time display."""
+  local_start = datetime.datetime(2024, 6, 3, 0, 30).astimezone()
+  behind = datetime.timezone(local_start.utcoffset()
+                             - datetime.timedelta(hours=10))
+  event = icalendar.Event()
+  event.summary = "Early booking"
+  event.start = local_start.astimezone(behind)
+  event.end = (local_start
+               + datetime.timedelta(hours=1)).astimezone(behind)
+  assert event.end.date() < datetime.date(2024, 6, 3)  # premise
+
+  schedule = icalendar.Calendar()
+  schedule.add_component(event)
+  kept = filter_events_for_range(
+    schedule,
+    datetime.datetime(2024, 6, 3),
+    datetime.datetime(2024, 6, 10),
+  )
+  assert [e.summary for e in kept] == ["Early booking"]
 @
 
 \subsection{Output format}

--- a/src/nytid/cli/signupsheets.nw
+++ b/src/nytid/cli/signupsheets.nw
@@ -171,11 +171,44 @@ for (course, register), course_conf in courses.items():
   <<set [[outfile]] for [[course]]>>
 
   url = course_conf.get("ics")
-  sheets.generate_signup_sheet(outfile, url, needed_TAs)
+  sheets.generate_signup_sheet(outfile, url, needed_TAs,
+                               window=sheet_window)
   <<open [[outfile]] for editing if requested>>
 <<imports>>=
 from nytid.signup import sheets
 from nytid.signup import utils
+@
+
+The rows of the sheet are the individual teaching sessions, but a
+TimeEdit schedule states a recurring session once and leaves its
+occurrences implicit, so the calendar has to be expanded---and
+expansion has to be bounded, since an [[RRULE]] need not ever end.
+The command has no date range of its own to bound it with: a sign-up
+sheet covers \enquote{the course}, whose term the user never states.
+We therefore use the library's default horizon
+(\cref{ExpandingRecurrences} in the schedules chapter), which brackets
+any course generously in both directions---generously enough that a
+sheet generated before the term starts, or during it, covers the same
+sessions either way.
+We compute it once per invocation, alongside the timestamp, so every
+course in the run gets the same range.
+<<generation iteration variables>>=
+sheet_window = schedutils.default_window()
+@
+
+The stub above records the keyword arguments it is called with, so we
+can check that the window reaches the generator at all---the difference
+between a sheet with every session on it and one with only the first.
+<<test functions>>=
+def test_generate_passes_an_expansion_window(monkeypatch, tmp_path):
+  """Recurring sessions need a window to become rows."""
+  written = stub_sheet_generation(monkeypatch, ["good"],
+                                  {"good": tmp_path})
+  generate_signup_sheet(".*")
+  _, kwargs = written[0]
+  start, end = kwargs["window"]
+  now = datetime.datetime.now().astimezone()
+  assert start < now < end
 @
 
 By default, [[utils.needed_TAs]] uses the 12 as the group size.
@@ -293,7 +326,8 @@ def stub_sheet_generation(monkeypatch, courses, data_dirs):
   written = []
   monkeypatch.setattr(
     signupsheets_module.sheets, "generate_signup_sheet",
-    lambda outfile, url, needed_TAs: written.append(str(outfile)),
+    lambda outfile, url, needed_TAs, **kwargs:
+      written.append((str(outfile), kwargs)),
   )
   return written
 
@@ -304,7 +338,7 @@ def test_generate_skips_course_without_data_dir(monkeypatch, tmp_path):
                                   {"good": tmp_path})
   generate_signup_sheet(".*")
   assert len(written) == 1
-  assert "good" in written[0]
+  assert "good" in written[0][0]
 
 def test_generate_skips_first_course_without_data_dir(monkeypatch):
   """A failing first course must not raise UnboundLocalError."""

--- a/src/nytid/cli/signupsheets.nw
+++ b/src/nytid/cli/signupsheets.nw
@@ -221,13 +221,96 @@ if not outpath:
     outfile = data_root.path / f"signup-{course}-{timestamp}.csv"
 else:
   outfile = outpath / f"signup-{course}-{timestamp}.csv"
+@
+
+Both failure modes must leave [[outfile]] in a defined state, because
+the code that consumes it---the call to [[sheets.generate_signup_sheet]]
+above---sits outside this chunk and runs unconditionally.
+This is the noweb chunk-dependency hazard in its purest form: the chunk
+that \emph{assigns} the variable is the [[else]] arm, so an [[except]]
+arm that neither assigns nor leaves the loop hands the generator a
+stale [[outfile]].
+And [[outfile]] is stale in a specific, harmful way: it still holds the
+\emph{previous} course's path, so the failing course's events would be
+written over a sheet named after a course they do not belong to---or,
+if the very first course fails, [[outfile]] is unbound and the command
+dies with [[UnboundLocalError]].
+
+The two failures therefore need different answers.
+A [[PermissionError]] means we know where the sheet belongs but may not
+write there, so falling back to the working directory still produces
+the sheet the user asked for.
+A [[KeyError]] means the course has no data directory registered at
+all; there is no defensible place to put its sheet, so we skip the
+course---the same response the [[group_size]] chunk above gives to a
+course whose configuration it cannot use.
 <<handle errors for accessing course data directory>>=
 except KeyError as err:
-  logging.warning(err)
+  logging.warning(f"Can't find the data directory for {course} in "
+                  f"{register}: {err}")
+  continue
 except PermissionError as err:
   logging.warning(f"You don't have access to {course} in {register}: {err}")
   outfile = f"./signup-{course}-{timestamp}.csv"
   logging.warning(f"Writing file to current working directory: {outfile}")
+@
+
+Let's verify that a course without a data directory is skipped rather
+than allowed to borrow another course's path.
+The first test drives two courses where only the second fails, which is
+the silent-overwrite case; the second drives a single failing course,
+which is the [[UnboundLocalError]] case.
+We stub the sheet generator so the tests observe which paths would have
+been written without touching the network or the file system.
+<<test functions>>=
+def make_course_config():
+  """Returns a course config with the fields generate reads."""
+  conf = MagicMock()
+  conf.get.side_effect = lambda key: {
+    "num_students": "120",
+    "num_groups": "10",
+    "ics": "http://example/cal.ics",
+  }[key]
+  return conf
+
+def stub_sheet_generation(monkeypatch, courses, data_dirs):
+  """Stubs course lookup and generation; returns written paths."""
+  monkeypatch.setattr(
+    signupsheets_module.coursescli, "get_courses_configs",
+    lambda course, register: {
+      (name, "reg"): make_course_config() for name in courses
+    },
+  )
+
+  def fake_get_course_data(course, register):
+    if course not in data_dirs:
+      raise KeyError(course)
+    return MagicMock(path=data_dirs[course])
+
+  monkeypatch.setattr(signupsheets_module.courseutils,
+                      "get_course_data", fake_get_course_data)
+
+  written = []
+  monkeypatch.setattr(
+    signupsheets_module.sheets, "generate_signup_sheet",
+    lambda outfile, url, needed_TAs: written.append(str(outfile)),
+  )
+  return written
+
+def test_generate_skips_course_without_data_dir(monkeypatch, tmp_path):
+  """A failing course must not overwrite the previous one's sheet."""
+  written = stub_sheet_generation(monkeypatch,
+                                  ["good", "bad"],
+                                  {"good": tmp_path})
+  generate_signup_sheet(".*")
+  assert len(written) == 1
+  assert "good" in written[0]
+
+def test_generate_skips_first_course_without_data_dir(monkeypatch):
+  """A failing first course must not raise UnboundLocalError."""
+  written = stub_sheet_generation(monkeypatch, ["bad"], {})
+  generate_signup_sheet(".*")
+  assert written == []
 @
 
 Now, to compute [[timestamp]] we'll need the current time and then we simply 

--- a/src/nytid/cli/utils/rooms.nw
+++ b/src/nytid/cli/utils/rooms.nw
@@ -106,34 +106,116 @@ return a CSV (list of tuples) of the free rooms:
 
 [(start, end, unbooked_rooms), ...]
 
-where start and end are datetime objects and unbooked_rooms is a set of 
+where start and end are strings and unbooked_rooms is a set of
 strings.
+@
+
+The tempting implementation---for each event, report every interesting
+room it does not book---is wrong, and wrong in the direction that gets
+someone turned away at a door.
+Freedom is a property of an \emph{instant}, not of an event: a room is
+free at some moment only if \emph{no} event books it then.
+Deriving the answer one event at a time can only ever consult one
+event, so with D1 booked 15--17 and D2 booked 15--16 it happily reports
+D1 free for the second row's 15--16 and D2 free for the first row's
+15--17.
+Both statements are false during the hour they overlap, and the
+command's help text invites the user to act on them.
+That the schedule contains such partial overlaps is not speculation:
+the [[booked]] command exists precisely because \enquote{some rooms are
+booked 15--17 and some 15--16}.
+
+So we invert the loop.
+First we cut the timeline at every point where anything starts or
+ends.
+Between two consecutive cuts nothing changes---by construction, no
+booking begins or ends there---so each such \emph{atomic} interval has
+a single, well-defined set of booked rooms, and subtracting it from the
+interesting rooms gives an answer that holds for the whole interval.
+Cutting this finely would make the output unreadable, though, so we
+glue back together any neighbours that turned out to say the same
+thing.
 <<helper functions>>=
 def free_rooms(ics_url: str) -> list[tuple]:
   """
   <<[[free_rooms]] doc>>
   """
-  results = []
   all_rooms = set(typerconf.get(INTERESTING_ROOMS))
 
   <<let [[schedule]] be the parsed ICS file we get from [[ics_url]]>>
-  for event in schedule.events:
-    start = event.start
-    end = event.end
-
-    <<let [[booked_rooms]] be the rooms of [[event]]>>
-
-    # If there are no booked rooms, we can skip this event.
-    if not booked_rooms:
-      continue
-
-    unbooked_rooms = all_rooms - booked_rooms
-    results.append((start, end, unbooked_rooms))
-
-  <<clean up [[results]]>>
+  <<let [[bookings]] be the room bookings in [[schedule]]>>
+  <<let [[results]] be the free rooms per atomic interval>>
+  <<merge neighbours that free the same rooms>>
+  <<format [[results]] for output>>
   return results
 <<imports>>=
 import datetime
+@
+
+Gathering the bookings is the old loop with its conclusion removed: we
+keep what each event books instead of deciding, then and there, what it
+leaves free.
+<<let [[bookings]] be the room bookings in [[schedule]]>>=
+bookings = []
+for event in schedule.events:
+  <<let [[booked_rooms]] be the rooms of [[event]]>>
+
+  # If there are no booked rooms, we can skip this event.
+  if not booked_rooms:
+    continue
+
+  bookings.append((event.start, event.end, booked_rooms))
+@
+
+The cut points are every start and every end, deduplicated and sorted;
+consecutive pairs of them are the atomic intervals.
+An interval that no booking overlaps gets no row, because the command
+documents an absent time as one where every room is free---emitting it
+would say the same thing at greater length.
+An interval where every interesting room is booked \emph{does} get a
+row, empty set and all: silence already means \enquote{everything
+free}, so an empty row is the only way left to say the opposite.
+<<let [[results]] be the free rooms per atomic interval>>=
+cuts = sorted({moment for start, end, _ in bookings
+                      for moment in (start, end)})
+results = []
+for start, end in zip(cuts, cuts[1:]):
+  booked = set()
+  for booking_start, booking_end, rooms in bookings:
+    if booking_start < end and booking_end > start:
+      booked |= rooms
+
+  if not booked:
+    continue
+
+  results.append((start, end, all_rooms - booked))
+@
+
+Neighbours that free exactly the same rooms describe one uninterrupted
+stretch, and the cut between them was an artefact of some \emph{other}
+room's booking changing.
+Extending the previous row rather than appending a new one restores the
+reading a person expects: back-to-back lectures in D1 are one span
+during which D2 and D3 are free, not two.
+<<merge neighbours that free the same rooms>>=
+merged = []
+for start, end, unbooked_rooms in results:
+  if merged and merged[-1][1] == start \
+             and merged[-1][2] == unbooked_rooms:
+    merged[-1] = (merged[-1][0], end, unbooked_rooms)
+  else:
+    merged.append((start, end, unbooked_rooms))
+
+results = merged
+@
+
+The rows come out in chronological order already, since they are built
+by walking the sorted cut points, so formatting is all that remains.
+<<format [[results]] for output>>=
+results = [(start.strftime(DATE_FORMAT),
+            end.strftime(DATE_FORMAT),
+            unbooked_rooms)
+           for start, end, unbooked_rooms in results]
 @
 
 A TimeEdit feed carries the rooms as a comma-separated list in
@@ -169,28 +251,7 @@ from nytid.schedules import read_calendar
 @
 
 
-\subsection{Clean up the results}
-
-Now that we have the CSV, we just have to merge all the overlap.
-We'll make it a simple algorithm:
-If the start and end are the same, merge them by taking the union.
-
-We'll use a dictionary to keep track of start and end times that are the same.
-We use the start and end as the key, the free rooms as the value.
-Then we can merge whenever the key already exists.
-<<clean up [[results]]>>=
-time_dict = {}
-for start, end, unbooked_rooms in results:
-  if (start, end) in time_dict:
-    time_dict[(start, end)] |= unbooked_rooms
-  else:
-    time_dict[(start, end)] = unbooked_rooms
-
-results = [(start.strftime(DATE_FORMAT),
-            end.strftime(DATE_FORMAT),
-            unbooked_rooms)
-           for (start, end), unbooked_rooms in time_dict.items()]
-results.sort()
+Both commands print timestamps, so they share one format.
 <<constants>>=
 DATE_FORMAT = "%Y-%m-%d %H:%M"
 @
@@ -264,6 +325,95 @@ def test_free_rooms_missing_location():
     assert len(result) == 1
     _, _, rooms = result[0]
     assert rooms == {"D2"}
+@
+
+The case the per-event computation got wrong is two bookings that
+overlap without sharing both endpoints.
+D1 is taken 15--17 and D2 only 15--16, so during the first hour nothing
+but D3 is free, and only in the second hour does D2 open up.
+The old code reported D1 free during 15--16, which is the answer that
+sends someone to a room in use.
+<<test functions>>=
+def test_free_rooms_partial_overlap():
+  """A room booked 15-17 is not free during 15-16."""
+  cal = make_schedule([
+    ("Long", "2024-01-15T15:00:00+01:00",
+     "2024-01-15T17:00:00+01:00", "D1"),
+    ("Short", "2024-01-15T15:00:00+01:00",
+     "2024-01-15T16:00:00+01:00", "D2"),
+  ])
+  with patch("nytid.cli.utils.rooms.read_calendar",
+             return_value=cal), \
+       patch("typerconf.get",
+             return_value=["D1", "D2", "D3"]):
+    result = free_rooms("http://example.com")
+    assert result == [
+      ("2024-01-15 15:00", "2024-01-15 16:00", {"D3"}),
+      ("2024-01-15 16:00", "2024-01-15 17:00", {"D2", "D3"}),
+    ]
+@
+
+Cutting at every boundary would also split runs that say the same
+thing, so the other half of the contract is that such runs come back
+out as one row: two back-to-back lectures in D1 leave D2 and D3 free
+for one continuous stretch, not two.
+<<test functions>>=
+def test_free_rooms_merges_adjacent_identical():
+  """Back-to-back bookings of one room give one free row."""
+  cal = make_schedule([
+    ("Lecture A", "2024-01-15T10:00:00+01:00",
+     "2024-01-15T11:00:00+01:00", "D1"),
+    ("Lecture B", "2024-01-15T11:00:00+01:00",
+     "2024-01-15T12:00:00+01:00", "D1"),
+  ])
+  with patch("nytid.cli.utils.rooms.read_calendar",
+             return_value=cal), \
+       patch("typerconf.get",
+             return_value=["D1", "D2", "D3"]):
+    result = free_rooms("http://example.com")
+    assert result == [
+      ("2024-01-15 10:00", "2024-01-15 12:00", {"D2", "D3"}),
+    ]
+@
+
+Finally, the two ways of saying \enquote{nothing to offer} must stay
+distinguishable.
+A gap between bookings carries no row, since an absent time already
+means every room is free; an interval in which every interesting room
+is taken carries a row with nothing in it, which is the only remaining
+way to say so.
+<<test functions>>=
+def test_free_rooms_skips_gaps_between_bookings():
+  """A time with no booking is absent, meaning all rooms free."""
+  cal = make_schedule([
+    ("Morning", "2024-01-15T10:00:00+01:00",
+     "2024-01-15T11:00:00+01:00", "D1"),
+    ("Afternoon", "2024-01-15T14:00:00+01:00",
+     "2024-01-15T15:00:00+01:00", "D1"),
+  ])
+  with patch("nytid.cli.utils.rooms.read_calendar",
+             return_value=cal), \
+       patch("typerconf.get",
+             return_value=["D1", "D2"]):
+    result = free_rooms("http://example.com")
+    assert [(start, end) for start, end, _ in result] == [
+      ("2024-01-15 10:00", "2024-01-15 11:00"),
+      ("2024-01-15 14:00", "2024-01-15 15:00"),
+    ]
+
+def test_free_rooms_reports_fully_booked_intervals():
+  """No room left free is still worth a row, unlike silence."""
+  cal = make_schedule([
+    ("Event", "2024-01-15T10:00:00+01:00",
+     "2024-01-15T12:00:00+01:00", "D1, D2"),
+  ])
+  with patch("nytid.cli.utils.rooms.read_calendar",
+             return_value=cal), \
+       patch("typerconf.get",
+             return_value=["D1", "D2"]):
+    assert free_rooms("http://example.com") == [
+      ("2024-01-15 10:00", "2024-01-15 12:00", set()),
+    ]
 @
 
 
@@ -346,36 +496,47 @@ def booked_cmd(<<arg [[delimiter]]>>):
     raise typer.Exit(1)
 @
 
-Now we implement the [[booked_rooms]] function similarly to the [[free_rooms]] 
-function.
+This function reuses the gathering step of [[free_rooms]] but stops
+there: reporting what is booked is exactly reporting the bookings, so
+cutting the timeline into atomic intervals would only obscure the
+answer.
+Where [[free_rooms]] must reason about instants---a claim of freedom is
+falsified by any overlapping booking---a claim that a room \emph{is}
+booked from 15 to 17 stands on its own, and keeping the interval the
+schedule states is what makes this command useful for spotting the
+ragged overlaps [[free_rooms]] has to work around.
+
+The one thing worth combining is bookings that state the same interval,
+which are one occasion split across rows; their union reads better than
+two rows.
 <<helper functions>>=
 def booked_rooms(ics_url: str) -> list[tuple]:
   """
-  Given a URL or path to a TimeEdit ICS file ([[ics_url]]),
-  return a ics (list of tuples) of the booked rooms:
+  Given a URL or path to a TimeEdit ICS file (`ics_url`),
+  return a list of tuples of the booked rooms:
 
   [(start, end, booked_rooms), ...]
 
-  where start and end are datetime objects and booked_rooms is a set of 
+  where start and end are strings and booked_rooms is a set of
   strings.
   """
-  results = []
-
   <<let [[schedule]] be the parsed ICS file we get from [[ics_url]]>>
-  for event in schedule.events:
-    start = event.start
-    end = event.end
-
-    <<let [[booked_rooms]] be the rooms of [[event]]>>
-
-    # If there are no booked rooms, we can skip this event.
-    if not booked_rooms:
-      continue
-
-    results.append((start, end, booked_rooms))
-
-  <<clean up [[results]]>>
+  <<let [[bookings]] be the room bookings in [[schedule]]>>
+  <<merge bookings stating the same interval>>
+  <<format [[results]] for output>>
   return results
+@
+
+<<merge bookings stating the same interval>>=
+time_dict = {}
+for start, end, rooms in bookings:
+  if (start, end) in time_dict:
+    time_dict[(start, end)] |= rooms
+  else:
+    time_dict[(start, end)] = rooms
+
+results = [(start, end, rooms)
+           for (start, end), rooms in sorted(time_dict.items())]
 @
 
 \subsection{Testing [[booked_rooms]]}

--- a/src/nytid/cli/utils/rooms.nw
+++ b/src/nytid/cli/utils/rooms.nw
@@ -121,8 +121,7 @@ def free_rooms(ics_url: str) -> list[tuple]:
     start = event.start
     end = event.end
 
-    booked_rooms = event.location.split(",")
-    <<turn [[booked_rooms]] into a set, properly>>
+    <<let [[booked_rooms]] be the rooms of [[event]]>>
 
     # If there are no booked rooms, we can skip this event.
     if not booked_rooms:
@@ -137,9 +136,22 @@ def free_rooms(ics_url: str) -> list[tuple]:
 import datetime
 @
 
-If there are no booked rooms for a time, we get an empty string in a 
-list---which will not be an empty set.
-<<turn [[booked_rooms]] into a set, properly>>=
+A TimeEdit feed carries the rooms as a comma-separated list in
+[[LOCATION]], so splitting on commas is all the parsing we need.
+The care goes into the two ways an event can fail to name a room, which
+[[icalendar]] reports differently.
+An event with an \emph{empty} [[LOCATION]] yields the empty string,
+which splits into a one-element list holding an empty string---not an
+empty set.
+An event with \emph{no} [[LOCATION]] property at all yields [[None]],
+and calling [[split]] on that raises [[AttributeError]]; since the
+whole query runs inside one [[try]], a single such event used to abort
+[[nytid utils rooms unbooked]] and [[booked]] with no output at all.
+Coercing with [[or ""]] folds the missing case into the empty case,
+which the check below already handles---and matches how
+[[schedules.format_event_csv]] treats the same property.
+<<let [[booked_rooms]] be the rooms of [[event]]>>=
+booked_rooms = (event.location or "").split(",")
 if len(booked_rooms) == 1 and booked_rooms[0].strip() == "":
   booked_rooms = set()
 else:
@@ -228,6 +240,30 @@ def test_free_rooms_empty_location():
              return_value=["D1", "D2"]):
     result = free_rooms("http://example.com")
     assert len(result) == 0
+@
+
+An event with no [[LOCATION]] property must be skipped just as quietly.
+We put a normal booking after it so the assertion distinguishes
+\enquote{skipped the bad event} from \enquote{gave up on the feed}:
+before the fix the [[AttributeError]] escaped and no results were
+produced at all.
+<<test functions>>=
+def test_free_rooms_missing_location():
+  """An event without LOCATION must not abort the query."""
+  cal = make_schedule([
+    ("Holiday", "2024-01-15T00:00:00+01:00",
+     "2024-01-15T23:59:00+01:00", None),
+    ("Event", "2024-01-16T10:00:00+01:00",
+     "2024-01-16T12:00:00+01:00", "D1"),
+  ])
+  with patch("nytid.cli.utils.rooms.read_calendar",
+             return_value=cal), \
+       patch("typerconf.get",
+             return_value=["D1", "D2"]):
+    result = free_rooms("http://example.com")
+    assert len(result) == 1
+    _, _, rooms = result[0]
+    assert rooms == {"D2"}
 @
 
 
@@ -330,8 +366,7 @@ def booked_rooms(ics_url: str) -> list[tuple]:
     start = event.start
     end = event.end
 
-    booked_rooms = event.location.split(",")
-    <<turn [[booked_rooms]] into a set, properly>>
+    <<let [[booked_rooms]] be the rooms of [[event]]>>
 
     # If there are no booked rooms, we can skip this event.
     if not booked_rooms:
@@ -374,6 +409,21 @@ def test_booked_rooms_merges_overlap():
     assert len(result) == 1
     _, _, rooms = result[0]
     assert rooms == {"D1", "D2"}
+
+def test_booked_rooms_missing_location():
+  """An event without LOCATION must not abort the query."""
+  cal = make_schedule([
+    ("Holiday", "2024-01-15T00:00:00+01:00",
+     "2024-01-15T23:59:00+01:00", None),
+    ("Event", "2024-01-16T10:00:00+01:00",
+     "2024-01-16T12:00:00+01:00", "D1"),
+  ])
+  with patch("nytid.cli.utils.rooms.read_calendar",
+             return_value=cal):
+    result = booked_rooms("http://example.com")
+    assert len(result) == 1
+    _, _, rooms = result[0]
+    assert rooms == {"D1"}
 @
 
 
@@ -396,16 +446,23 @@ from nytid.cli.utils.rooms import *
 @
 
 We build a mock calendar with events that have known rooms and times.
+A location of [[None]] means the event carries no [[LOCATION]] property
+at all, which is a different case from an empty one---and the case that
+used to crash the room commands.
 <<test helper: make rooms schedule>>=
 def make_schedule(events_data):
-  """Build a Calendar with events from (name, start, end, location)."""
+  """Build a Calendar with events from (name, start, end, location).
+
+  A location of None omits the LOCATION property entirely.
+  """
   cal = icalendar.Calendar()
   for name, start, end, location in events_data:
     e = icalendar.Event()
     e.summary = name
     e.start = datetime.datetime.fromisoformat(start)
     e.end = datetime.datetime.fromisoformat(end)
-    e.location = location
+    if location is not None:
+      e.location = location
     cal.add_component(e)
   return cal
 @

--- a/src/nytid/schedules.nw
+++ b/src/nytid/schedules.nw
@@ -1358,13 +1358,27 @@ def event_filter(events, whitelisted=TIMEEDIT_EVENTS):
     <<whitelisted events>>
   """
   for event in events:
+    summary = event.summary or ""
     for event_type in whitelisted:
-      if re.match(f"^{event_type}(,|\\s|$)", event.summary):
+      if re.match(f"^{event_type}(,|\\s|$)", summary):
         yield event
         break
 <<imports>>=
 import re
 @
+
+A [[VEVENT]] need not carry a [[SUMMARY]], and [[icalendar]] reports
+the absent property as [[None]] rather than an empty string, which
+[[re.match]] rejects with [[TypeError]].
+That exception surfaces at whoever drains the generator, and the two
+consumers fail differently and badly: [[schedule show]] catches it in
+its per-course handler and drops the \emph{entire course} from the
+schedule, while [[signupsheets generate]] has no such guard and shows
+the user a traceback.
+Coercing to the empty string is not merely defensive here---it is the
+whitelist's own answer.
+An unnamed event matches no entry, so it is excluded, which is exactly
+what the whitelist promises for anything it does not recognize.
 
 The events that we whitelist are taken from TimeEdits activity types\footnote{%
   URL: 
@@ -1442,6 +1456,20 @@ def test_event_filter_custom_whitelist():
 def test_event_filter_empty():
   result = list(event_filter([]))
   assert result == []
+@
+
+An event without a [[SUMMARY]] must be dropped like any other
+unrecognized event, not raise.
+We pair it with a matching event so the assertion tells apart
+\enquote{dropped the unnamed event} from \enquote{abandoned the feed}.
+<<test functions>>=
+def test_event_filter_missing_summary():
+  """An event without SUMMARY is dropped, not fatal."""
+  unnamed = icalendar.Event()
+  events = [unnamed, make_event(name="Laboration")]
+  result = list(event_filter(events))
+  assert len(result) == 1
+  assert result[0].summary == "Laboration"
 @
 
 

--- a/src/nytid/schedules.nw
+++ b/src/nytid/schedules.nw
@@ -443,6 +443,54 @@ we normalize here: dates become local midnight, naive times are
 interpreted as local time.
 Local is the right reading for both---an all-day event on the 15th
 means the 15th in the user's calendar, not in UTC.
+
+\paragraph{What \enquote{local} must mean}
+
+The obvious way to say \enquote{local} in Python is the no-argument
+[[datetime.astimezone()]], and that is what this function used to do.
+It produces a timezone-\emph{aware} value, so the invariant above
+holds---but the zone it attaches is a fixed offset
+([[datetime.timezone(datetime.timedelta(hours=2))]]), namely the offset
+that happened to be in effect at that one instant.
+A fixed offset has no daylight-saving rules, and that difference
+escapes as soon as anything derives a \emph{new} datetime from the
+value.
+Recurrence expansion (\cref{ExpandingRecurrences}) does exactly that:
+every occurrence of an [[RRULE]] inherits [[DTSTART]]'s [[tzinfo]], so
+a weekly meeting anchored in summer keeps reporting the summer offset
+all winter, and every occurrence past the October changeover is off by
+an hour.
+For an all-day event the error is worse than an hour: local midnight
+under the wrong offset falls at 23:00 the previous day, which changes
+the date, the weekday, and the ISO week number the schedule prints.
+
+So we attach the local \emph{zone} rather than the local offset.
+[[zoneinfo]] can build one from an IANA name, and [[tzlocal]] is what
+tells us which name the host is configured for---the standard library
+exposes no portable way to ask.
+We resolve it through a function rather than a module-level constant so
+that a process which changes its timezone, and a test that fakes one,
+both see the change.
+<<functions>>=
+def local_timezone():
+  """
+  Returns the host's local timezone as a `zoneinfo.ZoneInfo`.
+
+  Unlike the fixed offset that `datetime.astimezone()` attaches, the
+  returned zone carries the daylight-saving rules, so datetimes derived
+  from it get the offset in effect at their own time.
+  """
+  return zoneinfo.ZoneInfo(tzlocal.get_localzone_name())
+<<imports>>=
+import tzlocal
+import zoneinfo
+@
+
+With that settled, parsing is a sweep over the events, rewriting the
+two properties that carry times.
+We resolve the zone once per calendar rather than once per property:
+the answer cannot change while we parse, and the lookup reads the
+host's timezone configuration.
 <<functions>>=
 def parse_calendar(text):
   """
@@ -454,6 +502,7 @@ def parse_calendar(text):
   time. Raises ValueError if `text` is not valid ICS.
   """
   cal = icalendar.Calendar.from_ical(text)
+  local = local_timezone()
   for event in cal.events:
     for name in ("DTSTART", "DTEND"):
       <<normalize the [[name]] property of [[event]]>>
@@ -466,6 +515,10 @@ bare datetimes.
 The [[datetime]]-before-[[date]] test order matters:
 [[datetime.datetime]] is a subclass of [[datetime.date]], so testing
 [[date]] first would match everything.
+A floating time is normalized with [[replace]] rather than a
+conversion: the wall-clock reading is the part we trust---\enquote{ten
+o'clock} means ten o'clock here---and [[replace]] keeps it while
+declaring which zone it is read in.
 <<normalize the [[name]] property of [[event]]>>=
 value = event.get(name)
 if value is None:
@@ -473,10 +526,10 @@ if value is None:
 if isinstance(value.dt, datetime.datetime):
   if value.dt.tzinfo is None:
     del event[name]
-    event.add(name, value.dt.astimezone())
+    event.add(name, value.dt.replace(tzinfo=local))
 elif isinstance(value.dt, datetime.date):
   midnight = datetime.datetime(value.dt.year, value.dt.month,
-                               value.dt.day).astimezone()
+                               value.dt.day, tzinfo=local)
   del event[name]
   event.add(name, midnight)
 @
@@ -702,6 +755,90 @@ def test_no_window_keeps_master_event(tmp_path):
   path.write_text(make_recurring_ics())
   cal = read_calendar(str(path))
   assert len(cal.events) == 1
+@
+
+Expansion is also where the choice of [[tzinfo]] in
+\cref{ParsingCalendars} becomes observable, so this is where we pin it.
+Both tests below fake the local zone to Europe/Stockholm rather than
+setting [[TZ]] in the environment: the assertions must hold whatever
+timezone the developer's machine is in, and faking the resolver keeps
+the effect contained to the test instead of mutating process-global
+state.
+
+A floating weekly event anchored on 20 October 2024 crosses the
+European changeover the following week.
+Its wall-clock reading must stay at ten o'clock for every occurrence;
+with a fixed offset the later ones drift to nine.
+<<test functions>>=
+STOCKHOLM = "Europe/Stockholm"
+
+def fake_local_zone(monkeypatch, name=STOCKHOLM):
+  """Pins schedules' idea of the local zone; returns the zone."""
+  import zoneinfo
+  zone = zoneinfo.ZoneInfo(name)
+  monkeypatch.setattr(nytid.schedules, "local_timezone",
+                      lambda: zone)
+  return zone
+
+def make_dst_crossing_ics():
+  """Weekly floating event crossing the October 2024 changeover."""
+  return """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+SUMMARY:Weekly meeting
+DTSTART:20241020T100000
+DTEND:20241020T110000
+RRULE:FREQ=WEEKLY;COUNT=4
+END:VEVENT
+END:VCALENDAR"""
+
+def test_recurrence_keeps_wall_clock_across_dst(tmp_path,
+                                                monkeypatch):
+  zone = fake_local_zone(monkeypatch)
+  path = tmp_path / "dst.ics"
+  path.write_text(make_dst_crossing_ics())
+  window = (datetime.datetime(2024, 10, 1, tzinfo=zone),
+            datetime.datetime(2024, 11, 30, tzinfo=zone))
+  cal = read_calendar(str(path), window=window)
+  assert len(cal.events) == 4
+  hours = {event.start.astimezone(zone).hour
+           for event in cal.events}
+  assert hours == {10}
+@
+
+The all-day case is the same defect with a coarser symptom.
+A Monday all-day series anchored in January expands into July, where a
+frozen winter offset would place every occurrence at 23:00 on the
+preceding Sunday---a different date, weekday and ISO week than the one
+the calendar states.
+<<test functions>>=
+def make_all_day_recurring_ics():
+  """Weekly all-day event anchored on Monday 15 January 2024."""
+  return """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+SUMMARY:All day weekly
+DTSTART;VALUE=DATE:20240115
+DTEND;VALUE=DATE:20240116
+RRULE:FREQ=WEEKLY;COUNT=30
+END:VEVENT
+END:VCALENDAR"""
+
+def test_all_day_recurrence_keeps_date_across_dst(tmp_path,
+                                                  monkeypatch):
+  zone = fake_local_zone(monkeypatch)
+  path = tmp_path / "allday.ics"
+  path.write_text(make_all_day_recurring_ics())
+  window = (datetime.datetime(2024, 7, 1, tzinfo=zone),
+            datetime.datetime(2024, 7, 31, tzinfo=zone))
+  cal = read_calendar(str(path), window=window)
+  assert cal.events
+  for event in cal.events:
+    local = event.start.astimezone(zone)
+    assert local.hour == 0
+    assert local.weekday() == 0  # still a Monday
 @
 
 \subsection{Iterating events in chronological order}

--- a/src/nytid/schedules.nw
+++ b/src/nytid/schedules.nw
@@ -722,6 +722,30 @@ def expand_recurrences(calendar, window):
 import recurring_ical_events
 @
 
+Not every caller has a date range to offer, though.
+Exporting an ICS feed or writing a sign-up sheet covers \enquote{the
+course}, not a week the user picked---yet these callers need the
+occurrences just as much, since a sheet listing one row for a weekly
+lab is worse than useless.
+Leaving [[window]] unset is not an option for them, and inventing a
+range at each call site would scatter the same arbitrary choice around
+the code base.
+We therefore name the choice once: a span of [[horizon]] on either side
+of now.
+A year in each direction comfortably brackets any course while keeping
+the expansion finite, and the symmetry means a caller never has to
+reason about whether its data lies in the past or the future.
+<<functions>>=
+def default_window(horizon=datetime.timedelta(days=366)):
+  """
+  Returns a (start, end) window spanning `horizon` on either side of
+  now, for callers that need recurrences expanded but have no date
+  range of their own.
+  """
+  now = datetime.datetime.now().astimezone()
+  return (now - horizon, now + horizon)
+@
+
 Let's verify both behaviours with a weekly event: a window covering
 three occurrences yields three events, while no window preserves the
 single master event.
@@ -755,6 +779,23 @@ def test_no_window_keeps_master_event(tmp_path):
   path.write_text(make_recurring_ics())
   cal = read_calendar(str(path))
   assert len(cal.events) == 1
+@
+
+The default window has to be usable as a window---aware bounds
+straddling now---which is all a caller may assume about it.
+<<test functions>>=
+def test_default_window_brackets_now():
+  start, end = default_window()
+  now = datetime.datetime.now().astimezone()
+  assert start < now < end
+  assert start.tzinfo is not None and end.tzinfo is not None
+
+def test_default_window_honours_horizon(tmp_path):
+  """A short horizon still expands, but only nearby occurrences."""
+  path = tmp_path / "recurring.ics"
+  path.write_text(make_recurring_ics())
+  window = default_window(datetime.timedelta(days=1))
+  assert len(read_calendar(str(path), window=window).events) == 0
 @
 
 Expansion is also where the choice of [[tzinfo]] in

--- a/src/nytid/signup/sheets.nw
+++ b/src/nytid/signup/sheets.nw
@@ -62,7 +62,7 @@ def generate_signup_sheet(outfile, url,
   <<let [[out]] be [[outfile]] open for writing>>
   with out:
     csvout = csv.writer(out, delimiter="\t")
-    calendar = nytid.schedules.read_calendar(url)
+    calendar = nytid.schedules.read_calendar(url, window=window)
 
     max_num_TAs = 0
     rows = []
@@ -87,6 +87,68 @@ try:
 except FileNotFoundError:
   os.makedirs(os.path.dirname(outfile), exist_ok=True)
   out = open(outfile, "w")
+@
+
+A TimeEdit schedule states a weekly lab \emph{once}, as a single
+[[VEVENT]] carrying an [[RRULE]]; the individual sessions are implicit
+until something expands them
+(\cref{ExpandingRecurrences} in the schedules chapter).
+A sign-up sheet is precisely a list of those sessions, so reading the
+calendar without a window produced a sheet with one row where the term
+has a dozen---and the missing rows are not visibly missing, so the
+sheet looks finished.
+The window is a parameter rather than a fixed choice made here, because
+only the caller knows which stretch of the calendar the sheet is for.
+It defaults to [[None]], which is [[read_calendar]]'s own default and
+therefore leaves existing callers exactly as they were.
+<<more signup args doc>>=
+- window is an optional (start, end) pair of datetimes. When given,
+  recurring events are expanded into their occurrences within it;
+  when None (the default), the calendar is read as it is.
+<<more signup args>>=
+window=None,
+@
+
+The two behaviours are worth contrasting directly, since the failing
+one produced a plausible-looking sheet rather than an error: the same
+weekly session yields one row per occurrence with a window, and a
+single row without.
+<<test functions>>=
+def make_recurring_course_ics():
+  """A weekly lab stated once, as three occurrences would be."""
+  return """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+SUMMARY:Laboration
+DTSTART:20240115T100000Z
+DTEND:20240115T120000Z
+LOCATION:D1
+RRULE:FREQ=WEEKLY;COUNT=3
+END:VEVENT
+END:VCALENDAR"""
+
+def generated_sheet_rows(tmp_path, window):
+  """Generates a sheet from the weekly lab, returns its lines."""
+  ics = tmp_path / "course.ics"
+  ics.write_text(make_recurring_course_ics())
+  out = tmp_path / "sheet.csv"
+  generate_signup_sheet(str(out), str(ics),
+                        needed_TAs=lambda event: 1,
+                        window=window)
+  return out.read_text().splitlines()
+
+def test_generate_signup_sheet_expands_recurrences(tmp_path):
+  """A weekly session becomes one row per occurrence."""
+  window = (datetime(2024, 1, 1).astimezone(),
+            datetime(2024, 3, 1).astimezone())
+  rows = generated_sheet_rows(tmp_path, window)
+  assert len(rows) == 1 + 3  # header plus three occurrences
+
+def test_generate_signup_sheet_without_window(tmp_path):
+  """Without a window only the master event becomes a row."""
+  rows = generated_sheet_rows(tmp_path, None)
+  assert len(rows) == 1 + 1  # header plus the master event
 @
 
 To generate the rows of the sheet, we simply go through the calendar in

--- a/src/nytid/signup/sheets.nw
+++ b/src/nytid/signup/sheets.nw
@@ -182,10 +182,23 @@ However, we make this optional, but on by default.
   their own rows in the sign-up sheet. Default is True.
 <<more signup args>>=
 digital_separately=True,
+@
+
+We read the location once, through [[or ""]], because a [[VEVENT]] need
+not carry a [[LOCATION]] at all and [[icalendar]] reports the absent
+property as [[None]] rather than an empty string.
+Asking [[None]] whether it contains \enquote{digital} raises
+[[AttributeError]], and nothing guards the row loop, so one room-less
+event in the course's feed aborted [[signupsheets generate]] with a
+traceback and no sheet at all.
+The empty string answers the question correctly---an event with no room
+has no digital room either---so it takes the ordinary path and gets its
+single row, which is what a room-less session should produce.
 <<append [[event]] data to [[rows]]>>=
-if digital_separately and "digital" in event.location.casefold():
-  TAs_per_room = num_TAs // (event.location.count(",") + 1)
-  <<remove digital from [[event.location]]>>
+location = event.location or ""
+if digital_separately and "digital" in location.casefold():
+  TAs_per_room = num_TAs // (location.count(",") + 1)
+  <<remove digital from [[location]]>>
   if event.location: # check if digital was the only room
     rows.append([*event_to_CSV(event),
                 max(num_TAs-TAs_per_room, 1)]) # at least one TA
@@ -194,6 +207,16 @@ if digital_separately and "digital" in event.location.casefold():
                max(TAs_per_room, 1)])
 else:
   rows.append([*event_to_CSV(event), num_TAs])
+@
+
+The row builder needs the same coercion for the same reason, and here
+it also keeps the CSV honest: without it the row would carry [[None]],
+and the field would come out empty only because [[csv.writer]] happens
+to render [[None]] that way.
+Saying \enquote{no rooms} explicitly means the row is well-formed
+whoever consumes it.
+This mirrors [[schedules.format_event_csv]], which already writes
+[[event.location or ""]].
 <<functions>>=
 def event_to_CSV(event):
   """
@@ -206,7 +229,7 @@ def event_to_CSV(event):
     event.summary,
     event.start.astimezone().strftime(STRPTIME_FORMAT),
     event.end.astimezone().strftime(STRPTIME_FORMAT),
-    event.location
+    event.location or ""
   ]
 <<constants>>=
 SIGNUP_SHEET_HEADER = [
@@ -216,16 +239,50 @@ SIGNUP_SHEET_HEADER = [
 STRPTIME_FORMAT = "%Y-%m-%d %H:%M"
 @
 
-When we remove digital from the location, we want to remove it in a way that 
+When we remove digital from the location, we want to remove it in a way that
 doesn't break the list of rooms.
-So we want to remove it either with a preceding comma, or a trailing comma, but 
+So we want to remove it either with a preceding comma, or a trailing comma, but
 not both.
-We're fine removing it if it's the only room, since then we would detect it 
+We're fine removing it if it's the only room, since then we would detect it
 above.
-<<remove digital from [[event.location]]>>=
+We substitute over the coerced [[location]] rather than [[event.location]]
+so that this chunk, too, is independent of whether the property was set.
+<<remove digital from [[location]]>>=
 event.location = re.sub(r"(,\s*digital|digital,\s*|digital)", "",
-                        event.location,
+                        location,
                         flags=re.IGNORECASE).strip()
+@
+
+Let's verify that a session without a room still becomes a row.
+The whole command dies on such an event otherwise, so the assertion
+that matters is simply that a sheet gets written at all; we check the
+room field is empty rather than absent so the row stays aligned with
+the header.
+<<test functions>>=
+def make_roomless_course_ics():
+  """A whitelisted session carrying no LOCATION property."""
+  return """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+SUMMARY:Laboration
+DTSTART:20240115T100000Z
+DTEND:20240115T120000Z
+END:VEVENT
+END:VCALENDAR"""
+
+def test_generate_signup_sheet_without_location(tmp_path):
+  """An event with no room must not abort the whole sheet."""
+  ics = tmp_path / "course.ics"
+  ics.write_text(make_roomless_course_ics())
+  out = tmp_path / "sheet.csv"
+  generate_signup_sheet(str(out), str(ics),
+                        needed_TAs=lambda event: 1)
+  rows = out.read_text().splitlines()
+  assert len(rows) == 1 + 1  # header plus the one session
+  fields = rows[1].split("\t")
+  assert fields[SIGNUP_SHEET_HEADER.index("Event")] == "Laboration"
+  assert fields[SIGNUP_SHEET_HEADER.index("Rooms")] == ""
 @
 
 Finally, we can use the function as follows.


### PR DESCRIPTION
## Overview

Eleven verified bugs in the scheduling domain — `cli/schedule`, `schedules`,
`cli/utils/rooms`, `cli/signupsheets` and `signup/sheets` — each with a
regression test that was confirmed to fail before the fix and pass after.

**This PR is based on `fix/schedule-unranked-todos` (#360) and should be
merged after it.** It builds on that branch's unranked-todo sort fix
rather than duplicating it.

**⚠️ New dependency: `tzlocal`** (see fix 2). It is the only portable way
to learn the host's IANA timezone name; the standard library exposes no
equivalent. Added to `pyproject.toml` and `poetry.lock`; nothing else in
the lock changed.

Test counts: 658 → 686 passing (28 new tests). The 6 `test_clitrack.py`
failures are pre-existing on the base branch and environment-related
(the tests clear `os.environ`, so the `nytid` executable is not on
`PATH`); they are untouched by this PR.

Each commit is atomic and closes one issue.

---

### 1. `signupsheets generate` reused the previous course's outfile

The `except KeyError` arm of the data-directory handling logged the
failure but neither assigned `outfile` nor left the loop, so execution
fell through to `generate_signup_sheet(outfile, ...)` with the
*previous* course's path — silently overwriting that course's sheet, or
raising `UnboundLocalError` when the first course failed. A classic
noweb chunk-dependency hazard, now explained in the prose.

Closes #362

### 2. `parse_calendar` baked a fixed UTC offset into naive/all-day times

The no-argument `.astimezone()` attaches the offset in effect at one
instant, not the zone. Recurrence expansion derives every occurrence
from `DTSTART`'s tzinfo, so a series anchored on one side of a DST
changeover reported the wrong wall-clock time on the other — an hour off
for timed events, 23:00 the previous day (wrong date, weekday and ISO
week) for all-day ones. Verified under `TZ=Europe/Stockholm`:

```
2024-10-20 10:00 -> local 10:00   (correct)
2024-10-27 10:00 -> local 09:00   (wrong)
```

Now resolves the host's IANA zone through a new `local_timezone` helper
backed by `tzlocal`. Tests fake the zone rather than mutating `TZ`, so
they hold wherever they run.

Closes #363

### 3. Room commands crashed on events without `LOCATION`

`icalendar` 7.x returns `None`, not `""`, so `event.location.split()`
raised `AttributeError`. Both `free_rooms` and `booked_rooms` wrap the
whole query in one `try`, so a single such event produced **no output at
all** from `nytid utils rooms unbooked` and `booked`. Fixed with
`or ""`, matching `schedules.format_event_csv`.

Closes #364

### 4. `schedule show` dropped external events and todos on the end date

`--end` parses as the midnight *starting* the end date, but the display
filter is inclusive of that date. Three consumers stopped a day short:
the recurrence window (the default 7-day view always lost day 7),
`compute_free_slots` (the end date collapsed to a zero-length window, so
no todos there), and the occupied intervals fed to todo scheduling. Now
derives `end_of_range` once and passes it to all of them; `end` itself
is unchanged, so the filter and the option's meaning are untouched.

Closes #366

### 5. Course ICS read without a window collapsed RRULEs

Course calendars were read with `window=None`, leaving `RRULE`
occurrences implicit. `schedule show`/`ics` displayed only the first
occurrence of every recurring course event, and `signupsheets generate`
wrote **one row where the term has a dozen** — a sheet that looks
finished but omits sessions TAs then cannot sign up for.

Adds `schedules.default_window` (now ± 1 year) for callers with no range
of their own, gives `sheets.generate_signup_sheet` an optional `window`
(default `None` preserves current behaviour), and supplies one at each
call site: `show` uses its shown range, `ics` and `signupsheets` the
default horizon.

Closes #367

### 6. `event_filter` raised `TypeError` on events without `SUMMARY`

`re.match` rejects the `None` that `icalendar` returns for an absent
`SUMMARY`. `schedule show` caught it per course and dropped the **entire
course**; `signupsheets generate` showed a raw traceback. An unnamed
event now matches no whitelist entry and is excluded — which is what a
conservative whitelist already promises.

Closes #369

### 7. `schedule show` filtered in the event's timezone, displayed in local

The range filter compared `event.start.date()` in whatever zone the
event was stored in, against local dates from the command line, while
`format_event_csv` renders through `astimezone()`. Since
`sheets.EventFromCSV` stores bookings in UTC, a booking at 00:30 local
was dated the previous day and silently dropped from a range it would
have printed inside — and one just past the end was kept. Now compares
the same timestamps the display uses.

Closes #371

### 8. `rooms unbooked` reported rooms as free while they were booked

Free rooms were computed per event and merged only on *identical*
`(start, end)`. With D1 booked 15–17 and D2 booked 15–16, the 15–16 row
reported D1 free and the 15–17 row reported D2 free — both false during
the overlap, from a command whose help text invites acting on the
output, and whose sibling `booked` command exists precisely because such
ragged overlaps are normal.

Now cuts the timeline at every booking boundary, subtracts the rooms
booked by *any* overlapping event per atomic interval, and merges
neighbours that free the same rooms. A gap still carries no row (absent
means all free) while a fully booked interval still carries an empty one
— the two must stay distinguishable. `booked_rooms` keeps stating the
intervals the schedule states, which is what makes it useful.

Closes #373

### 9. `schedule show` never scheduled todos with an unset owner

The filter `t.who == user` is stricter than the convention `todo`
established — an unset `who` means the default user, as every ownership
test there spells out. Since `nytid todo add` leaves `who` unset without
`--who`, the most ordinary kind of todo silently never reached the
schedule, breaking the agreement with `todo ls` that the shared sort
order exists to preserve.

Closes #377

### 10. `map_drop_exceptions` did not protect a lazily-mapped input

The `for` statement advances the input iterator *outside* the `try`, so
only exceptions from `func` were dropped. With `--user`, the caller
wraps the rows in a lazy `map` over `add_reserve_to_title`, which raises
`ValueError` on a blank `#Needed TAs` cell — the normal state of a sheet
people are still filling in. That aborted `schedule ics/show --user X`
entirely, while the no-user path merely warned. Now advances the
iterator inside the `try`.

Closes #379

### 11. `signupsheets generate` crashed on events without `LOCATION`

Same event class as fix 3, at a call site those fixes did not reach.
`generate_signup_sheet` asked `event.location` whether it contained
`"digital"`, and `icalendar` 7.x returns `None` for a `VEVENT` with no
`LOCATION`, so `casefold` raised `AttributeError`. Nothing guards the
row loop, so one room-less event in the course feed aborted the command
with a traceback and **no sheet written at all**.

Reads the location once through `or ""` — a room-less session then
takes the ordinary path and gets its row — and coerces in
`event_to_CSV` too, so the row is well-formed rather than relying on
how `csv.writer` happens to render `None`.

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136fb1QAY29rDDLkELhZEpK

