### PR TITLE
fix/track stale window state

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1548,6 +1548,25 @@ files = [
 ]
 
 [[package]]
+name = "tzlocal"
+version = "5.4.4"
+description = "tzinfo object for the local timezone"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "tzlocal-5.4.4-py3-none-any.whl", hash = "sha256:aae09f0126a8a86fa736be266eb4a471380d26a0de3bc14844e7821fee3e2a15"},
+    {file = "tzlocal-5.4.4.tar.gz", hash = "sha256:8dbb8660838688a7b6ba4fed31d18dedf842afb4d47ca050d6d891c2c15f3be4"},
+]
+
+[package.dependencies]
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+devenv = ["zest.releaser"]
+testing = ["check_manifest", "pyroma", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "ruff"]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1657,4 +1676,4 @@ zulip = "*"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "3716863fc5ce1909a274101f7e8369aad40e321e7a591a4d5c457953fb4d7aa3"
+content-hash = "ac177a0c505ddeb673071f536d7dc1ef074743e7c3d3c9929b95f9945977e3c4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
   "cachetools>=5.3.1,<6.0.0",
   "rich>=13.0.0,<14.0.0",
   "weblogin (>=1.17,<2.0)",
-  "zulipcli (>=0.7,<1.0)"
+  "zulipcli (>=0.7,<1.0)",
+  "tzlocal (>=5.4.4,<6.0.0)"
 ]
 
 [project.scripts]

--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -557,7 +557,8 @@ Hence, we need both the register name and its path.
 <<helper functions>>=
 def complete_course_name(ctx: typer.Context, incomplete: str):
   """
-  Returns a list of course names matching `incomplete`.
+  Yields (course name, register)-pairs matching `incomplete`,
+  across every register in scope.
   """
   <<populate [[registers]] with the registers to use>>
   for register, register_path in registers:
@@ -588,13 +589,53 @@ def register_pairs(register=None):
 @
 
 In the register, each course has its own subdirectory.
-So we simply need to return the subdirectories of [[register_path]] matching 
-[[incomplete]] together with [[register]].
+So we need the courses of [[register_path]] that match [[incomplete]],
+paired with [[register]] so that same-named courses from different
+registers stay distinguishable.
+
+We must \emph{yield} those pairs rather than return them.
+This chunk is expanded inside the loop over registers, so a [[return]]
+here ends the entire function on the very first register: the user is
+silently offered only that register's courses, and with no registers at
+all the function falls off the end and hands [[None]] to Click.
+The chunk's name says nothing about where it is expanded, which is what
+makes the distinction invisible at the definition site---the
+chunk-composition hazard that literate programs have to watch for.
+Yielding makes [[complete_course_name]] a generator, so it visits every
+register and produces an empty sequence when there are none.
 <<yield (course name, register name) tuples that matches [[incomplete]]>>=
 courses_in_reg = courses.all_courses(register_path)
 matching_courses = filter(lambda x: x.startswith(incomplete), courses_in_reg)
-return map(lambda x: (x, f"from {register}"),
-           matching_courses)
+yield from map(lambda x: (x, f"from {register}"),
+               matching_courses)
+@
+
+Let's check both halves of that claim.
+With two registers configured, completion must reach past the first
+one:
+<<test functions>>=
+def test_complete_course_name_spans_registers():
+  second_reg = "second register"
+  second_path = pathlib.Path(tempfile.mkdtemp())
+  runner.invoke(cli, ["registry", "add", second_reg, str(second_path)])
+  try:
+    runner.invoke(cli, ["new", "secondcourse", "--register", second_reg])
+    ctx = SimpleNamespace(params={})
+    names = [name for name, _ in complete_course_name(ctx, "")]
+    assert target_course in names
+    assert "secondcourse" in names
+  finally:
+    runner.invoke(cli, ["registry", "rm", second_reg])
+@
+
+And with no registers at all, completion must produce an empty
+sequence rather than [[None]]:
+<<test functions>>=
+def test_complete_course_name_without_registers(monkeypatch):
+  monkeypatch.setattr("nytid.cli.courses.register_pairs",
+                      lambda register=None: [])
+  ctx = SimpleNamespace(params={})
+  assert list(complete_course_name(ctx, "")) == []
 @
 
 Now let's turn back to the main problem:

--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -527,6 +527,7 @@ target_value = "Test Tester"
 
 runner.invoke(cli, ["new", target_course, "--register", register])
 <<test imports>>=
+import pathlib
 import tempfile
 from types import SimpleNamespace
 import pytest
@@ -1342,26 +1343,124 @@ courses rather than crashing.
 This design lets callers decide whether an empty result is fatal
 (like [[signupsheets]], which calls [[sys.exit(1)]]) or merely means
 there is nothing to show (like [[schedule]]).
+
+Honouring that contract takes more care than wrapping the
+config-reading call in a [[try]], because there are \emph{two} places
+that touch the file system, not one.
+Reading a course's config is the obvious one.
+The less obvious one is scanning a register for course names: that
+scan lives inside the [[courses_regex]] generator, and a generator's
+body runs when the loop \emph{advances} it---that is, in the [[for]]
+statement itself, outside any [[try]] in the loop body.
+A register whose directory has gone missing (a common state when AFS
+isn't mounted) therefore raises from a line that looks like plain
+iteration.
+So we drive the generator explicitly, with [[next]] inside the guarded
+region.
+
+We also scan one register at a time.
+A generator that raises is exhausted and can't be resumed, so a single
+[[courses_regex]] over every register would let one unreachable
+register hide the courses of every register after it.
+Giving each register its own generator confines the damage to that
+register.
 <<helper functions>>=
 def get_courses_configs(course_regex,
                         register=MINE):
   """Return {(course, register): config} for matching courses.
 
-  Logs warnings for KeyError and PermissionError,
-  skipping inaccessible courses.
+  Registers that can't be scanned and courses whose config
+  can't be read are skipped with a warning, so one broken
+  register or config never hides the healthy courses.
   """
-  regs = registers_regex(register)
   result = {}
-  for course_reg in courses_regex(course_regex, regs):
-    try:
-      result[course_reg] = courses.get_course_config(
-        *course_reg
-      )
-    except KeyError as err:
-      logging.warning(err)
-    except PermissionError as err:
-      c, r = course_reg
-      logging.warning(
-        f"You don't have access to {c} in {r}: {err}"
-      )
+  for reg in registers_regex(register):
+    <<add [[reg]]'s matching courses to [[result]]>>
   return result
+@
+
+The errors that mean \enquote{we can't get at this course} are the same
+at both sites, so we name them once.
+Beyond the [[KeyError]] and [[PermissionError]] the function already
+handled, a course directory can vanish or turn out not to be a
+directory, and [[typerconf]] reports a corrupt [[config.json]] as a
+[[ValueError]]---which is precisely the state a half-written config
+leaves behind.
+<<constants>>=
+COURSE_ACCESS_ERRORS = (KeyError, FileNotFoundError,
+                        NotADirectoryError, PermissionError,
+                        ValueError)
+@
+
+Exhausting the generator normally means we're done with the register;
+any other exception means the scan itself failed, and since we can't
+resume a generator that raised, we warn and move on to the next
+register.
+<<add [[reg]]'s matching courses to [[result]]>>=
+matches = courses_regex(course_regex, [reg])
+while True:
+  try:
+    course_reg = next(matches)
+  except StopIteration:
+    break
+  except COURSE_ACCESS_ERRORS as err:
+    logging.warning(f"Can't list the courses in {reg}: {err}")
+    break
+  <<read [[course_reg]]'s config into [[result]]>>
+@
+
+Reading the config keeps the tailored message for [[PermissionError]],
+since \enquote{you don't have access} tells the user what to do about
+it, whereas the remaining errors are best reported verbatim.
+The specific clause has to come first: [[PermissionError]] is also a
+member of [[COURSE_ACCESS_ERRORS]], and Python takes the first clause
+that matches.
+<<read [[course_reg]]'s config into [[result]]>>=
+try:
+  result[course_reg] = courses.get_course_config(
+    *course_reg
+  )
+except PermissionError as err:
+  c, r = course_reg
+  logging.warning(
+    f"You don't have access to {c} in {r}: {err}"
+  )
+except COURSE_ACCESS_ERRORS as err:
+  logging.warning(err)
+@
+
+Let's verify both failure modes.
+A register pointing at a directory that was never created must yield
+nothing rather than a traceback.
+We remove the register again afterwards so that the shared test config
+stays healthy for the other tests.
+<<test functions>>=
+def test_get_courses_configs_skips_unreadable_register():
+  gone_reg = "goneregister"
+  gone_path = pathlib.Path(tempfile.mkdtemp()) / "never-created"
+  runner.invoke(cli, ["registry", "add", gone_reg, str(gone_path)])
+  try:
+    assert get_courses_configs(".*", f"^{gone_reg}$") == {}
+  finally:
+    runner.invoke(cli, ["registry", "rm", gone_reg])
+@
+
+A corrupt config must cost us that one course and no more---the point
+of the whole exercise is that the healthy course in the same register
+still comes back.
+<<test functions>>=
+def test_get_courses_configs_skips_corrupt_config():
+  broken_reg = "brokenregister"
+  broken_path = pathlib.Path(tempfile.mkdtemp())
+  runner.invoke(cli, ["registry", "add", broken_reg, str(broken_path)])
+  try:
+    runner.invoke(cli, ["new", "brokencourse", "--register", broken_reg])
+    runner.invoke(cli, ["new", "healthycourse", "--register", broken_reg])
+    (broken_path / "brokencourse" / "config.json").write_text("{not json")
+
+    configs = get_courses_configs(".*", f"^{broken_reg}$")
+    assert ("healthycourse", broken_reg) in configs
+    assert ("brokencourse", broken_reg) not in configs
+  finally:
+    runner.invoke(cli, ["registry", "rm", broken_reg])
+@

--- a/src/nytid/cli/courses.nw
+++ b/src/nytid/cli/courses.nw
@@ -527,6 +527,7 @@ target_value = "Test Tester"
 
 runner.invoke(cli, ["new", target_course, "--register", register])
 <<test imports>>=
+import logging
 import pathlib
 import tempfile
 from types import SimpleNamespace
@@ -1058,7 +1059,7 @@ def mine_add(course: Annotated[str, course_arg_autocomplete],
   if not alias:
     alias = course
 
-  <<set [[mine_path]] to the path of the mine register>>
+  mine_path = get_mine_path()
   <<exit if [[alias]] is already in [[mine_path]]>>
 
   <<set [[course_path]] to [[course]]'s path>>
@@ -1078,36 +1079,69 @@ except FileExistsError:
   sys.exit(1)
 @
 
-\subsection{Create the default mine register if it doesn't exist}
+\subsection{Getting at the mine register}
 
-When we attempt to get the [[mine_path]] from [[registry]], it might not exist 
-if it's the first time we use it.
-This means we want to create it in the default location.
-<<set [[mine_path]] to the path of the mine register>>=
-try:
-  mine_path = registry.get(MINE)
-except KeyError:
-  <<create the default mine register>>
-  mine_path = registry.get(MINE)
-@
+The [[mine]] register is unlike the others: nobody adds it deliberately,
+it appears the first time a course is added to it.
+That makes two states normal rather than exceptional---no register
+entry in the config, and an entry whose directory doesn't exist---and
+the register lives under the user's home directory, so both states
+arise routinely on a fresh machine or after dotfiles are restored
+without their data.
 
-Now, if the register doesn't exist, we want to create it in [[~/.nytid/mine]] 
-and add it to the registry.
-<<create the default mine register>>=
-home_path = pathlib.Path(os.environ["HOME"])
-registry.add(MINE, home_path / ".nytid/mine")
-mine_path = registry.get(MINE)
-os.makedirs(mine_path)
-logging.warning(f"Added register {MINE} and created its path {mine_path}.")
+All three [[mine]] subcommands need the same thing: a directory they
+can rely on.
+So rather than let each of them rediscover the register and each of
+them get the error handling slightly differently, we resolve it once,
+here.
+The function creates whatever is missing and, when it can't, reports it
+the way the rest of this module does---[[logging.error]] and
+[[sys.exit(1)]] rather than a traceback.
+We use [[pathlib.Path.home()]] instead of reading [[HOME]] directly, so
+that a process without that variable falls back to the password
+database rather than raising.
+<<helper functions>>=
+def get_mine_path():
+  """
+  Returns the path of the `mine` register, creating the register
+  entry and its directory if they don't exist.
+
+  Exits with an error message if the directory can't be created.
+  """
+  try:
+    mine_path = registry.get(MINE)
+  except KeyError:
+    mine_path = pathlib.Path.home() / ".nytid" / MINE
+    registry.add(MINE, mine_path)
+    logging.warning(f"Added register {MINE} at {mine_path}.")
+
+  try:
+    os.makedirs(mine_path, exist_ok=True)
+  except OSError as err:
+    logging.error(f"Can't use the {MINE} directory {mine_path}: {err}")
+    sys.exit(1)
+
+  return mine_path
 @
 
 \subsection{Check if the course is already among my courses}
 
-To check if the alias already exists among our courses, we simply iterate 
+To check if the alias already exists among our courses, we iterate
 through and look for such a filename.
+
+The comparison has to be against [[my_course.name]].
+[[registry.get]] returns a [[pathlib.Path]], so [[iterdir]] yields
+[[Path]] objects, and a [[Path]] never compares equal to a [[str]]---
+comparing them directly makes the check silently vacuous, which is what
+it used to be.
+The duplicate was then caught only by accident, further down, when
+[[os.symlink]] raised [[FileExistsError]]; that accident doesn't cover
+the case this check exists for, an [[alias]] that collides with a
+course added under a different name.
+The sibling [[mine_ls]] below already does it correctly.
 <<exit if [[alias]] is already in [[mine_path]]>>=
 for my_course in mine_path.iterdir():
-  if my_course == alias:
+  if my_course.name == alias:
     logging.error(f"{alias} is already among your courses.")
     sys.exit(1)
 @
@@ -1161,14 +1195,26 @@ course_path = registry.get(register) / course
 
 \subsection{Listing my courses}
 
+Listing goes through [[get_mine_path]] like the others, so an
+unconfigured or absent register is set up rather than reported as a
+[[KeyError]] traceback.
+That still leaves a directory that exists but can't be read---a
+permission problem the user has to fix themselves---so we say so
+plainly instead of letting the [[OSError]] surface raw.
 <<mine subcommands>>=
 @minecli.command(name="ls")
 def mine_ls():
   """
   Lists my courses.
   """
-  mine_path = registry.get(MINE)
-  for course in mine_path.iterdir():
+  mine_path = get_mine_path()
+  try:
+    my_courses = list(mine_path.iterdir())
+  except OSError as err:
+    logging.error(f"Can't list {mine_path}: {err}")
+    sys.exit(1)
+
+  for course in my_courses:
     print(course.name)
 @
 
@@ -1180,22 +1226,97 @@ def mine_rm(course: Annotated[str, my_course_arg]):
   """
   Removes a course from my courses.
   """
-  mine_path = registry.get(MINE)
+  mine_path = get_mine_path()
   try:
     os.unlink(mine_path / course)
   <<handle errors for trying to remove a course from mine>>
 <<argument and option definitions>>=
 my_course_arg = typer.Argument(help="The course in my courses.",
                                autocompletion=complete_my_course_arg)
+@
+
+Completion can't use [[get_mine_path]], even though it wants the same
+directory.
+A completer runs whenever the user presses \textsc{tab}, so it must
+neither create a register as a side effect nor call [[sys.exit]] in the
+middle of the shell's completion machinery.
+Instead it reads what is there and, if anything is missing or
+unreadable, offers nothing---the worst outcome being that the user
+types the name out in full.
+We materialise the courses inside the [[try]], because
+[[all_courses]] is a generator and would otherwise do its file-system
+work outside it (\cref{cli.courses}).
 <<helper functions>>=
 def complete_my_course_arg(incomplete: str) -> list[str]:
   """
-  Returns a list of courses in my courses that match `incomplete`.
+  Yields the courses in my courses that match `incomplete`.
+
+  Yields nothing when the `mine` register is missing or
+  unreadable; completion must never fail loudly.
   """
-  mine_path = registry.get(MINE)
-  for course in courses.all_courses(mine_path):
+  try:
+    my_courses = list(courses.all_courses(registry.get(MINE)))
+  except COURSE_ACCESS_ERRORS:
+    return
+
+  for course in my_courses:
     if course.startswith(incomplete):
       yield course
+@
+
+Let's verify the three claims above.
+Every test points [[HOME]] and the [[mine]] register at a temporary
+directory, and removes the register afterwards, so nothing here can
+reach the real [[~/.nytid]].
+
+The duplicate check must actually fire.
+We assert on the log rather than on the command output, because the
+module reports errors through [[logging]], which the Click runner does
+not capture:
+<<test functions>>=
+def test_mine_add_rejects_duplicate_alias(tmp_path, monkeypatch, caplog):
+  monkeypatch.setenv("HOME", str(tmp_path))
+  runner.invoke(cli, ["registry", "add", MINE, str(tmp_path / MINE)])
+  try:
+    assert runner.invoke(cli, ["mine", "add", target_course,
+                               register]).exit_code == 0
+
+    with caplog.at_level(logging.ERROR):
+      result = runner.invoke(cli, ["mine", "add", target_course, register])
+
+    assert result.exit_code == 1
+    assert "already among your courses" in caplog.text
+  finally:
+    runner.invoke(cli, ["registry", "rm", MINE])
+@
+
+A register whose directory was never created must be repaired by every
+subcommand rather than raising [[FileNotFoundError]]:
+<<test functions>>=
+def test_mine_commands_create_missing_directory(tmp_path, monkeypatch):
+  monkeypatch.setenv("HOME", str(tmp_path))
+  mine_dir = tmp_path / "never-created" / MINE
+  runner.invoke(cli, ["registry", "add", MINE, str(mine_dir)])
+  try:
+    assert runner.invoke(cli, ["mine", "ls"]).exit_code == 0
+    assert mine_dir.is_dir()
+
+    assert runner.invoke(cli, ["mine", "add", target_course,
+                               register]).exit_code == 0
+    assert (mine_dir / target_course).is_symlink()
+
+    assert runner.invoke(cli, ["mine", "rm", target_course]).exit_code == 0
+    assert not (mine_dir / target_course).exists()
+  finally:
+    runner.invoke(cli, ["registry", "rm", MINE])
+@
+
+Completion, by contrast, must stay silent and create nothing when the
+register isn't there at all:
+<<test functions>>=
+def test_complete_my_course_arg_without_register():
+  runner.invoke(cli, ["registry", "rm", MINE])
+  assert list(complete_my_course_arg("")) == []
 @
 
 There are several errors that can occur.

--- a/src/nytid/cli/hr.nw
+++ b/src/nytid/cli/hr.nw
@@ -3217,20 +3217,116 @@ generate it.
 We will store the diffs ([[added_events]] and [[removed_events]]), that way 
 we'll build up the set of all events by adding them.
 
-For each time sheet we'll store [[added_events]] and [[removed_events]] in a 
+For each time sheet we'll store [[added_events]] and [[removed_events]] in a
 JSON file.
 This is similar to how we store the amanuensis contracts.
 <<store [[added_events]], [[removed_events]] for [[user]] as reported>>=
-timesheets_dir = pathlib.Path(typerconf.get(TIMESHEETS_DIR_PATH))
-filename = f"{user}.{datetime.datetime.now().isoformat()}.json"
-with open(timesheets_dir / filename, "w") as outfile:
-  json.dump({"user": user,
-             "added_events": added_events,
-             "removed_events": removed_events},
-            outfile,
-            indent=2)
+store_timesheet(timesheets_dir, user, added_events, removed_events)
+@
+
+The write has to create the directory first, and that is not a nicety.
+The [[if store:]] block runs \emph{after} the xlsx files have been
+generated, so a missing directory raises [[FileNotFoundError]] at the one
+moment when the time sheets already exist on disk but nothing records
+that they were reported.
+The next run then recomputes the very same events as [[added_events]] and
+generates the same time sheets over again---a double-payment hazard, and
+exactly what storing the events was introduced to prevent.
+The sibling that stores amanuensis contracts calls [[mkdir]] for this
+reason; there is no reason for the two to differ.
+<<helper functions>>=
+def store_timesheet(timesheets_dir, user, added_events, removed_events):
+  """
+  Records `added_events` and `removed_events` for `user` as reported, in a
+  JSON file under `timesheets_dir`. Creates the directory if it doesn't
+  already exist. Returns the path written.
+  """
+  timesheets_dir.mkdir(parents=True, exist_ok=True)
+
+  filename = f"{user}.{datetime.datetime.now().isoformat()}.json"
+  path = timesheets_dir / filename
+
+  with open(path, "w") as outfile:
+    json.dump({"user": user,
+               "added_events": added_events,
+               "removed_events": removed_events},
+              outfile,
+              indent=2)
+
+  return path
+@
+
+The directory that receives them is a configuration key, so it can be
+absent.
+[[typerconf.get]] answers an unset key with [[KeyError]], which on a
+fresh install turns the first run of both [[generate]] and [[show]] into
+a traceback over something the user could trivially fix.
+The amanuensis commands earlier in this file already settled how to
+handle that: warn, quote the [[nytid config]] invocation that sets the
+key, and fall back to the working directory.
+We do the same here.
+
+We put it in a function rather than a chunk because three separate code
+paths need the value---storing, reading back, and the [[show]]
+command---and a function makes that dependency a visible argument-free
+call at each of them, whereas a shared chunk could silently be left out
+of one path.
+<<helper functions>>=
+def timesheets_directory():
+  """
+  Returns the configured directory for time sheet data as a pathlib.Path.
+  Falls back to `./` with a warning when the key isn't configured.
+  """
+  try:
+    return pathlib.Path(typerconf.get(TIMESHEETS_DIR_PATH))
+  except KeyError:
+    logging.warning(f"Can't find {TIMESHEETS_DIR_PATH} in config, "
+                    f"using `./`. Set by running "
+                    f"`nytid config {TIMESHEETS_DIR_PATH} -s <path>`.")
+    return pathlib.Path("./")
 <<constants>>=
 TIMESHEETS_DIR_PATH = "hr.timesheets.timesheets_dir"
+@
+
+The value is the same for every TA, so we look it up once, before the
+loop over the users, instead of once per TA.
+<<timesheet generation user iteration variables>>=
+timesheets_dir = timesheets_directory()
+@
+
+Let's verify both halves.
+The fallback must survive an unconfigured key, and the store must survive
+a directory that doesn't exist yet.
+<<test functions>>=
+def test_timesheets_directory_falls_back_when_unconfigured(monkeypatch):
+  import typerconf
+
+  def unset(key):
+    raise KeyError(key)
+
+  monkeypatch.setattr(typerconf, "get", unset)
+
+  assert timesheets_directory() == pathlib.Path("./")
+
+def test_timesheets_directory_uses_config(monkeypatch, tmp_path):
+  import typerconf
+  monkeypatch.setattr(typerconf, "get", lambda key: str(tmp_path))
+
+  assert timesheets_directory() == tmp_path
+
+def test_store_timesheet_creates_missing_directory(tmp_path):
+  target = tmp_path / "does" / "not" / "exist"
+
+  path = store_timesheet(target, "alice", [{"belopp": 1}], [])
+
+  assert path.parent == target
+
+  with open(path) as infile:
+    stored = json.load(infile)
+
+  assert stored["user"] == "alice"
+  assert stored["added_events"] == [{"belopp": 1}]
+  assert stored["removed_events"] == []
 @
 
 This means that we can read the data back as follows.
@@ -3240,8 +3336,9 @@ We simply read each time sheet file and add [[added_events]] to
 This way [[all_prev_events]] represents the correctly reported history.
 We must filter these events by the same date range as the current events to
 avoid falsely marking future events as \enquote{removed}.
+This chunk reads [[timesheets_dir]] from the iteration variables above,
+so it only works in a code path that includes them.
 <<add [[user]]'s previously reported events to [[all_prev_events]]>>=
-timesheets_dir = pathlib.Path(typerconf.get(TIMESHEETS_DIR_PATH))
 for timesheet_file in timesheets_dir.glob(f"{user}.*.json"):
   try:
     with open(timesheet_file) as infile:
@@ -3274,7 +3371,7 @@ def cli_show_timesheets(<<argument [[user_regex]] to match TAs>> = ".*",
   """
   Shows stored time sheets for TAs.
   """
-  timesheets_dir = pathlib.Path(typerconf.get(TIMESHEETS_DIR_PATH))
+  timesheets_dir = timesheets_directory()
 
   <<timesheets iteration variables>>
   <<set [[timesheets]] depending on [[all]]>>

--- a/src/nytid/cli/init.nw
+++ b/src/nytid/cli/init.nw
@@ -2296,13 +2296,28 @@ import importlib
 @
 
 Files are modules, directories are packages.
-So for each file, we check if it is a module (by extension) and add it if it 
+So for each file, we check if it is a module (by extension) and add it if it
 is.
-If it's a directory, we recursively call the function to find all modules in 
+If it's a directory, we recursively call the function to find all modules in
 that directory.
+
+A set is the right thing to \emph{collect} into---a package that has
+both [[foo.py]] and a [[foo]] directory must yield one name---but it is
+the wrong thing to \emph{return}.
+The caller below registers one Typer group per name in iteration order,
+and that order is what Typer prints in [[nytid --help]].
+Neither [[os.scandir]] nor a set of strings gives a stable order:
+[[scandir]] follows the file system, and Python randomises string
+hashing per process.
+The observable effect is that [[nytid --help]] listed its subcommand
+groups in a different order on every invocation, which defeats muscle
+memory and makes the help output impossible to diff or snapshot.
+Sorting on the way out costs nothing and makes discovery deterministic
+for every caller---[[nytid.cli.utils]] uses this same helper
+(\cref{chap:utils}).
 <<helper functions>>=
 def package_contents(package_name, recurse=False):
-  """Return the set of module names directly inside ``package_name``.
+  """Return the sorted module names directly inside ``package_name``.
 
   If ``recurse`` is True, sub-packages are traversed depth-first;
   the default is False because sub-packages register their own Typer
@@ -2310,7 +2325,7 @@ def package_contents(package_name, recurse=False):
   """
   spec = importlib.util.find_spec(package_name)
   if spec is None:
-      return set()
+      return []
 
   pathname = pathlib.Path(spec.origin).parent
 
@@ -2327,12 +2342,26 @@ def package_contents(package_name, recurse=False):
       elif entry.is_dir():
         modules.add(current)
         if recurse:
-          modules |= package_contents(current, recurse=True)
+          modules.update(package_contents(current, recurse=True))
 
-  return modules
+  return sorted(modules)
 <<additional imports>>=
 import pathlib
 import os
+@
+
+Sortedness is the contract, so that is what we assert.
+Checking that the result equals its own sorted copy catches a
+regression to an unordered container, which a single-process
+equality check between two calls would not.
+<<test [[init.py]]>>=
+from nytid.cli import package_contents
+
+def test_package_contents_is_ordered():
+  """Module discovery must be deterministic."""
+  modules = package_contents("nytid.cli")
+  assert modules == sorted(modules)
+  assert "nytid.cli.courses" in modules
 @
 
 With the module names in hand, we can import and register each one

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -81,11 +81,23 @@ def ics_cmd(<<argument for matching courses>> = ".*",
             <<option for matching registers, default to mine>>,
             <<option for username to filter for>>):
   """
-  Prints ICS data to stdout. Redirect to a .ics file, preferably in 
+  Prints ICS data to stdout. Redirect to a .ics file, preferably in
   ~/public_html, and add it to your calendar.
   """
+  <<let [[course_window]] be the export horizon>>
   <<generate [[schedule]] from sign-up sheets for matching courses>>
   print(schedule.to_ical().decode())
+@
+
+The shared generation chunk expands the courses' recurring events, and
+that expansion has to be bounded (\cref{ExpandingRecurrences}), so
+whoever includes the chunk must first say over what range.
+An export has no range to speak of: nobody asked for a week, they asked
+for their calendar.
+We hand it the library's default horizon, which brackets any course
+without ever running away on an endless [[RRULE]].
+<<let [[course_window]] be the export horizon>>=
+course_window = schedutils.default_window()
 @
 
 RFC~5545 requires every serialized calendar to carry exactly one
@@ -146,16 +158,73 @@ if "docs.google.com" in url:
   url = sheets.google_sheet_to_csv_url(url)
 @
 
-We read the ICS URL from the course's config and then read it in and add it to 
+We read the ICS URL from the course's config and then read it in and add it to
 [[schedule]].
-We also run all the events from the schedule through a filter that removes 
+We also run all the events from the schedule through a filter that removes
 events that are uninteresting.
-For instance, we don't want to include events like holidays, exam weeks or 
+For instance, we don't want to include events like holidays, exam weeks or
 fairs like KTH Global.
+
+We pass [[course_window]] for the same reason the external feeds get
+one: a TimeEdit course schedule states a weekly lab once, as a single
+[[VEVENT]] with an [[RRULE]], and reading it without a window leaves
+the occurrences implicit.
+This path is the fallback for courses that have no sign-up sheet, which
+is exactly when the ICS \emph{is} the schedule---so collapsing it to
+first occurrences quietly emptied those courses of everything but their
+first week.
 <<read schedule from [[config]], add to [[schedule]]>>=
-course_schedule = schedutils.read_calendar(config.get("ics"))
+course_schedule = schedutils.read_calendar(config.get("ics"),
+                                           window=course_window)
 for event in schedutils.event_filter(course_schedule.events):
   schedule.add_component(event)
+@
+
+Both commands include this chunk, and each supplies its own window, so
+the test drives both and checks what the reader was handed.
+The course config has no sign-up sheet, which is what sends [[show]]
+and [[ics]] down this fallback path in the first place.
+[[show]] must ask for exactly its own range; [[ics]], having none, must
+still ask for something that brackets now.
+<<test functions>>=
+def capture_course_window(monkeypatch, argv):
+  """Runs a schedule command, returns the course ICS window."""
+  from typer.testing import CliRunner
+  import typerconf
+  captured = {}
+
+  def fake_read_calendar(source, cache=None, window=None):
+    captured["window"] = window
+    return icalendar.Calendar()
+
+  config = typerconf.Config({"ics": "https://example.com/course.ics"})
+  monkeypatch.setattr(
+    schedule_module.coursescli, "get_courses_configs",
+    lambda *a, **k: {("DD1310", "reg"): config})
+  monkeypatch.setattr(schedule_module, "get_external_sources",
+                      lambda cli_sources=None: [])
+  monkeypatch.setattr(schedule_module.schedutils, "read_calendar",
+                      fake_read_calendar)
+
+  result = CliRunner().invoke(schedule_module.cli, argv)
+  assert result.exit_code == 0, result.output
+  return captured["window"]
+
+def test_show_expands_course_recurrences_over_its_range(monkeypatch):
+  """show asks for exactly the range it will display."""
+  window = capture_course_window(
+    monkeypatch,
+    ["show", "--start", "2024-06-03", "--end", "2024-06-09",
+     "--no-todo"])
+  start, end = window
+  assert start.astimezone().date() == datetime.date(2024, 6, 3)
+  assert end.astimezone().date() == datetime.date(2024, 6, 9)
+
+def test_ics_expands_course_recurrences_over_a_horizon(monkeypatch):
+  """ics has no range, so it must still bracket now."""
+  start, end = capture_course_window(monkeypatch, ["ics"])
+  now = datetime.datetime.now().astimezone()
+  assert start < now < end
 @
 
 We need a username.
@@ -441,6 +510,7 @@ def show(<<argument for matching courses>> = ".*",
   Shows schedule for courses, external calendars and scheduled todos.
   """
   <<double check [[start]] and [[end]] dates>>
+  <<let [[course_window]] be the shown range>>
   <<generate [[schedule]] from sign-up sheets for matching courses>>
   <<add external calendar events to [[schedule]]>>
   <<add scheduled todo events to [[schedule]]>>
@@ -511,6 +581,15 @@ def end_of_day(when):
 <<double check [[start]] and [[end]] dates>>=
 end = update_end_date(start, end)
 end_of_range = end_of_day(end)
+@
+
+Unlike the export, [[show]] does have a range, and it is the one the
+user asked for---so the courses' recurrences are expanded over exactly
+what will be displayed rather than over a generic horizon.
+The bounds must be timezone aware, since the expansion compares them
+against aware event times.
+<<let [[course_window]] be the shown range>>=
+course_window = (start.astimezone(), end_of_range.astimezone())
 @
 
 \paragraph{Testing [[update_end_date]]}

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -190,13 +190,44 @@ for event in map_drop_exceptions(sheets.EventFromCSV, booked):
   schedule.add_component(event)
 <<imports>>=
 import functools
+@
+
+The point of [[map_drop_exceptions]] is that one malformed CSV row must
+not cost the user their whole schedule.
+The obvious implementation---a [[for]] loop with the call to [[func]]
+inside a [[try]]---only half delivers that, because a [[for]] statement
+advances the input iterator \emph{outside} the [[try]].
+With an eager list that distinction is invisible; with the lazy [[map]]
+above it decides whether the command works.
+[[add_reserve_to_title]] calls [[sheets.get_booked_TAs_from_csv]],
+which raises [[ValueError]] on a row whose \enquote{\#Needed TAs} cell
+is blank---the normal state of a sign-up sheet people are still filling
+in.
+Raised inside the [[map]], that exception is produced while the input
+is advanced, so it escapes the generator and aborts the command; and it
+does so only when [[--user]] is given, since that is the only path that
+wraps [[booked]] in a [[map]].
+Advancing the iterator inside the [[try]] ourselves removes the
+distinction: both the production of an item and its transformation are
+covered, so a bad row is dropped with a warning either way.
+[[StopIteration]] must be caught separately and turned into a
+[[return]], since a generator may not let it propagate.
 <<helper functions>>=
 def map_drop_exceptions(func, iterable):
   """
-  Same as map, but ignores exceptions from `func`.
-  Logs a warning when an item is dropped.
+  Same as map, but ignores exceptions from `func` and from producing
+  the items of `iterable`. Logs a warning when an item is dropped.
   """
-  for item in iterable:
+  items = iter(iterable)
+  while True:
+    try:
+      item = next(items)
+    except StopIteration:
+      return
+    except Exception as err:
+      logging.warning(f"Dropped an item: {err}")
+      continue
+
     try:
       yield func(item)
     except Exception as err:
@@ -242,6 +273,37 @@ def test_map_drop_exceptions_all_fail():
 def test_map_drop_exceptions_empty():
   result = list(map_drop_exceptions(int, []))
   assert result == []
+@
+
+The tests above all pass eager lists, where producing an item cannot
+fail, so they say nothing about the case that actually broke.
+Here the input is lazy and \emph{it} raises.
+The second test reproduces the original report end to end: a sign-up
+row with a blank \enquote{\#Needed TAs} cell, run through the same
+[[add_reserve_to_title]] mapping that [[--user]] installs.
+<<test functions>>=
+def test_map_drop_exceptions_lazy_input_raises():
+  """Exceptions raised while producing items are dropped too."""
+  def explode(value):
+    if value == "bad":
+      raise ValueError("boom")
+    return value
+
+  lazy = map(explode, ["1", "bad", "3"])
+  assert list(map_drop_exceptions(int, lazy)) == [1, 3]
+
+def test_map_drop_exceptions_survives_blank_needed_TAs():
+  """A blank '#Needed TAs' cell must not abort a --user export."""
+  rows = [
+    ["Lab", "2024-01-01 10:00", "2024-01-01 12:00",
+     "D1", "", "alice"],
+    ["Lab", "2024-01-02 10:00", "2024-01-02 12:00",
+     "D1", "1", "alice"],
+  ]
+  booked = map(functools.partial(add_reserve_to_title, "alice"),
+               rows)
+  events = list(map_drop_exceptions(sheets.EventFromCSV, booked))
+  assert len(events) == 1
 @
 
 \paragraph{Testing [[add_reserve_to_title]]}

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -1035,7 +1035,7 @@ def schedule_todo_events(user, end, occupied):
   if not free_slots:
     return []
 
-  <<sort todos by priority>>
+  <<sort todos into scheduling order>>
 
   scheduled_events = []
   remaining_slots = list(free_slots)
@@ -1059,15 +1059,23 @@ if user:
   todos = [t for t in todos if t.who == user]
 @
 
-Sorting by effective priority means high-urgency items claim the
-earliest available slots.
+High-urgency items should claim the earliest available slots, so we
+order todos before assigning them.
+We cannot sort on [[effective_priority]] directly: unranked todos have
+no priority, so [[effective_priority]] returns [[None]] for them, and
+[[None]] does not compare with floats---one unranked open todo would
+crash the whole command.
+Instead we reuse [[sort_todos_for_display]], the shared helper that
+[[todo ls]] uses for exactly this mixed ranked/unranked case: ranked
+todos come first in descending effective priority, and unranked todos
+follow, earliest deadline first.
+Reusing it also means the schedule fills slots in the same order the
+user sees in [[todo ls]], so the two views never disagree about what
+comes next.
 We reuse the [[now]] that anchors the scheduling range, so priorities
 are evaluated at the same instant the plan starts.
-<<sort todos by priority>>=
-todos.sort(
-  key=lambda t: todocli.effective_priority(t, now),
-  reverse=True,
-)
+<<sort todos into scheduling order>>=
+todos = todocli.sort_todos_for_display(todos, now)
 @
 
 We greedily consume slots until the todo's estimated hours are
@@ -1124,13 +1132,18 @@ all, and with free time available the first event starts exactly at the
 frozen now.
 We fake the todo store and the clock so the tests are independent of
 the user's real todos and of when they run.
+The fake todo carries the ranking fields ([[priority]], [[deadline]],
+[[created]], [[id]]) that the shared sort key reads, so the tests
+exercise the real ordering code instead of mocking it away.
 <<test functions>>=
-def make_fake_todo():
+def make_fake_todo(id=1, title="task", priority=1.0, deadline=None):
   """Returns a minimal open todo for scheduling tests."""
   import types
   return types.SimpleNamespace(
-    status="open", who=None, estimated=1.0,
-    title="task", description="", labels=[],
+    id=id, status="open", who=None, estimated=1.0,
+    title=title, description="", labels=[],
+    priority=priority, deadline=deadline,
+    created="2024-01-01T00:00:00",
   )
 
 def freeze_schedule_now(monkeypatch, now):
@@ -1170,10 +1183,6 @@ def test_schedule_todo_events_starts_from_now(monkeypatch):
     lambda: (None, [make_fake_todo()]),
   )
   monkeypatch.setattr(
-    "nytid.cli.todo.effective_priority",
-    lambda t, now: 1.0,
-  )
-  monkeypatch.setattr(
     "nytid.cli.schedule.work_window",
     lambda: ("09:00", "12:00", ["mon"]),
   )
@@ -1184,6 +1193,34 @@ def test_schedule_todo_events_starts_from_now(monkeypatch):
   events = schedule_todo_events(None, end, [])
   assert len(events) == 1
   assert events[0].start == now.astimezone()
+@
+
+Unranked todos---those with no priority set---once crashed this
+function: their effective priority is [[None]], which cannot be
+compared with the floats of ranked todos.
+Let's verify that a mixed list schedules cleanly, with the ranked todo
+claiming the earliest slot and the unranked one still getting slots
+after it.
+<<test functions>>=
+def test_schedule_todo_events_mixed_ranked_unranked(monkeypatch):
+  ranked = make_fake_todo(id=1, title="ranked", priority=1.0)
+  unranked = make_fake_todo(id=2, title="unranked", priority=None)
+  monkeypatch.setattr(
+    "nytid.cli.todo.load_todos",
+    lambda: (None, [unranked, ranked]),
+  )
+  monkeypatch.setattr(
+    "nytid.cli.schedule.work_window",
+    lambda: ("09:00", "12:00", ["mon"]),
+  )
+  now = datetime.datetime(2024, 1, 8, 10, 30)
+  freeze_schedule_now(monkeypatch, now)
+
+  end = datetime.datetime(2024, 1, 15, 23, 59)
+  events = schedule_todo_events(None, end, [])
+  assert events[0].summary == "[TODO] ranked"
+  assert events[0].start == now.astimezone()
+  assert any(e.summary == "[TODO] unranked" for e in events)
 @
 
 Once we have the course schedule, we merge external calendars and then
@@ -1272,8 +1309,9 @@ def test_show_todo_option_defaults_to_scheduling(monkeypatch):
 @
 
 With all occupied time now in [[schedule]], we extract the busy intervals
-and greedily fill the remaining work-hour slots with todos, sorted by
-effective priority---unless the user opted out with [[--no-todo]].
+and greedily fill the remaining work-hour slots with todos, in the shared
+display order ([[todo ls]]'s ranked-first ordering)---unless the user
+opted out with [[--no-todo]].
 Note that [[start]] plays no role here: todos are scheduled from now
 until [[end]], and the print-time filtering
 (\cref{cli.schedule.filter-events}) trims any todo events that fall

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -476,8 +476,41 @@ def update_end_date(start, end):
   if end < start:
     return start + datetime.timedelta(weeks=1)
   return end
+@
+
+\paragraph{The end date is a day, not an instant}
+
+Both bounds are parsed with [[formats=["%Y-%m-%d"]]], so [[end]] is the
+\emph{midnight that starts} the end date.
+The user, however, said a date, and the print-time filter agrees with
+them: it keeps everything up to and including [[end.date()]].
+Anything that consumes [[end]] as an instant therefore stops a whole
+day short of what gets displayed.
+Three things did.
+The recurrence window never expanded external events on the last shown
+day, so the default seven-day view always lost day seven.
+[[compute_free_slots]] clipped that day's work window with
+[[min(day_end, end)]], collapsing it to nothing, so no todo was ever
+scheduled on the end date.
+And because those external events were missing, they were also missing
+from the occupied intervals, so a todo scheduled there would have
+double-booked.
+
+We fix all three at once by deriving the instant the user meant---the
+last moment of the end date---and passing \emph{that} wherever [[end]]
+is treated as a point in time.
+[[end]] itself stays as parsed, so the filter and the option's meaning
+are untouched.
+<<helper functions>>=
+def end_of_day(when):
+  """
+  Returns the last moment of `when`'s date.
+  """
+  return datetime.datetime.combine(when.date(),
+                                   datetime.time.max)
 <<double check [[start]] and [[end]] dates>>=
 end = update_end_date(start, end)
+end_of_range = end_of_day(end)
 @
 
 \paragraph{Testing [[update_end_date]]}
@@ -504,6 +537,42 @@ def test_update_end_date_equal():
   end = datetime.datetime(2024, 3, 1)
   result = update_end_date(start, end)
   assert result == end
+@
+
+\paragraph{Testing [[end_of_day]]}
+
+The helper itself is one line, so the test that matters is the one that
+shows what it buys us.
+We schedule a todo over a range whose only work day \emph{is} the end
+date: with the bare [[end]] the day collapses to a zero-length window
+and nothing is scheduled, while the end of that day leaves the whole
+work window available.
+<<test functions>>=
+def test_end_of_day_covers_the_whole_date():
+  end = datetime.datetime(2024, 1, 15)
+  assert end_of_day(end).date() == end.date()
+  assert end_of_day(end).hour == 23
+
+def test_todos_reach_the_last_shown_day(monkeypatch):
+  """The end date is a day the user can still work."""
+  monkeypatch.setattr(
+    "nytid.cli.todo.load_todos",
+    lambda: (None, [make_fake_todo()]),
+  )
+  monkeypatch.setattr(
+    "nytid.cli.schedule.work_window",
+    lambda: ("09:00", "12:00", ["mon"]),
+  )
+  # Friday; the only work day in range is Monday the 15th.
+  freeze_schedule_now(monkeypatch,
+                      datetime.datetime(2024, 1, 12, 10, 30))
+
+  end = datetime.datetime(2024, 1, 15)
+  assert schedule_todo_events(None, end, []) == []
+
+  events = schedule_todo_events(None, end_of_day(end), [])
+  assert len(events) == 1
+  assert events[0].start.date() == datetime.date(2024, 1, 15)
 @
 
 \subsection{Managing external calendars}
@@ -1360,22 +1429,58 @@ expanded into their occurrences (\cref{ExpandingRecurrences} in the
 schedules chapter).
 The window must cover both consumers of these events: the displayed
 range starts at [[start]], while todo scheduling treats events from
-\emph{now} until [[end]] as occupied time---so the window runs from
-the earlier of the two.
+\emph{now} until the end of the range as occupied time---so the window
+runs from the earlier of the two, and up to [[end_of_range]] so that
+the last shown day is included.
 The window bounds must be timezone aware (the expansion compares them
-against aware event times), whereas [[start]] and [[end]] arrive
-naive from the command line, hence the [[astimezone()]] calls.
+against aware event times), whereas the range bounds are naive, hence
+the [[astimezone()]] calls.
 <<add external calendar events to [[schedule]]>>=
 if not user or user == default_username:
   external_sources = get_external_sources(external)
   cache = build_calendar_cache(no_cache)
   now = datetime.datetime.now().astimezone()
-  window = (min(start.astimezone(), now), end.astimezone())
+  window = (min(start.astimezone(), now),
+            end_of_range.astimezone())
   external_calendar = schedutils.read_calendars(external_sources,
                                                 cache=cache,
                                                 window=window)
   for event in external_calendar.events:
     schedule.add_component(event)
+@
+
+The other consumer of [[end_of_range]] is worth pinning at the command
+level, since the window is assembled inline rather than in a helper we
+could call directly.
+We drive [[show]] with no courses and no todos, stubbing the calendar
+reader to capture the window it is handed.
+<<test functions>>=
+def test_show_window_covers_the_last_shown_day(monkeypatch):
+  """External recurrences must be expanded on the end date too."""
+  from typer.testing import CliRunner
+  captured = {}
+
+  def fake_read_calendars(sources, cache=None, window=None):
+    captured["window"] = window
+    return icalendar.Calendar()
+
+  monkeypatch.setattr(schedule_module.coursescli,
+                      "get_courses_configs", lambda *a, **k: {})
+  monkeypatch.setattr(schedule_module, "get_external_sources",
+                      lambda cli_sources=None: ["external.ics"])
+  monkeypatch.setattr(schedule_module.schedutils, "read_calendars",
+                      fake_read_calendars)
+
+  result = CliRunner().invoke(
+    schedule_module.cli,
+    ["show", "--start", "2024-06-03", "--end", "2024-06-09",
+     "--no-todo"])
+  assert result.exit_code == 0, result.output
+
+  _, window_end = captured["window"]
+  window_end = window_end.astimezone()
+  assert window_end.date() == datetime.date(2024, 6, 9)
+  assert window_end.hour == 23
 @
 
 \paragraph{Opting out of todo scheduling}
@@ -1427,17 +1532,49 @@ and greedily fill the remaining work-hour slots with todos, in the shared
 display order ([[todo ls]]'s ranked-first ordering)---unless the user
 opted out with [[--no-todo]].
 Note that [[start]] plays no role here: todos are scheduled from now
-until [[end]], and the print-time filtering
+until the end of the range, and the print-time filtering
 (\cref{cli.schedule.filter-events}) trims any todo events that fall
 before the shown range.
+We pass [[end_of_range]] for the same reason the recurrence window
+does---the last shown day is a day the user can work.
 [[schedule.events]] holds the \emph{complete} sign-up and external
 calendars---range filtering happens only at print time---so the busy
-intervals between now and a future [[end]] are all known here.
+intervals between now and the end of the range are all known here.
 <<add scheduled todo events to [[schedule]]>>=
 if todo:
   occupied = event_bounds(schedule.events)
-  for event in schedule_todo_events(user, end, occupied):
+  for event in schedule_todo_events(user, end_of_range, occupied):
     schedule.add_component(event)
+@
+
+Let's pin this wiring too, by stubbing the scheduler and inspecting the
+bound it is handed.
+Stubbing also keeps the test away from the running user's real todo
+store.
+<<test functions>>=
+def test_show_schedules_todos_to_the_last_shown_day(monkeypatch):
+  """Todo scheduling gets the same end-of-day bound."""
+  from typer.testing import CliRunner
+  captured = {}
+
+  def fake_schedule_todo_events(user, end, occupied):
+    captured["end"] = end
+    return []
+
+  monkeypatch.setattr(schedule_module.coursescli,
+                      "get_courses_configs", lambda *a, **k: {})
+  monkeypatch.setattr(schedule_module, "get_external_sources",
+                      lambda cli_sources=None: [])
+  monkeypatch.setattr(schedule_module, "schedule_todo_events",
+                      fake_schedule_todo_events)
+
+  result = CliRunner().invoke(
+    schedule_module.cli,
+    ["show", "--start", "2024-06-03", "--end", "2024-06-09",
+     "--todo"])
+  assert result.exit_code == 0, result.output
+  assert captured["end"].date() == datetime.date(2024, 6, 9)
+  assert captured["end"].hour == 23
 @
 
 \subsection{Filter events based on start--end time}

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -1111,6 +1111,18 @@ def schedule_todo_events(user, end, occupied):
 We import [[todo]] here rather than at the top of the file to avoid a
 circular import: [[todo]] imports [[schedule]] for scheduling its items,
 and [[schedule]] needs [[todo]] only for this helper.
+
+The owner test has to honour the convention [[todo]] established: an
+item with no [[who]] belongs to the default user.
+That is not a corner case---[[nytid todo add]] leaves [[who]] unset
+unless the user passes [[--who]], so it is the \emph{ordinary} way to
+record one's own task.
+Comparing [[t.who]] to [[user]] directly therefore filtered out
+precisely the todos most likely to be the user's own, and did so
+silently: they simply never appeared in the schedule.
+Every ownership test in [[todo]] spells the convention out the same
+way, and we match it here so the two views keep agreeing about what
+comes next---the reason the sort order is shared in the first place.
 <<load and filter todos>>=
 from nytid.cli import todo as todocli
 
@@ -1118,7 +1130,8 @@ _, todos = todocli.load_todos()
 todos = [t for t in todos if t.status != "done"]
 
 if user:
-  todos = [t for t in todos if t.who == user]
+  todos = [t for t in todos
+           if (t.who or default_username) == user]
 @
 
 High-urgency items should claim the earliest available slots, so we
@@ -1283,6 +1296,45 @@ def test_schedule_todo_events_mixed_ranked_unranked(monkeypatch):
   assert events[0].summary == "[TODO] ranked"
   assert events[0].start == now.astimezone()
   assert any(e.summary == "[TODO] unranked" for e in events)
+@
+
+The owner filter must read an unset [[who]] as the default user, the
+way the rest of [[todo]] does---otherwise the most ordinary kind of
+todo, added without [[--who]], never reaches the schedule.
+We pass the module's own [[default_username]] rather than a literal, so
+the tests hold for whoever runs them.
+The second test is the other half of the contract: honouring the
+default must not turn the filter into a no-op.
+<<test functions>>=
+def schedule_one_todo_for(monkeypatch, todo_item, user):
+  """Schedules `todo_item` for `user` at a frozen Monday now."""
+  monkeypatch.setattr(
+    "nytid.cli.todo.load_todos",
+    lambda: (None, [todo_item]),
+  )
+  monkeypatch.setattr(
+    "nytid.cli.schedule.work_window",
+    lambda: ("09:00", "12:00", ["mon"]),
+  )
+  freeze_schedule_now(monkeypatch,
+                      datetime.datetime(2024, 1, 8, 10, 30))
+  end = datetime.datetime(2024, 1, 15, 23, 59)
+  return schedule_todo_events(user, end, [])
+
+def test_schedule_todo_events_unset_who_is_default_user(monkeypatch):
+  """An unset owner means the default user, as in todo ls."""
+  events = schedule_one_todo_for(monkeypatch, make_fake_todo(),
+                                 schedule_module.default_username)
+  assert len(events) == 1
+  assert events[0].summary == "[TODO] task"
+
+def test_schedule_todo_events_excludes_other_owner(monkeypatch):
+  """Someone else's todos stay out of my schedule."""
+  item = make_fake_todo()
+  item.who = "somebody-else"
+  events = schedule_one_todo_for(monkeypatch, item,
+                                 schedule_module.default_username)
+  assert events == []
 @
 
 Once we have the course schedule, we merge external calendars and then

--- a/src/nytid/cli/schedule.nw
+++ b/src/nytid/cli/schedule.nw
@@ -1444,14 +1444,67 @@ if todo:
 \label{cli.schedule.filter-events}
 
 Before output, we keep only events overlapping the chosen interval.
+
+Which \emph{date} an event falls on depends on the timezone one asks
+in, and the events reaching this filter do not agree on one:
+[[sheets.EventFromCSV]] stores sign-up bookings in UTC, external feeds
+keep whatever zone the publisher used, and the todo events carry the
+local zone.
+The [[start]] and [[end]] bounds, meanwhile, are local dates the user
+typed.
+So the comparison must first put both sides in the same
+timezone---and the right one is the local zone, because that is what
+the output shows: [[format_event_csv]] renders every timestamp through
+[[astimezone()]].
+Comparing in the event's own zone instead made the filter and the
+display disagree around midnight, dropping a booking at 00:30 local
+(22:30 UTC the day before) from a range it would have printed inside,
+and keeping one just past the end for the same reason.
 <<set [[events]] to filtered timeline>>=
 events = []
 for event in schedutils.timeline(schedule):
-  if event.end.date() < start.date():
+  if event.end.astimezone().date() < start.date():
     continue
-  if event.start.date() > end.date():
+  if event.start.astimezone().date() > end.date():
     continue
   events.append(event)
+@
+
+Let's pin the agreement between filter and display.
+The test drives the filter through a helper that reuses the very same
+chunk, so it cannot drift from what [[show]] runs.
+The event is a booking at half past midnight local time---the shape
+that goes wrong---stored in a zone ten hours behind the local one, so
+that its own date is the previous day.
+We derive that zone from the current local offset rather than naming
+UTC, because whether UTC is behind or ahead depends on where the test
+runs, and the assertion should not.
+<<test functions>>=
+def filter_events_for_range(schedule, start, end):
+  """Runs show's print-time range filter over `schedule`."""
+  <<set [[events]] to filtered timeline>>
+  return events
+
+def test_filter_keeps_event_shown_on_start_date():
+  """The range filter must agree with the local-time display."""
+  local_start = datetime.datetime(2024, 6, 3, 0, 30).astimezone()
+  behind = datetime.timezone(local_start.utcoffset()
+                             - datetime.timedelta(hours=10))
+  event = icalendar.Event()
+  event.summary = "Early booking"
+  event.start = local_start.astimezone(behind)
+  event.end = (local_start
+               + datetime.timedelta(hours=1)).astimezone(behind)
+  assert event.end.date() < datetime.date(2024, 6, 3)  # premise
+
+  schedule = icalendar.Calendar()
+  schedule.add_component(event)
+  kept = filter_events_for_range(
+    schedule,
+    datetime.datetime(2024, 6, 3),
+    datetime.datetime(2024, 6, 10),
+  )
+  assert [e.summary for e in kept] == ["Early booking"]
 @
 
 \subsection{Output format}

--- a/src/nytid/cli/signupsheets.nw
+++ b/src/nytid/cli/signupsheets.nw
@@ -171,11 +171,44 @@ for (course, register), course_conf in courses.items():
   <<set [[outfile]] for [[course]]>>
 
   url = course_conf.get("ics")
-  sheets.generate_signup_sheet(outfile, url, needed_TAs)
+  sheets.generate_signup_sheet(outfile, url, needed_TAs,
+                               window=sheet_window)
   <<open [[outfile]] for editing if requested>>
 <<imports>>=
 from nytid.signup import sheets
 from nytid.signup import utils
+@
+
+The rows of the sheet are the individual teaching sessions, but a
+TimeEdit schedule states a recurring session once and leaves its
+occurrences implicit, so the calendar has to be expanded---and
+expansion has to be bounded, since an [[RRULE]] need not ever end.
+The command has no date range of its own to bound it with: a sign-up
+sheet covers \enquote{the course}, whose term the user never states.
+We therefore use the library's default horizon
+(\cref{ExpandingRecurrences} in the schedules chapter), which brackets
+any course generously in both directions---generously enough that a
+sheet generated before the term starts, or during it, covers the same
+sessions either way.
+We compute it once per invocation, alongside the timestamp, so every
+course in the run gets the same range.
+<<generation iteration variables>>=
+sheet_window = schedutils.default_window()
+@
+
+The stub above records the keyword arguments it is called with, so we
+can check that the window reaches the generator at all---the difference
+between a sheet with every session on it and one with only the first.
+<<test functions>>=
+def test_generate_passes_an_expansion_window(monkeypatch, tmp_path):
+  """Recurring sessions need a window to become rows."""
+  written = stub_sheet_generation(monkeypatch, ["good"],
+                                  {"good": tmp_path})
+  generate_signup_sheet(".*")
+  _, kwargs = written[0]
+  start, end = kwargs["window"]
+  now = datetime.datetime.now().astimezone()
+  assert start < now < end
 @
 
 By default, [[utils.needed_TAs]] uses the 12 as the group size.
@@ -293,7 +326,8 @@ def stub_sheet_generation(monkeypatch, courses, data_dirs):
   written = []
   monkeypatch.setattr(
     signupsheets_module.sheets, "generate_signup_sheet",
-    lambda outfile, url, needed_TAs: written.append(str(outfile)),
+    lambda outfile, url, needed_TAs, **kwargs:
+      written.append((str(outfile), kwargs)),
   )
   return written
 
@@ -304,7 +338,7 @@ def test_generate_skips_course_without_data_dir(monkeypatch, tmp_path):
                                   {"good": tmp_path})
   generate_signup_sheet(".*")
   assert len(written) == 1
-  assert "good" in written[0]
+  assert "good" in written[0][0]
 
 def test_generate_skips_first_course_without_data_dir(monkeypatch):
   """A failing first course must not raise UnboundLocalError."""

--- a/src/nytid/cli/signupsheets.nw
+++ b/src/nytid/cli/signupsheets.nw
@@ -221,13 +221,96 @@ if not outpath:
     outfile = data_root.path / f"signup-{course}-{timestamp}.csv"
 else:
   outfile = outpath / f"signup-{course}-{timestamp}.csv"
+@
+
+Both failure modes must leave [[outfile]] in a defined state, because
+the code that consumes it---the call to [[sheets.generate_signup_sheet]]
+above---sits outside this chunk and runs unconditionally.
+This is the noweb chunk-dependency hazard in its purest form: the chunk
+that \emph{assigns} the variable is the [[else]] arm, so an [[except]]
+arm that neither assigns nor leaves the loop hands the generator a
+stale [[outfile]].
+And [[outfile]] is stale in a specific, harmful way: it still holds the
+\emph{previous} course's path, so the failing course's events would be
+written over a sheet named after a course they do not belong to---or,
+if the very first course fails, [[outfile]] is unbound and the command
+dies with [[UnboundLocalError]].
+
+The two failures therefore need different answers.
+A [[PermissionError]] means we know where the sheet belongs but may not
+write there, so falling back to the working directory still produces
+the sheet the user asked for.
+A [[KeyError]] means the course has no data directory registered at
+all; there is no defensible place to put its sheet, so we skip the
+course---the same response the [[group_size]] chunk above gives to a
+course whose configuration it cannot use.
 <<handle errors for accessing course data directory>>=
 except KeyError as err:
-  logging.warning(err)
+  logging.warning(f"Can't find the data directory for {course} in "
+                  f"{register}: {err}")
+  continue
 except PermissionError as err:
   logging.warning(f"You don't have access to {course} in {register}: {err}")
   outfile = f"./signup-{course}-{timestamp}.csv"
   logging.warning(f"Writing file to current working directory: {outfile}")
+@
+
+Let's verify that a course without a data directory is skipped rather
+than allowed to borrow another course's path.
+The first test drives two courses where only the second fails, which is
+the silent-overwrite case; the second drives a single failing course,
+which is the [[UnboundLocalError]] case.
+We stub the sheet generator so the tests observe which paths would have
+been written without touching the network or the file system.
+<<test functions>>=
+def make_course_config():
+  """Returns a course config with the fields generate reads."""
+  conf = MagicMock()
+  conf.get.side_effect = lambda key: {
+    "num_students": "120",
+    "num_groups": "10",
+    "ics": "http://example/cal.ics",
+  }[key]
+  return conf
+
+def stub_sheet_generation(monkeypatch, courses, data_dirs):
+  """Stubs course lookup and generation; returns written paths."""
+  monkeypatch.setattr(
+    signupsheets_module.coursescli, "get_courses_configs",
+    lambda course, register: {
+      (name, "reg"): make_course_config() for name in courses
+    },
+  )
+
+  def fake_get_course_data(course, register):
+    if course not in data_dirs:
+      raise KeyError(course)
+    return MagicMock(path=data_dirs[course])
+
+  monkeypatch.setattr(signupsheets_module.courseutils,
+                      "get_course_data", fake_get_course_data)
+
+  written = []
+  monkeypatch.setattr(
+    signupsheets_module.sheets, "generate_signup_sheet",
+    lambda outfile, url, needed_TAs: written.append(str(outfile)),
+  )
+  return written
+
+def test_generate_skips_course_without_data_dir(monkeypatch, tmp_path):
+  """A failing course must not overwrite the previous one's sheet."""
+  written = stub_sheet_generation(monkeypatch,
+                                  ["good", "bad"],
+                                  {"good": tmp_path})
+  generate_signup_sheet(".*")
+  assert len(written) == 1
+  assert "good" in written[0]
+
+def test_generate_skips_first_course_without_data_dir(monkeypatch):
+  """A failing first course must not raise UnboundLocalError."""
+  written = stub_sheet_generation(monkeypatch, ["bad"], {})
+  generate_signup_sheet(".*")
+  assert written == []
 @
 
 Now, to compute [[timestamp]] we'll need the current time and then we simply 

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -10000,9 +10000,24 @@ environment or another non-system interpreter, so the detached helper
 must reuse [[sys.executable]] rather than assuming [[python3]] points at
 the correct environment.
 
+Because nobody is watching a detached run, the exit code is the only
+report it ever files.  We give it the same treatment the blocking
+headless path gives its subprocess: record it as a note so the outcome
+survives in the item's history, and hand a failed task to
+[[--reassign-to]] so it lands in a human's queue instead of quietly
+returning to [[pending]] indistinguishable from a run that simply did
+not finish.  Without that, the entire exit-code apparatus---the status
+file, [[read_detached_exit_code]] and its signal mapping---would deliver
+a number with no consumer.
+
+The note says \enquote{no output} because a detached pane writes to the
+terminal, not to a pipe we can capture; the wording matches the blocking
+path so both kinds of run leave notes in one format.
+
 <<helpers>>=
 def finalize_detached_todo(
-    todo_id, exit_code=1, exit_code_file=None
+    todo_id, exit_code=1, exit_code_file=None,
+    reassign_to=None,
 ):
     """Finish a non-blocking tmux-backed todo run."""
     if exit_code_file is not None:
@@ -10022,15 +10037,16 @@ def finalize_detached_todo(
     if item is None:
         return
 
-    result = type(
-        "DetachedResult", (),
-        {
-            "returncode": exit_code,
-            "stdout": None,
-        },
-    )()
+    append_note_to_item(
+        item,
+        f"Exit code: {exit_code} (no output)",
+        next_id,
+        todos,
+    )
 
     if item.status != "done":
+        if exit_code != 0 and reassign_to:
+            item.who = reassign_to
         item.status = "pending"
     for child in descendants:
         if child.status != "done":
@@ -10055,7 +10071,8 @@ def read_detached_exit_code(exit_code_file):
 
 
 def build_detached_todo_finalize_command(
-    todo_id, proc_wd, exit_code_file
+    todo_id, proc_wd, exit_code_file,
+    reassign_to=None,
 ):
     """Return shell command to finalize a detached todo run."""
     pythonpath = os.path.abspath(
@@ -10063,15 +10080,28 @@ def build_detached_todo_finalize_command(
             os.path.dirname(__file__), "..", "..", ".."
         )
     )
+    reassign_arg = (
+        f" --reassign-to {shlex.quote(reassign_to)}"
+        if reassign_to else ""
+    )
     return (
         f"PYTHONPATH={shlex.quote(pythonpath)} "
         f"{shlex.quote(sys.executable)} "
         "-c 'from nytid.cli.todo import cli; cli()' "
         f"_finalize-detached {todo_id} "
         f"--exit-code-file {shlex.quote(exit_code_file)}"
+        f"{reassign_arg}"
         f"; rm -f {shlex.quote(exit_code_file)}"
     )
 @
+
+The reassignee has to travel through that shell string because the
+finalizer runs in a fresh process minutes or hours later, long after
+the [[start]] invocation that knew about [[--reassign-to]] has exited.
+It is a user-supplied name interpolated into a command line, so it goes
+through [[shlex.quote]] like every other value here; omitting the flag
+entirely when there is no reassignee keeps the common case identical to
+what tmux ran before.
 
 <<argument and option definitions>>=
 finalize_id_arg = typer.Argument(
@@ -10081,6 +10111,9 @@ finalize_exit_arg = typer.Argument(
 finalize_file_opt = typer.Option(
     "--exit-code-file",
     help="File containing the exit code")
+finalize_reassign_opt = typer.Option(
+    "--reassign-to",
+    help="Worker to receive the todo if the run failed")
 @
 
 <<detached finalize command>>=
@@ -10091,10 +10124,13 @@ def finalize_detached_cmd(
                          finalize_exit_arg] = 1,
     exit_code_file: Annotated[str | None,
                               finalize_file_opt] = None,
+    reassign_to: Annotated[
+        str | None, finalize_reassign_opt] = None,
 ):
     """Finalize a detached tmux-backed todo run."""
     finalize_detached_todo(
-        todo_id, exit_code, exit_code_file
+        todo_id, exit_code, exit_code_file,
+        reassign_to,
     )
 @
 
@@ -10581,7 +10617,8 @@ try:
         )
         os.close(exit_fd)
         finalize_cmd = build_detached_todo_finalize_command(
-            todo_id, proc_wd, exit_code_file
+            todo_id, proc_wd, exit_code_file,
+            reassign_to,
         )
         run_todo_tmux_command(
             cmd,
@@ -11009,6 +11046,81 @@ def test_finalize_detached_todo_resets_pending(
     _, todos = load_todos()
     assert todos[0].status == "pending"
     assert load_active_stack() == []
+
+
+def test_finalize_detached_todo_records_exit_code(
+    temp_todo_dir,
+):
+    """Detached finalize leaves the exit code in the notes."""
+    save_todos(2, [
+        TodoItem(
+            id=1,
+            title="Review PR",
+            created="2026-02-20T10:00:00",
+            status="in-progress",
+        ),
+    ])
+    save_active_stack([1])
+    finalize_detached_todo(1, 3)
+    _, todos = load_todos()
+    assert "Exit code: 3" in todos[0].notes
+
+
+def test_finalize_detached_todo_reassigns_on_failure(
+    temp_todo_dir,
+):
+    """A failed detached run goes to the reassignee."""
+    save_todos(2, [
+        TodoItem(
+            id=1,
+            title="Review PR",
+            created="2026-02-20T10:00:00",
+            status="in-progress",
+            who="agent",
+        ),
+    ])
+    save_active_stack([1])
+    finalize_detached_todo(
+        1, 1, reassign_to="teacher",
+    )
+    _, todos = load_todos()
+    assert todos[0].who == "teacher"
+    assert todos[0].status == "pending"
+
+
+def test_finalize_detached_todo_keeps_owner_on_success(
+    temp_todo_dir,
+):
+    """A clean detached run stays with its worker."""
+    save_todos(2, [
+        TodoItem(
+            id=1,
+            title="Review PR",
+            created="2026-02-20T10:00:00",
+            status="in-progress",
+            who="agent",
+        ),
+    ])
+    save_active_stack([1])
+    finalize_detached_todo(
+        1, 0, reassign_to="teacher",
+    )
+    _, todos = load_todos()
+    assert todos[0].who == "agent"
+
+
+def test_detached_finalize_command_carries_reassignee():
+    """The tmux hook forwards --reassign-to to the finalizer."""
+    cmd = build_detached_todo_finalize_command(
+        7, "/tmp/project", "/tmp/status",
+        reassign_to="teacher",
+    )
+    assert "--reassign-to teacher" in cmd
+
+    plain = build_detached_todo_finalize_command(
+        7, "/tmp/project", "/tmp/status",
+    )
+    assert "--reassign-to" not in plain
 
 
 def test_finalize_detached_todo_reads_status_file(
@@ -13410,6 +13522,7 @@ from nytid.cli.todo import (
     get_active_stack_file,
     find_pending_by_priority,
     finalize_detached_todo,
+    build_detached_todo_finalize_command,
     read_detached_exit_code,
     parse_timeout,
     append_note_to_item,

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -7008,21 +7008,49 @@ priority, reconciliation keeps it that way instead of silently assigning
 one.  New children only receive numeric priorities when the parent has a
 numeric priority and the new child is entering the ranked subset.
 
+Reconciliation has to recurse, because the buffer the user edited does.
+[[render_child_markdown]] emits each child's own children at one deeper
+heading level and [[parse_editor_content]] parses them back into
+[[parsed_child.children]], so a reconciliation that walked only the
+first level would show the user their grandchildren, accept their
+edits, report success, and discard them.  Silently losing text the user
+typed is the worst failure mode an editor round-trip can have.
+
+We express the recursion as a nested \emph{function} rather than a
+reusable chunk.  The level being reconciled is described entirely by
+[[parent]] and [[parsed_children]]; making those parameters means a
+recursive call cannot accidentally inherit the outer level's variables,
+which is exactly the mistake a chunk reference would invite.  This also
+mirrors [[create_children_from_parsed]] on the [[add]] side, which has
+recursed from the start.
+
 <<reconcile children>>=
-<<build existing children index>>
-<<distribute child priorities>>
-<<update or create each parsed child>>
-<<remove deleted children>>
+def reconcile_children(parent, parsed_children):
+    """Match parsed sections against a parent's children.
+
+    Sections are matched to existing children by
+    normalized title so that they keep their ID,
+    status, and tracked time.  Unmatched sections
+    become new children, unmatched children are
+    removed with their subtrees, and each matched
+    child is reconciled against its own sections.
+    """
+    nonlocal next_id, todos
+    <<build existing children index>>
+    <<distribute child priorities>>
+    <<update or create each parsed child>>
+    <<remove deleted children>>
+
+reconcile_children(item, parsed.children)
 @
 
 We normalize titles to lowercase with stripped whitespace so that
 minor formatting changes in the editor do not accidentally create
 duplicate children.
 <<build existing children index>>=
-existing_children = get_children(todos, todo_id)
 existing_by_title = {
     c.title.strip().lower(): c
-    for c in existing_children
+    for c in get_children(todos, parent.id)
 }
 @
 
@@ -7036,13 +7064,13 @@ Existing unranked children do not consume a numeric slot.  They stay in
 the unranked tail until the user runs [[reprioritize]], while ranked or
 new children still share the parent's numeric range.
 <<distribute child priorities>>=
-if item.priority is None:
+if parent.priority is None:
     ranked_titles = []
     priorities = []
 else:
     ranked_titles = [
         parsed_child.title.strip().lower()
-        for parsed_child in parsed.children
+        for parsed_child in parsed_children
         if (
             parsed_child.title.strip().lower()
             not in existing_by_title
@@ -7053,7 +7081,7 @@ else:
     ]
     if ranked_titles:
         prio_high, prio_low = compute_child_priority_range(
-            todos, item
+            todos, parent
         )
         priorities = distribute_priorities_in_range(
             len(ranked_titles), prio_high, prio_low,
@@ -7063,21 +7091,27 @@ else:
 priority_iter = iter(priorities)
 @
 
-For each child in the parsed document we either update the matching
+For each section in the parsed document we either update the matching
 existing child (preserving its ID and status) or create a new one.
-New children inherit [[who]] from the parent ([[item]]) when their
+New children inherit [[who]] from the parent when their
 YAML block does not specify one --- the same rule as in
 [[create_children_from_parsed]] --- so that adding a sub-task in
 the editor never silently leaves it unassigned.
-We use a set to track which existing children were seen; any that
-remain unseen after this loop were removed in the editor.
+Popping each match out of [[existing_by_title]] doubles as the
+seen-marker: whatever is still in the index afterwards had no section
+and was therefore deleted in the editor.
+
+Each child is reconciled against its own sections immediately after it
+is settled, so a freshly created child can already receive
+grandchildren in the same save.  A newly appended child is on
+[[todos]] by then, which is what lets [[get_children]] find its own
+level on the recursive call.
 <<update or create each parsed child>>=
-new_child_ids = set()
-for i, parsed_child in enumerate(parsed.children):
+for parsed_child in parsed_children:
     norm_title = parsed_child.title.strip().lower()
     existing_child = existing_by_title.get(norm_title)
     if (
-        item.priority is None
+        parent.priority is None
         or (
             existing_child is not None
             and existing_child.priority is None
@@ -7086,7 +7120,7 @@ for i, parsed_child in enumerate(parsed.children):
         prio = None
     else:
         prio = next(priority_iter, None)
-    if norm_title in existing_by_title:
+    if existing_child is not None:
         child = existing_by_title.pop(norm_title)
         child.title = parsed_child.title
         child.notes = parsed_child.notes
@@ -7108,45 +7142,51 @@ for i, parsed_child in enumerate(parsed.children):
             )
         if "who" in child_meta:
             child.who = child_meta["who"]
-        new_child_ids.add(child.id)
     else:
         now = datetime.datetime.now().isoformat()
         child_meta = parsed_child.metadata
-        new_child = TodoItem(
+        child = TodoItem(
             id=next_id,
             title=parsed_child.title,
             labels=child_meta.get(
-                "labels", list(item.labels)
+                "labels", list(parent.labels)
             ),
             priority=prio,
             status="pending",
             created=now,
             deadline=normalize_deadline(
                 child_meta.get(
-                    "deadline", item.deadline
+                    "deadline", parent.deadline
                 )
             ),
-            parent_id=todo_id,
-            who=child_meta.get("who", item.who),
+            parent_id=parent.id,
+            who=child_meta.get("who", parent.who),
             notes=parsed_child.notes,
             wd=canonicalize_wd(child_meta.get("wd")),
             command=child_meta.get("command"),
         )
-        todos.append(new_child)
-        new_child_ids.add(next_id)
+        todos.append(child)
         next_id += 1
         typer.echo(
-            f"  Added sub-item #{new_child.id}: "
-            f"{new_child.title}"
+            f"  Added sub-item #{child.id}: "
+            f"{child.title}"
         )
+    reconcile_children(child, parsed_child.children)
 @
 
 Children remaining in [[existing_by_title]] were not present in the
-parsed document, meaning the user deleted their headings.  We remove
-them from the list rather than silently keeping orphaned sub-items.
+parsed document, meaning the user deleted their headings.  Their own
+subtrees go with them: an item whose parent is gone is not hidden but
+promoted to a visible root by [[get_visible_roots]], so leaving
+grandchildren behind would move them into the main list instead of
+removing them.
 <<remove deleted children>>=
 for removed in existing_by_title.values():
-    todos = [t for t in todos if t.id != removed.id]
+    doomed = {removed.id} | {
+        d.id
+        for d in get_descendants(todos, removed.id)
+    }
+    todos = [t for t in todos if t.id not in doomed]
     typer.echo(
         f"  Removed sub-item #{removed.id}: "
         f"{removed.title}"
@@ -7155,6 +7195,124 @@ for removed in existing_by_title.values():
 
 
 \subsection{Testing Editor Reconciliation}
+
+Let's verify the recursion in both directions: an edit to an existing
+grandchild reaches it and preserves its identity, and a brand-new
+[[##]] section becomes a real grandchild rather than being ignored.
+
+<<test functions>>=
+def test_edit_interactive_updates_grandchild(
+  temp_todo_dir,
+):
+  """Editing a '##' section reaches the grandchild."""
+  save_todos(4, [
+    TodoItem(
+      id=1, title="Parent",
+      created="2026-02-20T10:00:00",
+      priority=5.0,
+    ),
+    TodoItem(
+      id=2, title="Child", parent_id=1,
+      created="2026-02-20T10:00:00",
+      priority=4.0,
+    ),
+    TodoItem(
+      id=3, title="Grandchild", parent_id=2,
+      created="2026-02-20T10:00:00",
+      priority=3.0, status="done",
+    ),
+  ])
+  buffer = (
+    "Parent\n"
+    "\n"
+    "# Child\n"
+    "\n"
+    "## Grandchild\n"
+    "\n"
+    "Reviewed the notes.\n"
+  )
+  with patch(
+    "nytid.cli.todo.open_editor",
+    return_value=buffer,
+  ):
+    result = runner.invoke(cli, ["edit", "1", "-E"])
+
+  assert result.exit_code == 0, result.stdout
+  _, todos = load_todos()
+  grandchild = next(t for t in todos if t.id == 3)
+  assert grandchild.notes == "Reviewed the notes."
+  assert grandchild.status == "done"
+  assert grandchild.parent_id == 2
+
+
+def test_edit_interactive_adds_grandchild(
+  temp_todo_dir,
+):
+  """A new '##' section becomes a real grandchild."""
+  save_todos(3, [
+    TodoItem(
+      id=1, title="Parent",
+      created="2026-02-20T10:00:00",
+      priority=5.0,
+    ),
+    TodoItem(
+      id=2, title="Child", parent_id=1,
+      created="2026-02-20T10:00:00",
+      priority=4.0,
+    ),
+  ])
+  buffer = (
+    "Parent\n"
+    "\n"
+    "# Child\n"
+    "\n"
+    "## Brand new\n"
+  )
+  with patch(
+    "nytid.cli.todo.open_editor",
+    return_value=buffer,
+  ):
+    result = runner.invoke(cli, ["edit", "1", "-E"])
+
+  assert result.exit_code == 0, result.stdout
+  _, todos = load_todos()
+  added = next(
+    t for t in todos if t.title == "Brand new"
+  )
+  assert added.parent_id == 2
+
+
+def test_edit_interactive_removes_subtree(
+  temp_todo_dir,
+):
+  """Deleting a '#' section removes its grandchildren too."""
+  save_todos(4, [
+    TodoItem(
+      id=1, title="Parent",
+      created="2026-02-20T10:00:00",
+      priority=5.0,
+    ),
+    TodoItem(
+      id=2, title="Child", parent_id=1,
+      created="2026-02-20T10:00:00",
+      priority=4.0,
+    ),
+    TodoItem(
+      id=3, title="Grandchild", parent_id=2,
+      created="2026-02-20T10:00:00",
+      priority=3.0,
+    ),
+  ])
+  with patch(
+    "nytid.cli.todo.open_editor",
+    return_value="Parent\n",
+  ):
+    result = runner.invoke(cli, ["edit", "1", "-E"])
+
+  assert result.exit_code == 0, result.stdout
+  _, todos = load_todos()
+  assert [t.id for t in todos] == [1]
+@
 
 <<test functions>>=
 def test_edit_interactive_reconcile():

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -11744,6 +11744,17 @@ exit handling.  That keeps the high-level rule uniform across all three
 paths: stopping a parent also unwinds any active descendants before the
 caller decides what status changes, if any, should follow.
 
+It also means sharing the helper's one awkward property: it reports the
+item by looking it up in state reloaded \emph{after} the descendants
+were unwound, so a concurrent [[rm]] can leave that lookup empty.  The
+todo store is built for concurrent workers---that is what
+[[mutate_todo_state]] and its file locking are for---and the other two
+callers already treat the miss as reachable.  By the time we get here
+the stop has succeeded; only the sentence describing it is missing a
+title, so we fall back to naming the ID rather than turning a completed
+operation into a traceback the user might respond to by running it
+again.
+
 <<stop command>>=
 @cli.command()
 def stop(
@@ -11765,7 +11776,37 @@ def stop(
     ) = stop_todo_hierarchy(
         todo_id, who=default_username
     )
+    if item is None:
+        typer.echo(f"Stopped: #{todo_id}")
+        return
     typer.echo(f"Stopped: #{todo_id} {item.title}")
+@
+
+Let's verify the fallback, standing in for the concurrent removal by
+making the post-stop reload find nothing:
+
+<<test functions>>=
+def test_stop_reports_id_when_item_vanished(
+  temp_todo_dir,
+):
+  """A todo removed mid-stop is reported by ID, not a traceback."""
+  save_todos(2, [
+    TodoItem(
+      id=1, title="Task",
+      created="2026-02-20T10:00:00",
+      status="in-progress",
+    ),
+  ])
+  save_active_stack([1])
+
+  with patch(
+    "nytid.cli.todo.stop_todo_hierarchy",
+    return_value=(1, None, 2, [], [], []),
+  ):
+    result = runner.invoke(cli, ["stop", "1"])
+
+  assert result.exit_code == 0, result.stdout
+  assert "Stopped: #1" in result.output
 @
 
 Let's verify that the [[stop]] command also protects shared labels.

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -7980,8 +7980,18 @@ view.  We therefore give [[done]] its own [[--who]] option: omitting
 it defaults to the current user, while completing another worker's
 item requires naming that worker explicitly.
 
+[[<<argument and option definitions>>]] is a bucket chunk: noweb
+concatenates every definition of it into a single module-level block,
+so two chunks that happen to bind the same name are not a duplicate
+definition the reader can see---they are an ordinary reassignment, and
+the later one wins silently.  [[--force]] means something different for
+[[done]] than it does for [[rm]], so each gets a command-qualified
+name.  A bare [[force_opt]] here would be adopted by whichever command
+was defined last in the file, and the flag's help would describe the
+wrong operation.
+
 <<argument and option definitions>>=
-force_opt = typer.Option(
+done_force_opt = typer.Option(
     "--force", "-f",
     help="Force-complete even if children are "
          "still active (marks them done too)")
@@ -7996,7 +8006,7 @@ done_who_opt = typer.Option(
 def done(
     todo_id: Annotated[int | None,
                        todo_id_arg] = None,
-    force: Annotated[bool, force_opt] = False,
+    force: Annotated[bool, done_force_opt] = False,
     who: Annotated[str | None,
                    done_who_opt] = default_username,
 ):
@@ -9175,8 +9185,14 @@ An omitted ID means \enquote{remove the current active todo}, which mirrors
 the way [[done]], [[note]], and [[edit]] already target the same
 context-aware default.
 
+Here [[--force]] only waives the confirmation prompt; the removal it
+skips asking about is the same one either way.  That is a different
+promise from [[done --force]], which changes what the command
+\emph{does}, so the two carry separate option objects under
+command-qualified names.
+
 <<argument and option definitions>>=
-force_opt = typer.Option(
+rm_force_opt = typer.Option(
     "--force", "-f",
     help="Skip confirmation")
 @
@@ -9186,7 +9202,7 @@ force_opt = typer.Option(
 def rm(
     todo_id: Annotated[int | None,
                        todo_id_arg] = None,
-    force: Annotated[bool, force_opt] = False,
+    force: Annotated[bool, rm_force_opt] = False,
 ):
     """Remove a todo item.
 
@@ -9228,6 +9244,21 @@ def rm(
         typer.echo(
             f"  Also removed {len(descendants)} sub-items"
         )
+@
+
+Let's pin the separation down, since a name collision in a bucket chunk
+leaves no trace at either definition site---only the help output tells
+you which one survived:
+
+<<test functions>>=
+def test_force_help_is_per_command():
+  """done --force and rm --force document themselves."""
+  done_help = runner.invoke(cli, ["done", "--help"])
+  assert "Force-complete" in done_help.output
+
+  rm_help = runner.invoke(cli, ["rm", "--help"])
+  assert "Skip confirmation" in rm_help.output
+  assert "Force-complete" not in rm_help.output
 @
 
 Let's verify that a three-level tree disappears completely and that the

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -1523,6 +1523,49 @@ def get_siblings(
     ]
 @
 
+Direct children are the right unit for display and for priority
+comparison, because both work one level at a time.  Deletion is
+different: it is the one operation whose correctness depends on the
+\emph{whole} subtree, since an item whose parent no longer exists is
+treated as a visible root by [[get_visible_roots]] and would reappear
+at the top of [[ls]].  We therefore also offer the transitive view.
+
+<<sub-item helpers>>=
+def get_descendants(
+    todos: list[TodoItem], parent_id: int
+) -> list[TodoItem]:
+    """Get every descendant of a todo item.
+
+    Returns children, grandchildren, and deeper, in
+    depth-first order.
+    """
+    found = []
+    for child in get_children(todos, parent_id):
+        found.append(child)
+        found.extend(
+            get_descendants(todos, child.id)
+        )
+    return found
+@
+
+Let's verify that the transitive walk reaches past the first level and
+that the one-level helper still does not:
+
+<<test functions>>=
+def test_get_descendants_reaches_grandchildren():
+  """Descendants include deeper levels, children do not."""
+  todos = [
+    TodoItem(id=1, title="Root"),
+    TodoItem(id=2, title="Child", parent_id=1),
+    TodoItem(id=3, title="Grandchild", parent_id=2),
+    TodoItem(id=4, title="Unrelated"),
+  ]
+  assert {t.id for t in get_children(todos, 1)} == {2}
+  assert {
+    t.id for t in get_descendants(todos, 1)
+  } == {2, 3}
+@
+
 The [[add]], [[reprioritize]], and [[import]] commands compare a
 todo against its siblings to place it in the priority order.
 When multiple workers share a parent, the comparison set must be
@@ -8922,11 +8965,22 @@ def test_done_closes_github_issue(temp_todo_dir):
 
 \subsection{The [[rm]] Command}
 
-Removing a todo requires confirmation. If the item has children,
-those are removed as well.  We stop any active tracking for the
-removed item and clean up stale labels left by previously removed
-todos---otherwise orphaned [[todo:N]] labels accumulate in the
-session and generate phantom tracking entries.
+Removing a todo requires confirmation.  The whole subtree goes with
+it---children, grandchildren, and deeper---because the store has no
+notion of a parentless sub-item: [[get_visible_roots]] promotes any
+item whose parent is missing to the top level, so a surviving
+grandchild would not be tidied away but instead reappear in the main
+[[ls]] list, detached from the tree the user just deleted.
+
+That is also why the count shown in the confirmation prompt is the
+transitive one.  The prompt is the user's last chance to notice that
+[[rm]] is about to take more than they had in mind, so it must state
+the real size of what will disappear.
+
+We stop any active tracking for the removed item and clean up stale
+labels left by previously removed todos---otherwise orphaned
+[[todo:N]] labels accumulate in the session and generate phantom
+tracking entries.
 
 An omitted ID means \enquote{remove the current active todo}, which mirrors
 the way [[done]], [[note]], and [[edit]] already target the same
@@ -8964,28 +9018,56 @@ def rm(
         )
         raise typer.Exit(1)
 
-    children = get_children(todos, todo_id)
+    descendants = get_descendants(todos, todo_id)
     if not force:
         msg = f"Remove #{todo_id}: {item.title}?"
-        if children:
-            msg += f" ({len(children)} sub-items)"
+        if descendants:
+            msg += f" ({len(descendants)} sub-items)"
         if not typer.confirm(msg):
             typer.echo("Cancelled.")
             raise typer.Exit(0)
 
-    # Remove item and its children
     ids_to_remove = {todo_id}
-    ids_to_remove.update(c.id for c in children)
+    ids_to_remove.update(d.id for d in descendants)
     todos = [t for t in todos if t.id not in ids_to_remove]
 
     <<stop tracking if active>>
 
     save_todos(next_id, todos)
     typer.echo(f"Removed #{todo_id}: {item.title}")
-    if children:
+    if descendants:
         typer.echo(
-            f"  Also removed {len(children)} sub-items"
+            f"  Also removed {len(descendants)} sub-items"
         )
+@
+
+Let's verify that a three-level tree disappears completely and that the
+summary counts what actually went:
+
+<<test functions>>=
+def test_rm_removes_whole_subtree(temp_todo_dir):
+  """Removing a root also removes grandchildren."""
+  save_todos(4, [
+    TodoItem(
+      id=1, title="Root",
+      created="2026-02-20T10:00:00",
+    ),
+    TodoItem(
+      id=2, title="Child", parent_id=1,
+      created="2026-02-20T10:00:00",
+    ),
+    TodoItem(
+      id=3, title="Grandchild", parent_id=2,
+      created="2026-02-20T10:00:00",
+    ),
+  ])
+
+  result = runner.invoke(cli, ["rm", "1", "--force"])
+
+  assert result.exit_code == 0
+  assert "Also removed 2 sub-items" in result.output
+  _, todos = load_todos()
+  assert todos == []
 @
 
 Let's verify both the explicit and active-stack forms of [[rm]]:
@@ -12998,6 +13080,7 @@ from nytid.cli.todo import (
     get_todo_dir,
     get_todo_file,
     get_children,
+    get_descendants,
     get_siblings,
     get_active_siblings,
     check_parent_completion,

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -5662,8 +5662,39 @@ if label_filter:
 if who_filter:
     filtered = [
         t for t in filtered
-        if t.who and re.search(who_filter, t.who)
+        if re.search(
+            who_filter, t.who or default_username
+        )
     ]
+@
+
+An unset [[who]] means the current user, not \enquote{nobody}.  That is
+the rule [[find_pending_by_priority]] already documents and applies for
+the same backward-compatibility reason as the active stack: items
+written before the field existed have no owner recorded, but they still
+belong to whoever is running the command.
+
+Getting this wrong is not merely a display difference, because [[ls]]
+and [[next]] answer the same question from the same data.  With the
+stricter test, [[--who]] defaulting to [[$USER]] hid every ownerless
+item from the listing while [[next]] went on choosing them---so the
+user could be handed a task that their own todo list insisted did not
+exist, and no [[--who]] value short of the empty string would reveal
+it.
+
+<<test functions>>=
+def test_ls_shows_items_without_who(temp_todo_dir):
+  """An ownerless item is listed for the current user."""
+  save_todos(2, [
+    TodoItem(
+      id=1, title="Legacy task", priority=5.0,
+      created="2026-02-20T10:00:00",
+      who=None,
+    ),
+  ])
+  result = runner.invoke(cli, ["ls"])
+  assert result.exit_code == 0
+  assert "Legacy task" in result.output
 @
 
 Let's verify that the [[--status]] filter correctly isolates items

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -379,6 +379,7 @@ class TodoItem:
         """
         known = {f.name for f in cls.__dataclass_fields__.values()}
         filtered = {k: v for k, v in data.items() if k in known}
+        <<coerce stored estimate to hours>>
         return cls(**filtered)
 @
 
@@ -408,6 +409,52 @@ def __setattr__(self, name, value):
     if name == "labels" and value is not None:
         value = sorted(set(value))
     object.__setattr__(self, name, value)
+@
+
+\subsection{Estimates Are Numbers, Not Strings}
+
+[[estimated]] is declared [[float | None]] and is formatted with
+[[:.1f]] and fed to [[datetime.timedelta]] throughout the module, so a
+string in that field is not merely untidy---it makes [[ls]], [[view]],
+and [[export]] raise.  Every command that writes an estimate converts
+it with [[parse_hours]] first, but the store is plain JSON that users
+are invited to inspect and edit, and older versions of the [[--edit]]
+path wrote the raw front-matter string.  Deserialization is the one
+place all of that flows through, so it is where we can repair it.
+
+We fall back to [[None]] rather than propagating the [[ValueError]] for
+the same reason [[effective_priority]] tolerates a bad deadline: one
+unreadable estimate should cost that item its duration, not lock the
+user out of their entire todo list.
+
+<<coerce stored estimate to hours>>=
+if isinstance(filtered.get("estimated"), str):
+    try:
+        filtered["estimated"] = parse_hours(
+            filtered["estimated"]
+        )
+    except ValueError:
+        filtered["estimated"] = None
+@
+
+Let's verify that a suffixed string estimate is converted on load and
+that an unreadable one degrades to no estimate:
+
+<<test functions>>=
+def test_from_dict_coerces_string_estimate():
+  """A stored '90m' estimate loads as 1.5 hours."""
+  item = TodoItem.from_dict({
+    "id": 1, "title": "Test", "estimated": "90m",
+  })
+  assert item.estimated == pytest.approx(1.5)
+
+
+def test_from_dict_drops_unreadable_estimate():
+  """An unparseable estimate becomes None, not a crash."""
+  item = TodoItem.from_dict({
+    "id": 1, "title": "Test", "estimated": "soon",
+  })
+  assert item.estimated is None
 @
 
 \subsection{Testing the Data Model}
@@ -5094,7 +5141,16 @@ if run_command:
 @
 
 We apply metadata from the YAML front matter to the parent item,
-with CLI flags taking precedence where provided:
+with CLI flags taking precedence where provided.
+
+The estimate needs the same [[parse_hours]] treatment on both branches,
+not just on the CLI one.  Our minimal YAML parser deliberately returns a
+plain string for anything that is not a bare number, so the
+[[1h30m]] and [[90m]] forms that [[--estimate]] advertises arrive here
+as text.  Storing that text in a field the rest of the module formats
+with [[:.1f]] would write a value that every later [[ls]], [[view]],
+and [[export]] chokes on, so the front-matter branch converts it to
+hours exactly as its sibling child and [[edit]] paths already do.
 
 <<create parent from parsed>>=
 now = datetime.datetime.now().isoformat()
@@ -5125,7 +5181,9 @@ parent_item = TodoItem(
     estimated=(
         parse_hours(estimate)
         if estimate
-        else meta.get("estimate")
+        else parse_hours(str(meta["estimate"]))
+        if "estimate" in meta
+        else None
     ),
     description=description or "",
     parent_id=resolved_parent,
@@ -5144,6 +5202,39 @@ typer.echo(
     f"Added todo #{parent_item.id}: "
     f"{parent_item.title}"
 )
+@
+
+Let's verify that a suffixed front-matter estimate is stored as a
+number, and that the resulting item survives the listing that used to
+crash on it:
+
+<<test functions>>=
+def test_add_edit_yaml_estimate_parses_suffix(
+  temp_todo_dir,
+):
+  """Editor YAML `estimate: 90m` stores 1.5 hours."""
+  buffer = (
+    "Estimated task\n"
+    "---\n"
+    "estimate: 90m\n"
+    "---\n"
+  )
+  with patch(
+    "nytid.cli.todo.open_editor",
+    return_value=buffer,
+  ):
+    result = runner.invoke(
+      cli,
+      ["add", "--edit", "--top-level", "--prio", "1"],
+    )
+
+  assert result.exit_code == 0, result.stdout
+  _, todos = load_todos()
+  assert todos[0].estimated == pytest.approx(1.5)
+
+  listing = runner.invoke(cli, ["ls", "--who", ""])
+  assert listing.exit_code == 0
+  assert "1.5" in listing.output
 @
 
 Children are created recursively. Each child inherits the parent's

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -130,6 +130,7 @@ cli = typer.Typer(
 )
 
 <<data model>>
+<<deadline helpers>>
 <<effective priority>>
 <<storage functions>>
 <<active stack helpers>>
@@ -469,6 +470,198 @@ def test_todo_item_from_dict_preserves_null_priority():
     assert item.priority is None
 @
 
+\section{Deadlines}
+
+A deadline enters the system as whatever string the user typed at the
+command line or in the editor buffer, and is then read back on every
+subsequent listing, ranking, and export.  Those two roles pull in
+opposite directions.  The write side wants to be \emph{strict}: at the
+moment of writing we still know which option produced the value, so a
+mistake can be reported against the flag the user just typed.  The read
+side wants to be \emph{forgiving}: by then the value sits in
+[[todos.json]] next to dozens of healthy items, and one bad timestamp
+must not take the whole list down with it.
+
+Doing only one of the two is not enough.  Validating on write alone
+leaves every todo file written by an older version---or edited by hand,
+which the plain-JSON storage format openly invites---able to crash
+[[ls]].  Being forgiving on read alone silently accepts
+[[--deadline tomorrow]] and then quietly ignores it forever.  So we do
+both, and share the one primitive they need: turning a stored string
+into a [[datetime]] that can be compared with the current time.
+
+\subsection{Comparable Timestamps}
+
+Two shapes of stored value defeat a direct comparison.  A string that is
+not ISO 8601 at all cannot be parsed.  A string that carries a UTC
+offset \emph{does} parse, but into an \emph{aware} [[datetime]], and
+Python refuses to subtract that from the \emph{naive}
+[[datetime.datetime.now()]] the rest of this module compares against.
+
+Converting an aware value to local time and then dropping its offset
+resolves the second case without distorting the first: the local
+wall-clock reading denotes the same instant, so ordering and
+time-remaining arithmetic are unchanged, and the result is
+commensurable with every other timestamp we hold.  Returning [[None]]
+rather than raising for unparseable input lets each caller decide what
+a missing timestamp means for it, instead of forcing every call site to
+wrap the parse in a [[try]] block.
+
+<<deadline helpers>>=
+def naive_local_datetime(value):
+    """Return `value` as a naive local-time datetime.
+
+    Accepts a datetime or an ISO 8601 string.  Aware
+    values are converted to local time and stripped of
+    their offset so that they can be compared with
+    `datetime.datetime.now()`.  Returns ``None`` when
+    the value is empty or is not a recognizable
+    timestamp.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime.datetime):
+        parsed = value
+    else:
+        try:
+            parsed = datetime.datetime.fromisoformat(
+                str(value)
+            )
+        except (TypeError, ValueError):
+            return None
+    if parsed.tzinfo is None:
+        return parsed
+    return parsed.astimezone().replace(tzinfo=None)
+@
+
+Let's verify all four cases: a naive string passes through unchanged,
+an aware string loses its offset while denoting the same instant, an
+already-parsed [[datetime]] is accepted directly, and unparseable
+input yields [[None]] instead of an exception.
+
+<<test functions>>=
+def test_naive_local_datetime_passes_naive_through():
+  """A naive ISO string parses unchanged."""
+  assert naive_local_datetime(
+    "2026-03-01T12:00:00"
+  ) == datetime.datetime(2026, 3, 1, 12, 0)
+
+
+def test_naive_local_datetime_strips_offset():
+  """An aware string becomes naive local time."""
+  aware = "2026-03-01T12:00:00+01:00"
+  expected = datetime.datetime.fromisoformat(
+    aware
+  ).astimezone().replace(tzinfo=None)
+  result = naive_local_datetime(aware)
+  assert result.tzinfo is None
+  assert result == expected
+
+
+def test_naive_local_datetime_accepts_datetime():
+  """An already-parsed datetime is accepted."""
+  when = datetime.datetime(2026, 3, 1, 12, 0)
+  assert naive_local_datetime(when) == when
+
+
+def test_naive_local_datetime_rejects_garbage():
+  """Unparseable input yields None, not an exception."""
+  assert naive_local_datetime("tomorrow") is None
+  assert naive_local_datetime("") is None
+  assert naive_local_datetime(None) is None
+@
+
+\subsection{Validating Deadlines at Write Time}
+
+Every command that stores a deadline routes it through
+[[normalize_deadline]], which is what makes the stored field
+trustworthy: it either becomes a string that
+[[datetime.datetime.fromisoformat]] will accept, or the command exits
+before writing anything.  Reporting the error here rather than at read
+time is the whole point---the user is looking at the deadline they just
+typed, so the message can name it.
+
+The bare calendar date is the shape people actually type, so we detect
+it exactly with [[strptime]] and return it untouched.  Preserving it
+keeps [[todo view]] and the editor buffer showing [[2026-03-01]]
+instead of a padded [[2026-03-01T00:00:00]], and an exact format match
+behaves identically on every supported Python version, unlike
+[[datetime.date.fromisoformat]], whose accepted syntax widened in
+Python~3.11.
+
+Anything else is stored as naive local time.  That matters beyond
+[[effective_priority]]: [[todo_display_sort_key]] orders the unranked
+tail by comparing deadline \emph{strings}, and a mixture of offsets
+would make that lexicographic comparison disagree with chronological
+order.
+
+<<deadline helpers>>=
+def normalize_deadline(value):
+    """Return `value` as a canonical deadline string.
+
+    A bare ``YYYY-MM-DD`` date is kept as written; any
+    other ISO 8601 timestamp is stored as naive local
+    time.  Returns ``None`` for ``None`` or an empty
+    string, and exits with an error when the value is
+    not a recognizable timestamp.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        datetime.datetime.strptime(text, "%Y-%m-%d")
+        return text
+    except ValueError:
+        pass
+    parsed = naive_local_datetime(text)
+    if parsed is None:
+        typer.echo(
+            f"Error: invalid deadline {text!r}; use "
+            "YYYY-MM-DD or an ISO 8601 datetime such "
+            "as 2026-03-01T17:00",
+            err=True,
+        )
+        raise typer.Exit(1)
+    return parsed.isoformat()
+@
+
+Let's verify the three outcomes: a bare date survives verbatim, an
+offset-bearing timestamp is rewritten to naive local time, and prose
+input is rejected rather than stored.
+
+<<test functions>>=
+def test_normalize_deadline_keeps_bare_date():
+  """A YYYY-MM-DD deadline is stored as written."""
+  assert normalize_deadline("2026-03-01") == "2026-03-01"
+
+
+def test_normalize_deadline_strips_offset():
+  """An offset-bearing deadline becomes naive local."""
+  stored = normalize_deadline(
+    "2026-03-01T12:00:00+01:00"
+  )
+  assert "+" not in stored
+  assert datetime.datetime.fromisoformat(
+    stored
+  ) == datetime.datetime.fromisoformat(
+    "2026-03-01T12:00:00+01:00"
+  ).astimezone().replace(tzinfo=None)
+
+
+def test_normalize_deadline_rejects_prose():
+  """A non-ISO deadline exits instead of being stored."""
+  with pytest.raises(typer.Exit):
+    normalize_deadline("tomorrow")
+
+
+def test_normalize_deadline_passes_empty_through():
+  """Absent deadlines stay absent."""
+  assert normalize_deadline(None) is None
+  assert normalize_deadline("") is None
+@
+
 \section{Effective Priority}
 
 The effective priority determines display and scheduling order for
@@ -488,6 +681,24 @@ quadratic curve stays near zero until roughly the last third of the
 time span, then ramps up sharply---matching the human experience of
 \enquote{it's not urgent yet} followed by \enquote{this is due soon!}
 
+This function is on the read path of nearly every command, so it is
+also where a single malformed stored timestamp does the most damage.
+[[normalize_deadline]] keeps new writes clean, but a file written by an
+older version or edited by hand can still hold anything, and raising
+here would take down [[ls]], [[next]], [[export]], and
+[[schedule show --todo]] for \emph{all} items because of \emph{one}.
+We therefore treat the boost as a refinement that can be skipped: an
+unparseable deadline simply yields the base priority, so the item keeps
+its place in the ranking rather than crashing it.
+
+The [[created]] timestamp needs a different fallback, because it is
+only used to measure how long the item has been waiting.  When it is
+missing---it defaults to the empty string---we substitute the deadline
+itself, which drives [[total_span]] down to its one-day floor.  The
+resulting curve stays flat until the final day and still awards the
+full boost once the deadline has passed, so overdue work keeps
+surfacing even when we cannot tell how long it has been pending.
+
 <<effective priority>>=
 def effective_priority(
     item: TodoItem,
@@ -498,10 +709,13 @@ def effective_priority(
     Returns ``None`` when the stored base priority is
     unset. Otherwise returns base priority plus a
     deadline-based urgency boost that increases
-    quadratically as the deadline approaches.
+    quadratically as the deadline approaches.  An
+    unparseable stored deadline yields the base
+    priority instead of raising.
     """
     if now is None:
         now = datetime.datetime.now()
+    now = naive_local_datetime(now)
 
     if item.priority is None:
         return None
@@ -511,11 +725,12 @@ def effective_priority(
     if not item.deadline:
         return base
 
-    deadline_dt = datetime.datetime.fromisoformat(
-        item.deadline
-    )
-    created_dt = datetime.datetime.fromisoformat(
-        item.created
+    deadline_dt = naive_local_datetime(item.deadline)
+    if deadline_dt is None:
+        return base
+    created_dt = (
+        naive_local_datetime(item.created)
+        or deadline_dt
     )
 
     max_boost = get_max_boost()
@@ -612,6 +827,45 @@ def test_effective_priority_past_deadline():
     now = datetime.datetime(2026, 1, 20)
     result = effective_priority(item, now)
     assert result == 5.0 + DEFAULT_MAX_BOOST
+
+
+def test_effective_priority_ignores_bad_deadline():
+    """An unparseable deadline yields the base priority."""
+    item = TodoItem(
+        id=1, title="Test", priority=5.0,
+        created="2026-01-01T00:00:00",
+        deadline="tomorrow",
+    )
+    now = datetime.datetime(2026, 1, 20)
+    assert effective_priority(item, now) == 5.0
+
+
+def test_effective_priority_accepts_aware_deadline():
+    """A timezone-aware deadline does not break the math."""
+    item = TodoItem(
+        id=1, title="Test", priority=5.0,
+        created="2026-01-01T00:00:00",
+        deadline="2026-01-15T00:00:00+01:00",
+    )
+    now = datetime.datetime(2026, 1, 20)
+    assert effective_priority(item, now) == (
+        5.0 + DEFAULT_MAX_BOOST
+    )
+
+
+def test_effective_priority_without_created():
+    """A missing created timestamp still boosts overdue work."""
+    item = TodoItem(
+        id=1, title="Test", priority=5.0,
+        created="",
+        deadline="2026-01-15T00:00:00",
+    )
+    overdue = datetime.datetime(2026, 1, 20)
+    assert effective_priority(item, overdue) == (
+        5.0 + DEFAULT_MAX_BOOST
+    )
+    early = datetime.datetime(2026, 1, 1)
+    assert effective_priority(item, early) == 5.0
 
 
 def test_effective_priority_unset_priority():
@@ -4468,11 +4722,15 @@ if parent is None and not top_level:
 @
 
 When a parent is set, inherit its deadline and labels unless the user
-explicitly provided overrides:
+explicitly provided overrides.  This chunk is shared by [[add]] and
+[[import]], which makes it the single place where a command-line
+[[--deadline]] becomes stored data---so it is also where that string
+has to be validated.  An inherited parent deadline needs no check: it
+was normalized when the parent was written.
 
 <<inherit from parent>>=
 inherited_labels = list(label) if label else []
-inherited_deadline = deadline
+inherited_deadline = normalize_deadline(deadline)
 if resolved_parent is not None:
     parent_item = next(
         (t for t in todos if t.id == resolved_parent),
@@ -4488,6 +4746,51 @@ if resolved_parent is not None:
         inherited_labels = list(parent_item.labels)
     if deadline is None and parent_item.deadline:
         inherited_deadline = parent_item.deadline
+@
+
+Let's verify the two halves of the deadline contract end to end.  A
+mistyped [[--deadline]] must be refused before anything reaches disk,
+and a todo file that already contains such a value---written by an
+older version, or edited by hand---must still list.
+
+<<test functions>>=
+def test_add_rejects_invalid_deadline(temp_todo_dir):
+  """A non-ISO --deadline fails before writing."""
+  result = runner.invoke(
+    cli,
+    ["add", "-t", "Grade labs", "-d", "tomorrow",
+     "--prio", "1"],
+  )
+  assert result.exit_code == 1
+  assert "invalid deadline" in result.output
+  _, todos = load_todos()
+  assert todos == []
+
+
+def test_add_normalizes_aware_deadline(temp_todo_dir):
+  """An offset-bearing --deadline is stored naive."""
+  result = runner.invoke(
+    cli,
+    ["add", "-t", "Grade labs", "--prio", "1",
+     "-d", "2026-03-01T12:00:00+01:00"],
+  )
+  assert result.exit_code == 0
+  _, todos = load_todos()
+  assert "+" not in todos[0].deadline
+
+
+def test_ls_survives_unparseable_deadline(temp_todo_dir):
+  """A legacy bad deadline must not break the listing."""
+  save_todos(2, [
+    TodoItem(
+      id=1, title="Legacy task", priority=5.0,
+      created="2026-02-20T10:00:00",
+      deadline="tomorrow",
+    ),
+  ])
+  result = runner.invoke(cli, ["ls", "--who", ""])
+  assert result.exit_code == 0
+  assert "Legacy task" in result.output
 @
 
 Priority selection has three modes. [[--prio]] bypasses all inference.
@@ -4775,7 +5078,9 @@ initial_meta = {}
 if label:
     initial_meta["labels"] = list(label)
 if deadline:
-    initial_meta["deadline"] = deadline
+    initial_meta["deadline"] = normalize_deadline(
+        deadline
+    )
 if estimate:
     initial_meta["estimate"] = parse_hours(estimate)
 if who:
@@ -4814,7 +5119,9 @@ parent_item = TodoItem(
     priority=priority,
     status="pending",
     created=now,
-    deadline=deadline or meta.get("deadline"),
+    deadline=normalize_deadline(
+        deadline or meta.get("deadline")
+    ),
     estimated=(
         parse_hours(estimate)
         if estimate
@@ -4920,8 +5227,8 @@ child_meta = parsed_child.metadata
 child_labels = child_meta.get(
     "labels", list(parent_labels)
 )
-child_deadline = child_meta.get(
-    "deadline", parent_deadline
+child_deadline = normalize_deadline(
+    child_meta.get("deadline", parent_deadline)
 )
 child_who = child_meta.get("who", parent_who)
 child_wd = canonicalize_wd(child_meta.get("wd"))
@@ -6426,7 +6733,7 @@ item:
 if title is not None:
     item.title = title
 if deadline is not None:
-    item.deadline = deadline
+    item.deadline = normalize_deadline(deadline)
 if estimate is not None:
     item.estimated = parse_hours(estimate)
 <<apply label edits>>
@@ -6546,7 +6853,9 @@ if "command" in meta:
 if "labels" in meta:
     item.labels = meta["labels"]
 if "deadline" in meta:
-    item.deadline = meta["deadline"]
+    item.deadline = normalize_deadline(
+        meta["deadline"]
+    )
 if "estimate" in meta:
     item.estimated = parse_hours(str(meta["estimate"]))
 if "who" in meta:
@@ -6656,7 +6965,9 @@ for i, parsed_child in enumerate(parsed.children):
         if "labels" in child_meta:
             child.labels = child_meta["labels"]
         if "deadline" in child_meta:
-            child.deadline = child_meta["deadline"]
+            child.deadline = normalize_deadline(
+                child_meta["deadline"]
+            )
         if "estimate" in child_meta:
             child.estimated = parse_hours(
                 str(child_meta["estimate"])
@@ -6676,8 +6987,10 @@ for i, parsed_child in enumerate(parsed.children):
             priority=prio,
             status="pending",
             created=now,
-            deadline=child_meta.get(
-                "deadline", item.deadline
+            deadline=normalize_deadline(
+                child_meta.get(
+                    "deadline", item.deadline
+                )
             ),
             parent_id=todo_id,
             who=child_meta.get("who", item.who),
@@ -12585,6 +12898,8 @@ from nytid.cli.todo import (
     ParsedItem,
     ParsedTodo,
     canonicalize_wd,
+    naive_local_datetime,
+    normalize_deadline,
     effective_priority,
     sort_todos_for_display,
     load_todos,

--- a/src/nytid/cli/todo.nw
+++ b/src/nytid/cli/todo.nw
@@ -10169,6 +10169,7 @@ if item.wd or run or pane or window or item.command:
     <<prepare subprocess environment>>
     <<resolve todo auto-suspend>>
     <<determine command to run>>
+    <<initialize run outcome>>
     if pane or window:
         <<run in tmux>>
         if block:
@@ -10176,6 +10177,18 @@ if item.wd or run or pane or window or item.command:
     else:
         <<run subprocess>>
         <<handle subprocess exit>>
+@
+
+[[<<handle subprocess exit>>]] is shared by both arms of that branch,
+so every variable it reads has to be bound before the branch rather
+than inside one arm.  [[result]] satisfies that on its own because each
+arm assigns it, but only the direct-spawn arm can time out---tmux
+launches pass no timeout to the pane---so its outcome flag needs a
+default here.  Without one, the shared exit handler would raise
+[[NameError]] on every blocking [[--pane]] and [[--window]] run.
+
+<<initialize run outcome>>=
+timed_out = False
 @
 
 Todo launches now follow the same context-building path as track launches.
@@ -11109,12 +11122,23 @@ finally:
 
 When a [[--timeout]] fires, [[subprocess.TimeoutExpired]] carries
 any partial output captured before the kill signal.  We post that
-partial output as a note (so the teacher sees what the agent
-managed to do), reassign the task to [[--reassign-to]] (defaulting
-to [[$USER]]), and reset to pending.  Setting [[result = None]]
-signals to the exit handler that timeout was already handled.
+partial output as a note so the teacher sees what the agent managed
+to do, and reset the item to pending.
+
+What we deliberately do \emph{not} do here is reassign the task, even
+though this is where we learn that it timed out.  Ownership is what
+[[stop_todo_hierarchy]] uses to decide whose tracking session to close:
+it reloads the item from disk and derives the worker as
+[[item.who or default_username]].  Writing the new owner before the
+stop would therefore aim the stop at somebody who never started
+tracking, and the agent's clock would keep running long after its
+process was killed.  Recording [[timed_out]] instead lets the exit
+handler apply the reassignment on the far side of the stop, which is
+exactly what the non-timeout failure path in
+[[<<handle headless exit status>>]] already does.
 
 <<handle subprocess timeout>>=
+timed_out = True
 partial = (
     exc.stdout if exc.stdout else ""
 )
@@ -11136,8 +11160,6 @@ if item is not None:
     append_note_to_item(
         item, note, next_id, todos
     )
-    if reassign_to:
-        item.who = reassign_to
     item.status = "pending"
     save_todos(next_id, todos)
 typer.echo(
@@ -11175,6 +11197,8 @@ if item is None:
 
 if item.status == "done":
     pass
+elif timed_out:
+    <<handle timeout exit status>>
 elif headless:
     <<handle headless exit status>>
 elif typer.confirm(
@@ -11211,6 +11235,23 @@ if headless and result is not None:
     append_note_to_item(
         item, note, next_id, todos
     )
+@
+
+This is the deferred half of the timeout handling: tracking has now
+been stopped against the worker who started it, so we are finally free
+to hand the task to whoever should look at it.
+
+The branch sits ahead of the [[headless]] one and ahead of the
+interactive prompt because a killed process never reported an outcome.
+Asking \enquote{mark todo as done?} about work we ourselves cut short
+invites the user to record a completion that did not happen, so a
+timed-out task always goes back to pending regardless of how it was
+launched.
+
+<<handle timeout exit status>>=
+if reassign_to:
+    item.who = reassign_to
+item.status = "pending"
 @
 
 In headless mode, a non-zero exit code indicates failure.
@@ -11291,6 +11332,47 @@ def test_start_headless_captures_output(temp_todo_dir):
     assert item.notes is not None
     assert "hello" in item.notes
     assert "Exit code: 0" in item.notes
+@
+
+A timed-out run must close the \emph{original} worker's tracking
+session before the task changes hands.  We drive the timeout by making
+[[subprocess.run]] raise, then check both halves: the agent's clock is
+closed, and the task now belongs to the teacher.
+
+<<test functions>>=
+def test_start_timeout_stops_original_worker(
+  temp_todo_dir,
+):
+  """A timed-out run closes the agent's clock, then reassigns."""
+  from subprocess import TimeoutExpired
+  from nytid.cli.track import load_active_session
+
+  save_todos(2, [
+    TodoItem(
+      id=1, title="Task",
+      created="2026-02-20T10:00:00",
+      who="agent", labels=["grading"],
+    ),
+  ])
+  with patch(
+    "nytid.cli.todo.subprocess.run",
+    side_effect=TimeoutExpired(["true"], 1),
+  ):
+    result = runner.invoke(
+      cli,
+      ["start", "1", "--headless",
+       "--command", "true",
+       "--timeout", "1s",
+       "--reassign-to", "teacher"],
+    )
+
+  assert result.exit_code == 0, result.stdout
+  _, todos = load_todos()
+  item = todos[0]
+  assert item.who == "teacher"
+  assert item.status == "pending"
+  agent_session = load_active_session("agent")
+  assert agent_session.get_active_labels() == []
 @
 
 A failing subprocess in headless mode should reassign to the

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -5270,13 +5270,19 @@ def run_tmux_command(
     focus_labels: list[str] | None = None,
     focus_who: str | None = None,
     focus_window: bool = False,
+    auto_suspend: bool = True,
 ) -> int | None:
     """Run a command in tmux and optionally wait for exit.
 
-    When ``focus_labels`` is set, auto-suspend hooks are
-    installed.  Pane launches suspend directly on pane focus
-    changes, while window launches synchronize against the
-    authoritative tmux selected window.
+    When ``focus_labels`` is set, they are published as the new
+    pane's or window's tracked context, which is what lets
+    nested commands discover the labels they run under.
+
+    ``auto_suspend`` additionally arms the hooks that stop and
+    restart those labels when attention moves.  Pane launches
+    suspend directly on pane focus changes, while window
+    launches synchronize against the authoritative tmux
+    selected window.
     """
     ready_channel = make_tmux_channel("ready")
     wait_channel = None
@@ -5437,11 +5443,12 @@ state of its own.
 source_window_id = None
 source_window_labels = None
 needs_window_sync = False
+published_window_labels = False
 
 def launch_and_publish_state():
     nonlocal pane_id, window_id, session_id
     nonlocal source_window_id, source_window_labels
-    nonlocal needs_window_sync
+    nonlocal needs_window_sync, published_window_labels
 
     result = subprocess.run(
         tmux_args,
@@ -5460,7 +5467,7 @@ def launch_and_publish_state():
     if focus_labels and focus_who:
         if not tmux_server_key:
             raise RuntimeError(
-                "tmux server key missing for auto-suspend launch"
+                "tmux server key missing for tracked launch"
             )
         if focus_window and window_id and session_id:
             write_window_labels(
@@ -5469,25 +5476,27 @@ def launch_and_publish_state():
                 tmux_server_key,
                 focus_labels,
             )
-            prev_wid = read_last_selected_window(
-                focus_who,
-                tmux_server_key,
-                session_id,
-            )
-            source_window_id = prev_wid
-            if prev_wid is not None:
-                source_window_labels = read_window_labels(
-                    prev_wid,
+            published_window_labels = True
+            if auto_suspend:
+                prev_wid = read_last_selected_window(
                     focus_who,
                     tmux_server_key,
+                    session_id,
                 )
+                source_window_id = prev_wid
+                if prev_wid is not None:
+                    source_window_labels = read_window_labels(
+                        prev_wid,
+                        focus_who,
+                        tmux_server_key,
+                    )
+                needs_window_sync = True
             write_last_selected_window(
                 focus_who,
                 tmux_server_key,
                 session_id,
                 window_id,
             )
-            needs_window_sync = True
         else:
             write_pane_labels(
                 pane_id,
@@ -5495,11 +5504,12 @@ def launch_and_publish_state():
                 tmux_server_key,
                 focus_labels,
             )
-            install_tmux_focus_hooks(
-                pane_id,
-                focus_who,
-                tmux_server_key,
-            )
+            if auto_suspend:
+                install_tmux_focus_hooks(
+                    pane_id,
+                    focus_who,
+                    tmux_server_key,
+                )
             install_tmux_suspend_cleanup_hook(
                 pane_id,
                 focus_who,
@@ -5548,6 +5558,8 @@ if needs_window_sync:
         focus_who,
         tmux_server_key,
     )
+
+if published_window_labels:
     install_tmux_window_cleanup_hook(
         pane_id,
         window_id,
@@ -5556,6 +5568,24 @@ if needs_window_sync:
         focus_labels,
     )
 @
+
+Note which steps hang off which condition.  Publishing the labels and
+installing the cleanup hook that eventually removes them are two halves
+of the same act, so they follow \emph{publication}: leaving them coupled
+to auto-suspend would let a labels file outlive the pane that owned it
+and make every later command believe that window is still tracked.
+
+The transition itself---suspending the window we came from, restarting
+the labels of the one we arrived at, and arming the session hook that
+repeats this on every subsequent switch---is the auto-suspend behaviour
+proper, so it follows [[auto_suspend]].
+
+[[write_last_selected_window]] stays unconditional because it is a
+statement of fact about tmux, not a policy: some \emph{other} tracked
+window in this session may already have armed the session hook, and that
+hook compares against this file.  Leaving it pointing at the window we
+just left would make the next real switch compute its transition from a
+window nobody is in.
 
 When [[--no-block]] is used, the tmux pane needs to call
 [[nytid track stop]] after the child exits.  The
@@ -8638,16 +8668,25 @@ else:
     )
 @
 
+The pane and window labels files answer two questions that happen to
+share a storage location.  Auto-suspend asks \enquote{which labels
+should I stop when attention moves away from here?}, but every nested
+command asks a different one: \enquote{what am I working on right
+now?}---[[--inherit-labels]] to branch off the current context,
+[[register_tmux_context_labels]] to join it, and the ID-less [[todo]]
+commands to know which task they refer to.
+
+Only the first question is about suspending.  Withholding the labels
+when the user passes [[--no-auto-suspend]] therefore disabled a set of
+features that have nothing to do with suspension, and did so silently:
+[[--inherit-labels]] simply inherited nothing.  We publish the context
+for every tracked launch and let [[auto_suspend]] decide only whether
+the suspend machinery is armed on top of it.
+
 <<run launched process>>=
-focus_labels_for_tmux = (
-    tracking_labels if use_auto_suspend else None
-)
-focus_who_for_tmux = (
-    who if use_auto_suspend else None
-)
-focus_window_for_tmux = (
-    bool(window and use_auto_suspend)
-)
+focus_labels_for_tmux = tracking_labels
+focus_who_for_tmux = who
+focus_window_for_tmux = bool(window)
 try:
     if pane or window:
         if block:
@@ -8660,6 +8699,7 @@ try:
                 focus_labels=focus_labels_for_tmux,
                 focus_who=focus_who_for_tmux,
                 focus_window=focus_window_for_tmux,
+                auto_suspend=use_auto_suspend,
             )
         else:
             <<set up non-blocking tmux launch>>
@@ -8736,6 +8776,7 @@ run_tmux_command(
     focus_labels=focus_labels_for_tmux,
     focus_who=focus_who_for_tmux,
     focus_window=focus_window_for_tmux,
+    auto_suspend=use_auto_suspend,
 )
 exit_code = None
 @
@@ -11916,6 +11957,145 @@ def test_build_tmux_hook_command_uses_guarded_run_shell():
     assert "#{pane_dead_signal}" in hook
     assert "cleanup-command" in hook
     assert "tmux wait-for -S done-chan" in hook
+
+def test_start_publishes_context_without_auto_suspend(
+  temp_tracking_dir,
+):
+  """--no-auto-suspend still hands the launch its context labels."""
+  with patch.dict(
+    os.environ, {"TMUX": "session"}, clear=True,
+  ), patch(
+    "nytid.cli.track.run_tmux_command",
+    return_value=0,
+  ) as mock_tmux:
+    result = runner.invoke(
+      cli,
+      ["start", "work", "--pane", "--no-auto-suspend"],
+    )
+
+  assert result.exit_code == 0
+  call_kwargs = mock_tmux.call_args.kwargs
+  assert call_kwargs["focus_labels"] == ["work"]
+  assert call_kwargs["focus_who"] == default_username
+  assert call_kwargs["auto_suspend"] is False
+
+
+def test_start_window_publishes_context_without_auto_suspend(
+  temp_tracking_dir,
+):
+  """A --window launch publishes window labels either way."""
+  with patch.dict(
+    os.environ, {"TMUX": "session"}, clear=True,
+  ), patch(
+    "nytid.cli.track.run_tmux_command",
+    return_value=0,
+  ) as mock_tmux:
+    result = runner.invoke(
+      cli,
+      ["start", "work", "--window", "--no-auto-suspend"],
+    )
+
+  assert result.exit_code == 0
+  call_kwargs = mock_tmux.call_args.kwargs
+  assert call_kwargs["focus_window"] is True
+  assert call_kwargs["focus_labels"] == ["work"]
+  assert call_kwargs["auto_suspend"] is False
+
+
+def test_run_tmux_command_publishes_pane_labels_unsuspended(
+  temp_tracking_dir,
+):
+  """Pane labels are written even when the focus hooks stay off."""
+  events = []
+
+  def fake_subprocess_run(args, **kwargs):
+    class Result:
+      stdout = "%42 @7 $9\n"
+    return Result()
+
+  with patch(
+    "nytid.cli.track.subprocess.run",
+    side_effect=fake_subprocess_run,
+  ), patch(
+    "nytid.cli.track.install_tmux_exit_hooks",
+  ), patch(
+    "nytid.cli.track.build_tmux_server_key",
+    return_value=TEST_SERVER_KEY,
+  ), patch(
+    "nytid.cli.track.install_tmux_focus_hooks",
+    side_effect=lambda *a, **k: events.append("focus-hooks"),
+  ), patch(
+    "nytid.cli.track.install_tmux_suspend_cleanup_hook",
+    side_effect=lambda *a, **k: events.append("cleanup-hook"),
+  ):
+    run_tmux_command(
+      ["/bin/sh"],
+      cwd="/tmp",
+      env={"TMUX": "/tmp/tmux.sock,1,0"},
+      block=False,
+      focus_labels=["work"],
+      focus_who=default_username,
+      auto_suspend=False,
+    )
+
+  assert read_pane_labels(
+    "%42", default_username, TEST_SERVER_KEY,
+  ) == ["work"]
+  assert "focus-hooks" not in events
+  assert "cleanup-hook" in events
+
+
+def test_run_tmux_command_publishes_window_labels_unsuspended(
+  temp_tracking_dir,
+):
+  """Window labels are published without arming the transition."""
+  events = []
+
+  def fake_subprocess_run(args, **kwargs):
+    class Result:
+      stdout = "%42 @7 $9\n"
+    return Result()
+
+  with patch(
+    "nytid.cli.track.subprocess.run",
+    side_effect=fake_subprocess_run,
+  ), patch(
+    "nytid.cli.track.install_tmux_exit_hooks",
+  ), patch(
+    "nytid.cli.track.build_tmux_server_key",
+    return_value=TEST_SERVER_KEY,
+  ), patch(
+    "nytid.cli.track.stop_tracking_labels",
+    side_effect=lambda *a, **k: events.append("stop"),
+  ), patch(
+    "nytid.cli.track.install_tmux_window_sync_hooks",
+    side_effect=lambda *a, **k: events.append("sync-hooks"),
+  ), patch(
+    "nytid.cli.track.install_tmux_window_cleanup_hook",
+    side_effect=lambda *a, **k: events.append("cleanup-hook"),
+  ):
+    run_tmux_command(
+      ["/bin/sh"],
+      cwd="/tmp",
+      env={"TMUX": "/tmp/tmux.sock,1,0"},
+      window=True,
+      block=False,
+      focus_labels=["work"],
+      focus_who=default_username,
+      focus_window=True,
+      auto_suspend=False,
+    )
+
+  assert read_window_labels(
+    "@7", default_username, TEST_SERVER_KEY,
+  ) == ["work"]
+  assert read_last_selected_window(
+    default_username, TEST_SERVER_KEY, "$9",
+  ) == "@7"
+  assert "stop" not in events
+  assert "sync-hooks" not in events
+  assert "cleanup-hook" in events
+
 
 def test_make_tmux_completion_guard_without_status_file():
   """A launch with no status file still gets a unique guard."""

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -4279,19 +4279,26 @@ def status(
         <<show all workers status>>
 @
 
-<<show single worker status>>=
-session = load_active_session(who)
+Rendering one worker's active labels is needed in three places---the
+single-worker view, the per-worker loop below, and the
+backward-compatibility path that follows it.  Keeping three copies is
+how the three views drift apart, so we write it once as a function.  A
+function rather than a chunk: the three call sites live in different
+scopes, and a parameter list makes the inputs explicit where a shared
+chunk would silently depend on whatever names happen to be bound.
 
-if not session.is_active():
-    typer.echo(f"No active tracking for {who}")
-    return
-
-typer.echo(f"Currently tracking ({who}):")
-current_time = datetime.datetime.now()
-
-for label in session.get_active_labels():
-    info = session.get_label_info(label)
-    if info:
+<<helper functions>>=
+def echo_worker_status(
+    display_name: str,
+    session: "ActiveSession",
+) -> None:
+    """Print one worker's active labels with their durations."""
+    typer.echo(f"Currently tracking ({display_name}):")
+    current_time = datetime.datetime.now()
+    for label in session.get_active_labels():
+        info = session.get_label_info(label)
+        if info is None:
+            continue
         start_time, notes, batch_id = info
         duration = current_time - start_time
         notes_display = f" - {notes}" if notes else ""
@@ -4302,13 +4309,38 @@ for label in session.get_active_labels():
         )
 @
 
+<<show single worker status>>=
+session = load_active_session(who)
+
+if not session.is_active():
+    typer.echo(f"No active tracking for {who}")
+    return
+
+echo_worker_status(who, session)
+@
+
 When no [[--who]] is specified, we discover all active workers by
 globbing for session files in the tracking directory. This gives a
 quick overview of who is currently tracking time.
 
+The glob deliberately cannot match the pre-multi-worker
+[[current_session.json]], whose name carries no worker suffix.  That
+file therefore needs its own pass, and the question that pass must ask
+is narrow: \emph{was the default worker already shown?}  Asking the
+broader question---was \emph{anything} shown---hides an unmigrated
+user's own session as soon as any other worker (an agent, say) is
+tracking, which is precisely when a stale timer is easiest to miss.
+
+We answer it by recording which session files the loop actually
+rendered.  Comparing paths rather than worker names is what makes this
+robust: [[get_current_session_file]] is the single authority on which
+file a worker's session lives in, including its own fallback to the
+legacy name, so a path already in the set means the same session, no
+matter which spelling of the worker got us there.
+
 <<show all workers status>>=
 tracking_dir = get_tracking_dir()
-found_any = False
+rendered_session_files = set()
 
 if tracking_dir.exists():
     for session_file in sorted(
@@ -4319,48 +4351,22 @@ if tracking_dir.exists():
         )
         session = load_active_session(worker)
         if session.is_active():
-            found_any = True
-            typer.echo(f"Currently tracking ({worker}):")
-            current_time = datetime.datetime.now()
-            for label in session.get_active_labels():
-                info = session.get_label_info(label)
-                if info:
-                    start_time, notes, batch_id = info
-                    duration = current_time - start_time
-                    notes_display = (
-                        f" - {notes}" if notes else ""
-                    )
-                    typer.echo(
-                        f"  {label}: "
-                        f"{format_duration(duration)}"
-                        f"{notes_display}"
-                    )
+            rendered_session_files.add(session_file)
+            echo_worker_status(worker, session)
 
 # Also check old unsuffixed file for backward compat
 old_session_file = tracking_dir / "current_session.json"
 if old_session_file.exists():
     session = load_active_session(default_username)
-    if session.is_active() and not found_any:
-        found_any = True
-        typer.echo(
-            f"Currently tracking ({default_username}):"
-        )
-        current_time = datetime.datetime.now()
-        for label in session.get_active_labels():
-            info = session.get_label_info(label)
-            if info:
-                start_time, notes, batch_id = info
-                duration = current_time - start_time
-                notes_display = (
-                    f" - {notes}" if notes else ""
-                )
-                typer.echo(
-                    f"  {label}: "
-                    f"{format_duration(duration)}"
-                    f"{notes_display}"
-                )
+    already_shown = (
+        get_current_session_file(default_username)
+        in rendered_session_files
+    )
+    if session.is_active() and not already_shown:
+        rendered_session_files.add(old_session_file)
+        echo_worker_status(default_username, session)
 
-if not found_any:
+if not rendered_session_files:
     typer.echo("No active tracking")
 @
 
@@ -4447,6 +4453,58 @@ def test_status_tuple_unpacking_regression(temp_tracking_dir):
     # Should not see any error messages
     assert "ValueError" not in result.stdout
     assert "too many values to unpack" not in result.stdout
+
+def test_status_shows_legacy_session_beside_other_workers(
+  temp_tracking_dir,
+):
+  """An unmigrated session stays visible when another worker tracks."""
+  legacy_file = temp_tracking_dir / "current_session.json"
+
+  def legacy_aware_session_file(who=None):
+    if who is None:
+      who = default_username
+    per_worker = temp_tracking_dir / (
+      f"current_session_{sanitize_who(who)}.json"
+    )
+    if (who == default_username
+        and not per_worker.exists()
+        and legacy_file.exists()):
+      return legacy_file
+    return per_worker
+
+  legacy_session = ActiveSession()
+  legacy_session.start_labels(["mine"], datetime.datetime.now())
+  temp_tracking_dir.mkdir(parents=True, exist_ok=True)
+  legacy_file.write_text(json.dumps(legacy_session.to_dict()))
+
+  with patch(
+    "nytid.cli.track.get_current_session_file",
+    side_effect=legacy_aware_session_file,
+  ), patch(
+    "nytid.cli.track.get_current_session_lock_file",
+    side_effect=lambda who=None:
+      legacy_aware_session_file(who).with_suffix(".lock"),
+  ):
+    runner.invoke(cli, ["start", "theirs", "--who", "Agent"])
+    result = runner.invoke(cli, ["status"])
+
+  assert result.exit_code == 0
+  assert "mine" in result.stdout
+  assert "theirs" in result.stdout
+
+def test_status_does_not_repeat_migrated_worker(temp_tracking_dir):
+  """A worker with both file names is rendered exactly once."""
+  runner.invoke(cli, ["start", "work"])
+  legacy_file = temp_tracking_dir / "current_session.json"
+  legacy_file.write_text(
+    (temp_tracking_dir / (
+      f"current_session_{sanitize_who(default_username)}.json"
+    )).read_text()
+  )
+
+  result = runner.invoke(cli, ["status"])
+  assert result.exit_code == 0
+  assert result.stdout.count("Currently tracking") == 1
 
 def test_status_with_batch_tracking(temp_tracking_dir):
     """Test status command with labels from different batches"""

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -333,16 +333,62 @@ def sanitize_tmux_id(value: str) -> str:
         for c in value
     )
 
-def build_tmux_server_key(
+@
+
+Tmux-scoped state files---window labels, pane labels, suspend state,
+the last-selected window---embed a \emph{server key} in their
+filenames.  The key must identify a server \emph{instance}, not merely
+a server address.  Hostname and socket path alone are not enough:
+after a reboot, a fresh tmux server listens on the very same default
+socket path, and its window numbering restarts at [[@0]].  Under an
+address-only key, a brand-new window would collide with a dead
+server's state file for the same [[@N]] identifier, and nytid would
+resurrect the dead window's labels in a window that was never tracked.
+The reboot also kills tmux without firing any [[pane-exited]] hooks,
+so the hook-based cleanup (\cref{track:detached-finalize}) never gets
+a chance to remove those files.
+
+We therefore extend the key with a \emph{generation}: the server's
+PID and start time.  The PID comes for free from [[$TMUX]]; the start
+time guards against a deterministic boot sequence handing a new
+server the same PID again.  The address part (the \emph{sockethash})
+and the generation are joined with hyphens---characters that
+[[sanitize_tmux_id]] passes through unchanged---so every state
+filename carries the key as a single underscore-free token from which
+the sockethash prefix is recoverable.  That recoverability is what
+makes sweeping possible: a socket path hosts at most one live server
+at a time, so a state file carrying the current sockethash but a
+different generation provably belongs to a dead server
+(\cref{track:server-sweep}).
+
+<<configuration management>>=
+def build_tmux_sockethash(
     hostname: str,
     socket_path: str,
 ) -> str:
-    """Return a stable key for one tmux server."""
+    """Return the address part of a tmux server key."""
     digest = hashlib.sha256(
         f"{hostname}\0{socket_path}".encode()
     ).hexdigest()
     return digest[:16]
 
+def build_tmux_server_key(
+    hostname: str,
+    socket_path: str,
+    generation: str,
+) -> str:
+    """Return a stable key for one tmux server instance."""
+    sockethash = build_tmux_sockethash(
+        hostname, socket_path,
+    )
+    return f"{sockethash}-{generation}"
+@
+
+Both the socket path and the server PID live in [[$TMUX]], whose
+format is [[socket,server_pid,session_idx]].  We split from the right
+because the socket path itself may contain commas.
+
+<<configuration management>>=
 def parse_tmux_socket_path(
     tmux_env: str | None,
 ) -> str | None:
@@ -355,17 +401,119 @@ def parse_tmux_socket_path(
         return tmux_env or None
     return socket_path or None
 
-def get_current_tmux_server_key() -> str | None:
-    """Return the current tmux server key from the environment."""
-    socket_path = parse_tmux_socket_path(
-        os.environ.get("TMUX")
-    )
-    if not socket_path:
+def parse_tmux_server_pid(
+    tmux_env: str | None,
+) -> str | None:
+    """Extract the tmux server PID from ``$TMUX`` if present."""
+    if not tmux_env:
+        return None
+    try:
+        _socket_path, server_pid, _session_idx = tmux_env.rsplit(",", 2)
+    except ValueError:
+        return None
+    return server_pid or None
+@
+
+The start time is not part of [[$TMUX]], so we have to ask the server
+itself.  One subprocess call per CLI process is acceptable, but hook
+subprocesses and nested commands may build several keys, so we
+memoize the answer per [[$TMUX]] value.  A failed query yields
+[[None]] rather than an exception: a server that cannot answer is
+dying or absent, and every caller already treats a missing key as
+\enquote{no tmux context}.
+
+<<configuration management>>=
+def get_tmux_server_start_time() -> str | None:
+    """Return the current tmux server's start time, or ``None``."""
+    tmux_env = os.environ.get("TMUX")
+    if not tmux_env:
+        return None
+    if tmux_env in _TMUX_START_TIME_CACHE:
+        return _TMUX_START_TIME_CACHE[tmux_env]
+    try:
+        result = subprocess.run(
+            [
+                "tmux",
+                "display-message",
+                "-p",
+                "#{start_time}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    start_time = result.stdout.strip()
+    if not start_time:
+        return None
+    _TMUX_START_TIME_CACHE[tmux_env] = start_time
+    return start_time
+<<constants>>=
+_TMUX_START_TIME_CACHE: dict[str, str] = {}
+@
+
+Assembling a key combines all three ingredients.  The [[tmux_env]]
+parameter names the server whose namespace we are keying, while the
+start-time query always asks the ambient server---the two agree
+because tmux client commands themselves resolve the server from the
+process environment, which is also where callers obtain the
+[[tmux_env]] they pass in.
+
+<<configuration management>>=
+def compute_tmux_server_key(
+    tmux_env: str | None,
+) -> str | None:
+    """Return the instance key for the server named by ``tmux_env``."""
+    socket_path = parse_tmux_socket_path(tmux_env)
+    server_pid = parse_tmux_server_pid(tmux_env)
+    if not socket_path or not server_pid:
+        return None
+    start_time = get_tmux_server_start_time()
+    if not start_time:
         return None
     return build_tmux_server_key(
+        socket.gethostname(),
+        socket_path,
+        f"{server_pid}-{start_time}",
+    )
+@
+
+The everyday entry point adds one refinement: it returns [[None]] not
+only outside tmux but also when this worker's filesystem holds no
+state for the current socket at all.  All its callers use the key
+solely to address \emph{existing} state (state files are only ever
+created by [[run_tmux_command]], which computes its key directly via
+[[compute_tmux_server_key]]), so when no state exists we can skip the
+start-time query and keep untracked [[track start]]/[[stop]]
+invocations free of tmux subprocess calls---the same hot-path
+principle as [[has_tracked_window_state]].  The glob requires a
+hyphen after the sockethash, so state written by the pre-generation
+key format never reactivates this path.
+
+<<configuration management>>=
+def get_current_tmux_server_key() -> str | None:
+    """Return the current tmux server instance key, or ``None``.
+
+    Returns ``None`` outside tmux, and also when no tmux-scoped
+    state exists for the current server's socket, so that callers
+    addressing existing state stay subprocess-free.
+    """
+    tmux_env = os.environ.get("TMUX")
+    socket_path = parse_tmux_socket_path(tmux_env)
+    if not socket_path:
+        return None
+    sockethash = build_tmux_sockethash(
         socket.gethostname(), socket_path,
     )
+    if not any(
+        get_tracking_dir().glob(f"*_{sockethash}-*")
+    ):
+        return None
+    return compute_tmux_server_key(tmux_env)
+@
 
+<<configuration management>>=
 def get_current_session_file(
     who: str = None
 ) -> pathlib.Path:
@@ -5433,13 +5581,11 @@ def run_tmux_command(
         )
 
     try:
-        socket_path = parse_tmux_socket_path(
+        tmux_server_key = compute_tmux_server_key(
             env.get("TMUX")
         )
-        if socket_path:
-            tmux_server_key = build_tmux_server_key(
-                socket.gethostname(), socket_path,
-            )
+        if tmux_server_key:
+            sweep_stale_server_state(tmux_server_key)
         <<launch tmux command and install hooks>>
         subprocess.run(
             ["tmux", "wait-for", "-S", ready_channel],
@@ -5498,6 +5644,17 @@ still alive, so removing the guard then would simply hand the later
 hooks a clean slate to re-claim.  Detached launches instead let their
 own cleanup remove the throwaway directory that holds guard and status
 alike (see \cref{track:detached-launch-dir}).
+
+A tracked launch is also the natural moment to amortize cleanup of
+state left behind by dead tmux servers.  Hook-based cleanup cannot
+fire when the whole server dies---a reboot takes every pane with it
+before any [[pane-exited]] hook runs---so before publishing this
+launch's state we sweep files whose key names a dead instance of the
+current server (\cref{track:server-sweep}).  The sweep runs outside
+[[with_tmux_context_lock]] deliberately: the files it removes belong
+to server instances that no longer exist, so no live hook can race
+it, and keeping it outside the lock avoids nesting with the
+hook-observability critical section below.
 
 Tracked window launches need one stronger serialization guarantee than
 steady-state hooks.  The [[tmux new-window]] command itself may spawn a
@@ -5714,7 +5871,9 @@ Each tracked pane that uses auto-suspend stores a JSON file
 identifying the labels that were suspended.  The filename encodes the
 tmux server key, the tmux pane ID (with the leading [[%]] replaced by
 [[pane_]]), and the worker identity so that parallel workers or
-independent tmux servers sharing the same filesystem do not collide.
+independent tmux server instances sharing the same filesystem do not
+collide---including a dead pre-reboot server whose pane numbering the
+current server has begun reusing (\cref{track:server-sweep}).
 
 <<helper functions>>=
 def suspend_state_path(
@@ -6047,8 +6206,13 @@ Instead of following terminal focus, it follows whether the tracked tmux
 window is selected by any attached client.  To support that, we keep a
 window-scoped labels file analogous to the pane labels file.  As with
 pane state, the filename includes the tmux server key so two different
-tmux servers sharing a filesystem do not reuse the same window-state
-path for identical [[@...]] identifiers.
+tmux server instances sharing a filesystem do not reuse the same
+window-state path for identical [[@...]] identifiers.  The instance
+distinction matters most across reboots: a fresh server reuses the
+same socket path \emph{and} restarts window numbering at [[@0]], so
+only the generation part of the key keeps a dead server's files from
+being mistaken for the new server's windows
+(\cref{track:server-sweep}).
 
 <<helper functions>>=
 def window_labels_path(
@@ -7379,6 +7543,403 @@ def cleanup_window_detached(
     with_tmux_context_lock(cleanup)
 @
 
+\subsubsection{Sweeping State from Dead Server Instances}
+\label{track:server-sweep}
+
+The pane-exit hooks above share one blind spot: they need the tmux
+server alive to fire.  A reboot (or [[tmux kill-server]]) destroys
+every pane and window without running a single [[pane-exited]] hook,
+so all tmux-scoped state files survive in the persistent tracking
+directory.  These leftovers are worse than clutter.  The next server
+on the same socket restarts window numbering at [[@0]], so a
+generation-less key would let a brand-new, untracked window inherit a
+dead window's labels the moment their [[@N]] identifiers coincide.
+The generation in the server key (\cref{track:configuration})
+prevents that resurrection, but the dead files still accumulate
+forever unless something removes them.  That something is a sweep,
+run at every tracked tmux launch and on demand via
+[[nytid track clean]].
+
+What makes the sweep safe is that staleness is \emph{provable} rather
+than guessed.  Every state filename carries the server key as one
+hyphen-joined token, so the sockethash is recoverable from the
+filename alone.  A socket path hosts at most one live server at a
+time; hence a file whose token shares the current server's sockethash
+but differs in generation belongs to a server that provably no longer
+exists.  No boot-time detection or file-age heuristic is needed.  The
+converse also holds: a file keyed to a \emph{different} sockethash
+may belong to a live server we simply are not attached to (a
+[[tmux -L work]] side server, or another host sharing this home
+directory over NFS), so the sweep must never touch it.
+
+Two legacy name formats are also provably dead, because no current
+code can ever address them: files from before the server key existed
+(their token is the literal [[window]] or [[pane]] from the sanitized
+tmux identifier, or empty for old last-window files), and files whose
+token is a bare generation-less sockethash (the key format that this
+sweep's design replaced---the glob in
+[[get_current_tmux_server_key]] requires a hyphen after the
+sockethash, so such files can never be matched again).  The
+[[window_events_]] prefix covers debug state files from a since
+removed design; nothing writes them anymore, so any survivor is
+swept as legacy.
+
+<<constants>>=
+TMUX_STATE_FILE_PREFIXES = (
+    "window_labels_",
+    "pane_labels_",
+    "suspend_",
+    "last_window_",
+    "window_events_",
+)
+LEGACY_STATE_KEY_TOKENS = frozenset({"window", "pane", ""})
+@
+
+Recovering the key token from a filename relies on the key being the
+first underscore-free token after the prefix, which
+[[sanitize_tmux_id]] guarantees for current keys and which happens to
+classify the legacy formats correctly as well.
+
+<<helper functions>>=
+def parse_state_file_server_key(
+    filename: str,
+) -> str | None:
+    """Return the server-key token of a tmux state filename.
+
+    Returns ``None`` for filenames that are no tmux state files.
+    """
+    for prefix in TMUX_STATE_FILE_PREFIXES:
+        if filename.startswith(prefix):
+            rest = filename[len(prefix):]
+            return rest.split("_", 1)[0]
+    return None
+@
+
+Let's verify the token recovery on all the name formats the sweep
+must classify:
+
+<<test functions>>=
+def test_parse_state_file_server_key():
+  """Key tokens are recovered from current and legacy names."""
+  key = "abc123-45-6789"
+  assert parse_state_file_server_key(
+    f"window_labels_{key}_window_1_me.json"
+  ) == key
+  assert parse_state_file_server_key(
+    f"suspend_{key}_pane_2_me.json"
+  ) == key
+  assert parse_state_file_server_key(
+    "window_labels_abc123_window_1_me.json"
+  ) == "abc123"
+  assert parse_state_file_server_key(
+    "pane_labels_pane_10_me.json"
+  ) == "pane"
+  assert parse_state_file_server_key(
+    "last_window__0_me.txt"
+  ) == ""
+  assert parse_state_file_server_key(
+    "tracking_data.json"
+  ) is None
+@
+
+The two sweep entry points share one walk over the state files and
+differ only in which key tokens they condemn.  The walk returns the
+removed paths so [[nytid track clean --dry-run]] can reuse the exact
+same classification without unlinking anything.  Removal is
+idempotent: a hook or concurrent sweep may have unlinked a file
+between the glob and the unlink, and a dead file that is already gone
+is success, not failure.
+
+<<helper functions>>=
+def _sweep_state_files(
+    should_remove,
+    dry_run: bool,
+) -> list[pathlib.Path]:
+    removed = []
+    tracking_dir = get_tracking_dir()
+    for prefix in TMUX_STATE_FILE_PREFIXES:
+        for path in tracking_dir.glob(prefix + "*"):
+            token = parse_state_file_server_key(path.name)
+            if token is None or not should_remove(token):
+                continue
+            removed.append(path)
+            if not dry_run:
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+    return removed
+@
+
+The regular sweep condemns exactly the provably dead: same
+sockethash with a different (or no) generation, plus the legacy
+formats.  Everything keyed to another socket survives.
+
+<<helper functions>>=
+def sweep_stale_server_state(
+    current_server_key: str,
+    dry_run: bool = False,
+) -> list[pathlib.Path]:
+    """Remove tmux state files from dead instances of this server.
+
+    Removes files keyed to the current server's socket but another
+    generation, plus files in legacy name formats that no current
+    code can address.  Files keyed to other sockets are kept.
+    Returns the affected paths; with ``dry_run`` nothing is
+    removed, but the same paths are returned.
+    """
+    sockethash = current_server_key.split("-", 1)[0]
+
+    def is_stale(token: str) -> bool:
+        if token == current_server_key:
+            return False
+        return (
+            token.startswith(sockethash)
+            or token in LEGACY_STATE_KEY_TOKENS
+        )
+
+    return _sweep_state_files(is_stale, dry_run)
+@
+
+Let's first verify the scenario that motivated all of this: after a
+reboot, a stale window-labels file must not make a new, untracked
+window appear tracked, even when the window IDs coincide.
+
+<<test functions>>=
+def test_reboot_collision_not_read_as_tracked(temp_tracking_dir):
+  """A dead server's window file never matches a new server's window."""
+  temp_tracking_dir.mkdir(parents=True, exist_ok=True)
+  sockethash = TEST_SERVER_KEY.split("-", 1)[0]
+  dead_key = f"{sockethash}-111-1000"
+  new_key = f"{sockethash}-222-2000"
+  (temp_tracking_dir
+   / f"window_labels_{dead_key}_window_1"
+   f"_{sanitize_who(default_username)}.json"
+   ).write_text('{"devel": 1}')
+
+  with patch.dict(
+    os.environ, {"TMUX_PANE": "%1"}, clear=True,
+  ), patch(
+    "nytid.cli.track.get_tmux_window_id_for_pane",
+    return_value="@1",
+  ):
+    assert get_current_tracked_window_id(
+      default_username, new_key,
+    ) is None
+@
+
+The sweep itself must remove every state-file kind for a dead
+generation while keeping the live generation's files:
+
+<<test functions>>=
+def test_sweep_removes_dead_generation(temp_tracking_dir):
+  """All state files of a dead server generation are removed."""
+  temp_tracking_dir.mkdir(parents=True, exist_ok=True)
+  sockethash = TEST_SERVER_KEY.split("-", 1)[0]
+  dead_key = f"{sockethash}-111-1000"
+  dead_files = [
+    f"window_labels_{dead_key}_window_1_me.json",
+    f"pane_labels_{dead_key}_pane_2_me.json",
+    f"suspend_{dead_key}_pane_2_me.json",
+    f"last_window_{dead_key}__0_me.txt",
+    f"window_events_{dead_key}__0_me.txt",
+  ]
+  live_files = [
+    f"window_labels_{TEST_SERVER_KEY}_window_1_me.json",
+    f"last_window_{TEST_SERVER_KEY}__0_me.txt",
+  ]
+  for name in dead_files + live_files:
+    (temp_tracking_dir / name).write_text("{}")
+
+  removed = sweep_stale_server_state(TEST_SERVER_KEY)
+
+  assert sorted(p.name for p in removed) == sorted(dead_files)
+  for name in dead_files:
+    assert not (temp_tracking_dir / name).exists()
+  for name in live_files:
+    assert (temp_tracking_dir / name).exists()
+
+def test_sweep_removes_legacy_names(temp_tracking_dir):
+  """Pre-server-key and generation-less files are swept."""
+  temp_tracking_dir.mkdir(parents=True, exist_ok=True)
+  sockethash = TEST_SERVER_KEY.split("-", 1)[0]
+  legacy_files = [
+    f"window_labels_{sockethash}_window_3_me.json",
+    "window_labels_window_9_me.json",
+    "pane_labels_pane_10_me.json",
+    "suspend_pane_11_me.json",
+    "last_window__0_me.txt",
+  ]
+  for name in legacy_files:
+    (temp_tracking_dir / name).write_text("{}")
+
+  removed = sweep_stale_server_state(TEST_SERVER_KEY)
+
+  assert sorted(p.name for p in removed) == sorted(legacy_files)
+  for name in legacy_files:
+    assert not (temp_tracking_dir / name).exists()
+
+def test_sweep_keeps_other_sockets(temp_tracking_dir):
+  """State keyed to other sockets may be alive and survives."""
+  temp_tracking_dir.mkdir(parents=True, exist_ok=True)
+  other = build_tmux_sockethash("host", "/tmp/other.sock")
+  kept = [
+    f"window_labels_{other}-333-4000_window_1_me.json",
+    f"window_labels_{other}_window_1_me.json",
+  ]
+  for name in kept:
+    (temp_tracking_dir / name).write_text("{}")
+
+  assert sweep_stale_server_state(TEST_SERVER_KEY) == []
+  for name in kept:
+    assert (temp_tracking_dir / name).exists()
+
+def test_stale_last_window_not_used(temp_tracking_dir):
+  """A dead generation's last-window file is invisible to reads."""
+  temp_tracking_dir.mkdir(parents=True, exist_ok=True)
+  sockethash = TEST_SERVER_KEY.split("-", 1)[0]
+  dead_key = f"{sockethash}-111-1000"
+  path = last_selected_window_path(
+    "me", dead_key, "$0",
+  )
+  path.write_text("@5\n")
+
+  assert read_last_selected_window(
+    "me", TEST_SERVER_KEY, "$0",
+  ) is None
+@
+
+The [[--all]] variant condemns every state file regardless of
+socket.  We cannot prove other sockets' servers dead from here, so
+this variant exists only behind an explicit user assertion in
+[[nytid track clean --all]]: \enquote{no tracked tmux work is in
+flight anywhere on this filesystem}.
+
+<<helper functions>>=
+def sweep_all_server_state(
+    dry_run: bool = False,
+) -> list[pathlib.Path]:
+    """Remove all tmux state files, regardless of server.
+
+    Returns the affected paths; with ``dry_run`` nothing is
+    removed, but the same paths are returned.
+    """
+    return _sweep_state_files(lambda token: True, dry_run)
+@
+
+The user-facing command wraps the two sweeps.  The default scope is
+the current server because that is the only scope where staleness is
+provable; anything wider needs the user's [[--all]] assertion.
+Since deletion is irreversible, [[--dry-run]] lets the user inspect
+the verdict first using the very same classification.  We bypass
+[[get_current_tmux_server_key]] here on purpose: its no-state glob
+guard only recognizes current-format keys, which would make the
+command refuse to run right when only legacy files are left to
+clean.
+
+<<argument and option definitions>>=
+clean_dry_run_opt = typer.Option(
+    "--dry-run", "-n",
+    help="Only list the files that would be removed")
+clean_all_opt = typer.Option(
+    "--all",
+    help="Remove tmux state for all servers, not only "
+         "dead instances of the current one")
+@
+
+<<clean command>>=
+@cli.command()
+def clean(
+    dry_run: Annotated[bool, clean_dry_run_opt] = False,
+    all_servers: Annotated[bool, clean_all_opt] = False,
+):
+    """
+    Remove stale tmux tracking state files.
+
+    Tracked tmux launches sweep automatically; this command covers
+    cleaning up without launching anything, and wiping other
+    servers' state with --all.
+    """
+    if all_servers:
+        removed = sweep_all_server_state(dry_run=dry_run)
+    else:
+        server_key = compute_tmux_server_key(
+            os.environ.get("TMUX")
+        )
+        if server_key is None:
+            typer.echo(
+                "Not inside a running tmux server; "
+                "use --all to remove state for all servers.",
+                err=True,
+            )
+            raise typer.Exit(1)
+        removed = sweep_stale_server_state(
+            server_key, dry_run=dry_run,
+        )
+    verb = "Would remove" if dry_run else "Removed"
+    for path in removed:
+        typer.echo(f"{verb} {path.name}")
+    if not removed:
+        typer.echo("No stale tmux state files found.")
+@
+
+Let's verify the command's scoping and its dry-run contract:
+
+<<test functions>>=
+def test_clean_removes_stale_files(temp_tracking_dir):
+  """clean removes dead-generation files for the current server."""
+  temp_tracking_dir.mkdir(parents=True, exist_ok=True)
+  sockethash = TEST_SERVER_KEY.split("-", 1)[0]
+  stale = f"window_labels_{sockethash}-111-1000_window_1_me.json"
+  (temp_tracking_dir / stale).write_text("{}")
+
+  with patch(
+    "nytid.cli.track.compute_tmux_server_key",
+    return_value=TEST_SERVER_KEY,
+  ):
+    result = runner.invoke(cli, ["clean"])
+
+  assert result.exit_code == 0
+  assert stale in result.stdout
+  assert not (temp_tracking_dir / stale).exists()
+
+def test_clean_dry_run_keeps_files(temp_tracking_dir):
+  """clean --dry-run lists stale files without removing them."""
+  temp_tracking_dir.mkdir(parents=True, exist_ok=True)
+  sockethash = TEST_SERVER_KEY.split("-", 1)[0]
+  stale = f"window_labels_{sockethash}-111-1000_window_1_me.json"
+  (temp_tracking_dir / stale).write_text("{}")
+
+  with patch(
+    "nytid.cli.track.compute_tmux_server_key",
+    return_value=TEST_SERVER_KEY,
+  ):
+    result = runner.invoke(cli, ["clean", "--dry-run"])
+
+  assert result.exit_code == 0
+  assert stale in result.stdout
+  assert (temp_tracking_dir / stale).exists()
+
+def test_clean_all_clears_other_sockets(temp_tracking_dir):
+  """clean --all also removes other sockets' state files."""
+  temp_tracking_dir.mkdir(parents=True, exist_ok=True)
+  other = build_tmux_sockethash("host", "/tmp/other.sock")
+  name = f"window_labels_{other}-333-4000_window_1_me.json"
+  (temp_tracking_dir / name).write_text("{}")
+
+  result = runner.invoke(cli, ["clean", "--all"])
+
+  assert result.exit_code == 0
+  assert not (temp_tracking_dir / name).exists()
+
+def test_clean_outside_tmux_requires_all(temp_tracking_dir):
+  """Without tmux and without --all, clean explains and fails."""
+  with patch.dict(os.environ, {}, clear=True):
+    result = runner.invoke(cli, ["clean"])
+
+  assert result.exit_code == 1
+@
+
 \subsubsection{Focus-Events Validation}
 
 The pane [[pane-focus-out]]/[[pane-focus-in]] hooks require tmux's
@@ -8633,11 +9194,13 @@ def test_build_detached_nytid_prefix_requires_resolvable_nytid():
             build_detached_nytid_prefix()
 
 def test_build_tmux_server_key_changes_with_host_or_socket():
-    """Server key distinguishes host/socket combinations."""
-    assert build_tmux_server_key("a", "/tmp/x") != \
-        build_tmux_server_key("b", "/tmp/x")
-    assert build_tmux_server_key("a", "/tmp/x") != \
-        build_tmux_server_key("a", "/tmp/y")
+    """Server key distinguishes host/socket/generation combinations."""
+    assert build_tmux_server_key("a", "/tmp/x", "1-2") != \
+        build_tmux_server_key("b", "/tmp/x", "1-2")
+    assert build_tmux_server_key("a", "/tmp/x", "1-2") != \
+        build_tmux_server_key("a", "/tmp/y", "1-2")
+    assert build_tmux_server_key("a", "/tmp/x", "1-2") != \
+        build_tmux_server_key("a", "/tmp/x", "3-4")
 
 def test_parse_tmux_socket_path_reads_socket_path():
     """$TMUX parsing keeps commas that belong to the socket path."""
@@ -8648,14 +9211,43 @@ def test_parse_tmux_socket_path_reads_socket_path():
     assert parse_tmux_socket_path("malformed") == "malformed"
     assert parse_tmux_socket_path(None) is None
 
-def test_get_current_tmux_server_key_from_env():
-    """Current server key is derived from hostname and $TMUX."""
+def test_parse_tmux_server_pid_reads_pid():
+    """$TMUX parsing extracts the middle server-PID field."""
+    assert parse_tmux_server_pid("/tmp/tmux.sock,123,0") == "123"
+    assert parse_tmux_server_pid("/tmp/tmux,sock,123,0") == "123"
+    assert parse_tmux_server_pid("malformed") is None
+    assert parse_tmux_server_pid(None) is None
+
+def test_get_current_tmux_server_key_from_env(temp_tracking_dir):
+    """Current server key composes sockethash, PID and start time."""
+    temp_tracking_dir.mkdir(parents=True, exist_ok=True)
+    expected = build_tmux_server_key(
+        "host", "/tmp/tmux.sock", "123-1700000000",
+    )
+    (temp_tracking_dir
+     / f"window_labels_{expected}_window_1_me.json"
+     ).write_text("{}")
     with patch.dict(
         os.environ, {"TMUX": "/tmp/tmux.sock,123,0"}, clear=True,
-    ), patch("nytid.cli.track.socket.gethostname", return_value="host"):
-        assert get_current_tmux_server_key() == build_tmux_server_key(
-            "host", "/tmp/tmux.sock",
-        )
+    ), patch(
+        "nytid.cli.track.socket.gethostname", return_value="host",
+    ), patch(
+        "nytid.cli.track.get_tmux_server_start_time",
+        return_value="1700000000",
+    ):
+        assert get_current_tmux_server_key() == expected
+
+def test_get_current_tmux_server_key_skips_tmux_without_state(
+    temp_tracking_dir,
+):
+    """Without any state files, no tmux subprocess is spawned."""
+    with patch.dict(
+        os.environ, {"TMUX": "/tmp/tmux.sock,123,0"}, clear=True,
+    ), patch(
+        "nytid.cli.track.get_tmux_server_start_time",
+        side_effect=AssertionError("tmux queried"),
+    ):
+        assert get_current_tmux_server_key() is None
 @
 
 \subsection{Blocking Command Execution}
@@ -10841,6 +11433,7 @@ and checking the status of active tracking sessions:
 <<start command>>
 <<stop command>>
 <<switch command>>
+<<clean command>>
 <<detached finalize command>>
 <<detached suspend command>>
 <<detached resume command>>
@@ -10986,9 +11579,17 @@ from nytid.cli.track import (
     build_tmux_hook_command,
     install_tmux_exit_hooks,
     run_tmux_command,
+    build_tmux_sockethash,
     build_tmux_server_key,
     parse_tmux_socket_path,
+    parse_tmux_server_pid,
+    compute_tmux_server_key,
+    get_tmux_server_start_time,
     get_current_tmux_server_key,
+    get_tracking_dir,
+    parse_state_file_server_key,
+    sweep_stale_server_state,
+    sweep_all_server_state,
     sanitize_who, complete_workers,
     complete_entry_hashes,
     should_auto_suspend,
@@ -11039,7 +11640,7 @@ from nytid.cli.track import (
 
 runner = CliRunner()
 TEST_SERVER_KEY = build_tmux_server_key(
-    socket.gethostname(), "/tmp/tmux.sock",
+    socket.gethostname(), "/tmp/tmux.sock", "123-1700000000",
 )
 TEST_SESSION_ID = "$1"
 
@@ -12171,7 +12772,7 @@ def test_run_tmux_command_publishes_pane_labels_unsuspended(
   ), patch(
     "nytid.cli.track.install_tmux_exit_hooks",
   ), patch(
-    "nytid.cli.track.build_tmux_server_key",
+    "nytid.cli.track.compute_tmux_server_key",
     return_value=TEST_SERVER_KEY,
   ), patch(
     "nytid.cli.track.install_tmux_focus_hooks",
@@ -12214,7 +12815,7 @@ def test_run_tmux_command_publishes_window_labels_unsuspended(
   ), patch(
     "nytid.cli.track.install_tmux_exit_hooks",
   ), patch(
-    "nytid.cli.track.build_tmux_server_key",
+    "nytid.cli.track.compute_tmux_server_key",
     return_value=TEST_SERVER_KEY,
   ), patch(
     "nytid.cli.track.stop_tracking_labels",
@@ -12390,10 +12991,7 @@ def test_run_tmux_command_locks_window_launch_setup(
         "nytid.cli.track.make_tmux_channel",
         side_effect=["ready-chan"],
     ), patch(
-        "nytid.cli.track.parse_tmux_socket_path",
-        return_value="/tmp/tmux.sock",
-    ), patch(
-        "nytid.cli.track.build_tmux_server_key",
+        "nytid.cli.track.compute_tmux_server_key",
         return_value=TEST_SERVER_KEY,
     ), patch(
         "nytid.cli.track.with_tmux_context_lock",

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -504,23 +504,53 @@ DEFAULT_WEEKLY_LIMIT_HOURS = 40.0  # Standard full-time work week
 DEFAULT_DAILY_LIMIT_HOURS = 8.0    # Standard work day
 @
 
+Durations are normally positive, but they must never be \emph{rendered}
+as positive when they are not.  Python's [[divmod]] floors towards
+negative infinity, so splitting a raw negative second count into hours,
+minutes and seconds yields components that read as a plausible positive
+duration: $-30$~minutes becomes [[30m 0s]], and so does $-90$~minutes.
+A corrupt entry would then be indistinguishable from a healthy one in
+[[status]], [[ls]], and [[stats]] output.
+
+We therefore split the magnitude and carry the sign as an explicit
+prefix.  This is a display safeguard rather than a licence to store
+negative durations---the commands that build entries reject inverted
+intervals---but a formatter that cannot lie is what makes such a bug
+visible instead of silent.
+
 <<helper functions>>=
 def format_duration(duration: datetime.timedelta) -> str:
-    """Format a duration in a human-readable way"""
+    """Format a duration in a human-readable way.
+
+    Negative durations keep a leading minus sign so an
+    inverted interval can never be displayed as a
+    positive one.
+    """
     total_seconds = int(duration.total_seconds())
-    hours, remainder = divmod(total_seconds, 3600)
+    sign = "-" if total_seconds < 0 else ""
+    hours, remainder = divmod(abs(total_seconds), 3600)
     minutes, seconds = divmod(remainder, 60)
-    
+
     if hours > 0:
-        return f"{hours}h {minutes}m {seconds}s"
+        return f"{sign}{hours}h {minutes}m {seconds}s"
     elif minutes > 0:
-        return f"{minutes}m {seconds}s"
+        return f"{sign}{minutes}m {seconds}s"
     else:
-        return f"{seconds}s"
+        return f"{sign}{seconds}s"
 
 def get_labels_display(labels: list[str]) -> str:
     """Get a display string for labels (as comma-separated tags)"""
     return ", ".join(sorted(labels)) if labels else "No labels"
+@
+
+<<test functions>>=
+def test_format_duration_is_sign_aware():
+  """Negative durations must not render as positive ones."""
+  assert format_duration(datetime.timedelta(minutes=30)) == "30m 0s"
+  assert format_duration(datetime.timedelta(minutes=-30)) == "-30m 0s"
+  assert format_duration(datetime.timedelta(minutes=-90)) == "-1h 30m 0s"
+  assert format_duration(datetime.timedelta(seconds=-5)) == "-5s"
+  assert format_duration(datetime.timedelta()) == "0s"
 @
 
 \subsubsection{Abbreviating Content Hashes}
@@ -1228,6 +1258,10 @@ class ActiveSession:
 
         Returns:
             List of TrackingEntry objects for the stopped labels
+
+        Raises:
+            ValueError: if `end_time` is not after the start time of
+                every label that would be stopped
         """
         if who is None:
             who = default_username
@@ -1257,7 +1291,39 @@ class ActiveSession:
             # Stop the N most recently started labels
             labels = self.label_order[-count:] if self.label_order else []
         # else: use the provided labels list
+
+        inverted = sorted(
+            label for label in labels
+            if label in self.active_labels
+            and end_time <= self.active_labels[label][0]
+        )
+        if inverted:
+            raise ValueError(
+                "End time must be after start time for: "
+                + ", ".join(inverted)
+            )
 @
+
+The check above belongs here, before anything is popped, because this is
+the last point at which the session is still untouched.  Every caller
+reaches [[stop_labels]] through [[mutate_worker_tracking_state]], which
+persists whatever the callback returns; raising once the labels have
+already been removed would leave the on-disk session inconsistent with
+the error the user sees.
+
+The rule is the same one [[edit]] enforces on historical entries: an
+entry's end must come after its start.  Only [[stop]] could break it,
+because [[--at]] and [[--offset]] let the user name an end time
+independently of when tracking began.  An inverted entry is not merely
+displayed wrongly---it is stored, and a negative interval subtracts from
+every aggregate built on top of it: the merged wall-clock totals,
+[[stats]], the exports, and the times [[nytid todo]] derives from
+tracking history.
+
+We name the offending labels rather than failing anonymously.  A
+[[stop --all]] can span labels started hours apart, so
+\enquote{which of them started after the end time you gave?} is exactly
+the question the user needs answered.
 
 At this point [[labels]] is only a \emph{request}.  The caller may have
 named a label that is not being tracked---most often a typo---and the
@@ -3602,16 +3668,7 @@ def stop(
             )
             raise typer.Exit(1)
 
-    try:
-        session, completed_entries = stop_tracking_labels(
-            who=who,
-            labels=labels,
-            all_labels=all_labels,
-            end_time=end_time,
-        )
-    except ValueError as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(1)
+    <<stop the requested labels or report why not>>
 
     # Display what was completed
     for entry in completed_entries:
@@ -3639,7 +3696,69 @@ def stop(
 
 @
 
+Two quite different things can go wrong once the end time is known, and
+both surface here as a [[ValueError]] carrying its own explanation:
+either none of the named labels are tracking, or the end time given by
+[[--at]]/[[--offset]] falls before some label started.  The command has
+nothing to add to either message, so it prints the exception verbatim
+and exits non-zero.
+
+What matters is that the exception reaches this point with the on-disk
+state untouched.  [[stop_labels]] validates before it pops anything, so
+a rejected [[stop]] leaves the session exactly as it was and the user
+can simply retry with a corrected time.
+
+<<stop the requested labels or report why not>>=
+try:
+    session, completed_entries = stop_tracking_labels(
+        who=who,
+        labels=labels,
+        all_labels=all_labels,
+        end_time=end_time,
+    )
+except ValueError as exc:
+    typer.echo(str(exc), err=True)
+    raise typer.Exit(1)
+@
+
 \subsubsection{Testing Stop Command}
+
+Let's verify that a backdated stop cannot invert an entry, and that the
+rejection is total---no entry written, no label stopped:
+
+<<test functions>>=
+def test_stop_rejects_end_before_start(temp_tracking_dir):
+  """A backdated stop must not record a negative interval."""
+  runner.invoke(cli, ["start", "A"])
+
+  result = runner.invoke(cli, ["stop", "--offset", "-30m"])
+  assert result.exit_code == 1
+  assert "End time must be after start time" in result.output
+  assert "A" in result.output
+
+  assert load_tracking_data() == []
+  assert load_active_session().get_active_labels() == ["A"]
+
+def test_stop_all_names_only_inverted_labels(temp_tracking_dir):
+  """The error names the labels that started after the end time."""
+  runner.invoke(cli, ["start", "old", "--offset", "-2h"])
+  runner.invoke(cli, ["start", "new"])
+
+  result = runner.invoke(cli, ["stop", "--all", "--offset", "-30m"])
+  assert result.exit_code == 1
+  assert "new" in result.output
+  assert "old" not in result.output
+
+def test_switch_rejects_end_before_start(temp_tracking_dir):
+  """A backdated switch fails instead of inverting the old context."""
+  runner.invoke(cli, ["start", "A"])
+
+  result = runner.invoke(cli, ["switch", "B", "--offset", "-30m"])
+  assert result.exit_code == 1
+  assert "End time must be after start time" in result.output
+
+  assert load_tracking_data() == []
+  assert load_active_session().get_active_labels() == ["A"]
 
 <<test functions>>=
 def test_stop_batch_behavior(temp_tracking_dir):
@@ -3840,6 +3959,52 @@ elif offset is not None:
         raise typer.Exit(1)
 @
 
+\subsubsection{Closing the Current Context}
+
+Both switch directions begin identically: whatever is running must be
+stopped at [[switch_time]] before the new context starts.  We name that
+step once so the forward and reverse directions cannot drift apart, and
+so the error handling below exists in exactly one place.
+
+A backdated [[--at]] or [[--offset]] may name a moment before one of the
+active labels began.  [[stop_tracking_labels]] rejects that rather than
+recording an inverted interval, and there is nothing sensible to do with
+the rest of the switch: starting the new context while the old one is
+still open would leave both running.  We therefore report the problem
+and stop.
+
+<<stop current context at switch time>>=
+if session.is_active():
+    try:
+        session, completed = stop_tracking_labels(
+            who=who,
+            all_labels=all_labels,
+            end_time=switch_time,
+        )
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1)
+    session = load_active_session(who)
+    for entry in completed:
+        typer.echo(
+            f"Stopped: "
+            f"{get_labels_display(entry.labels)}"
+            f" ({format_duration(entry.duration())})"
+        )
+    stopped_labels = [
+        label
+        for entry in completed
+        for label in entry.labels
+    ]
+else:
+    stopped_labels = []
+@
+
+The chunk expects [[session]], [[who]], [[all_labels]] and
+[[switch_time]] to be in scope, and leaves behind a refreshed
+[[session]] plus the [[stopped_labels]] both directions need for the
+toggle bookkeeping.
+
 \subsubsection{Switching to New Labels}
 
 The key question when labels are given is whether the current context
@@ -3855,26 +4020,7 @@ so a subsequent bare [[switch]] correctly restores the idle state.
 
 <<switch to new labels>>=
 session = load_active_session(who)
-if session.is_active():
-    session, completed = stop_tracking_labels(
-        who=who,
-        all_labels=all_labels,
-        end_time=switch_time,
-    )
-    session = load_active_session(who)
-    for entry in completed:
-        typer.echo(
-            f"Stopped: "
-            f"{get_labels_display(entry.labels)}"
-            f" ({format_duration(entry.duration())})"
-        )
-    stopped_labels = [
-        label
-        for entry in completed
-        for label in entry.labels
-    ]
-else:
-    stopped_labels = []
+<<stop current context at switch time>>
 previous_switch_other = session.switch_other
 if not pop:
     update_switch_other_labels(stopped_labels, who=who)
@@ -3920,26 +4066,7 @@ if session.switch_other is None:
         "only one label set in play."
     )
     raise typer.Exit(0)
-if session.is_active():
-    session, completed = stop_tracking_labels(
-        who=who,
-        all_labels=all_labels,
-        end_time=switch_time,
-    )
-    session = load_active_session(who)
-    for entry in completed:
-        typer.echo(
-            f"Stopped: "
-            f"{get_labels_display(entry.labels)}"
-            f" ({format_duration(entry.duration())})"
-        )
-    stopped_labels = [
-        label
-        for entry in completed
-        for label in entry.labels
-    ]
-else:
-    stopped_labels = []
+<<stop current context at switch time>>
 if session.switch_other is None:
     typer.echo(
         "Nothing to switch back to: "
@@ -10539,6 +10666,7 @@ from nytid.cli.track import (
     AUTO_SUSPEND_CONFIG,
     TRACK_DEBUG_CONFIG,
     load_tracking_data, load_active_session,
+    format_duration,
     filter_entries, filter_entries_for_stats_window,
     normalize_tracking_entries,
     merge_duplicate_tracking_entries,

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -10301,10 +10301,33 @@ def stats(
       nytid track stats -n 7 --summary
       nytid track stats --who Dan-Claude
     """
+    <<reject a window shorter than a day>>
     <<resolve stats limits>>
     <<load and filter entries for stats>>
     <<display stats summary when requested>>
     <<display grouped daily breakdown>>
+@
+
+A report needs at least one calendar day to describe.  Zero days yields
+no dates, hence no rows, and the two output paths then fail in different
+ways: the summary divides the total by the window length, and the
+plain-text table takes the [[max]] over an empty sequence of rows.
+Neither failure is caught anywhere, so the user gets a traceback.
+
+Rejecting the input is better than clamping it because the value can
+come from [[track.stats.days]] as easily as from [[-n]].  A clamp would
+leave a nonsensical configuration in place and quietly report something
+the user did not ask for, every time; an error names the setting that
+needs fixing.
+
+<<reject a window shorter than a day>>=
+if days < 1:
+    typer.echo(
+        f"Error: --days must be at least 1, got {days} "
+        f"(check {TRACK_STATS_DAYS_CONFIG} in your config)",
+        err=True,
+    )
+    raise typer.Exit(1)
 @
 
 The [[--weekly-limit]] and [[--daily-limit]] flags are optional because
@@ -10488,12 +10511,20 @@ for row in rows:
 console.print(table)
 @
 
+Each column must be at least as wide as its own header, so we simply
+measure the header row alongside the data rows.  Treating the header as
+one more row also makes the computation total: [[max]] over an empty
+sequence raises, and the old spelling---[[max]] of the header width
+\emph{unpacked} together with the row widths---turned an empty report
+into a [[TypeError]] rather than a header with no rows under it.
+
 <<render stats table as plain columns>>=
 headers = ("Date", "Total", "Labels", "Time")
-date_width = max(len(headers[0]), *(len(row[0]) for row in rows))
-total_width = max(len(headers[1]), *(len(row[1]) for row in rows))
-labels_width = max(len(headers[2]), *(len(row[2]) for row in rows))
-time_width = max(len(headers[3]), *(len(row[3]) for row in rows))
+measured_rows = [headers] + rows
+date_width = max(len(row[0]) for row in measured_rows)
+total_width = max(len(row[1]) for row in measured_rows)
+labels_width = max(len(row[2]) for row in measured_rows)
+time_width = max(len(row[3]) for row in measured_rows)
 
 typer.echo(
     f"{headers[0]:<{date_width}}  "
@@ -10514,6 +10545,43 @@ for date, total, labels_text, labels_time in rows:
         f"{labels_text:<{labels_width}}  "
         f"{labels_time:>{time_width}}".rstrip()
     )
+@
+
+Let's verify that a degenerate window is refused rather than crashing,
+whichever way it arrives and whichever output path would have rendered
+it:
+
+<<test functions>>=
+def test_stats_rejects_window_shorter_than_a_day(temp_tracking_dir):
+  """A zero or negative window is an error, not a traceback."""
+  runner.invoke(cli, ["add", "work", "--duration", "1"])
+
+  for args in (
+    ["stats", "-n", "0"],
+    ["stats", "-n", "0", "--summary"],
+    ["stats", "-n", "-3"],
+  ):
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(
+      result.exception, SystemExit
+    )
+    assert "--days must be at least 1" in result.output
+    assert TRACK_STATS_DAYS_CONFIG in result.output
+
+def test_stats_plain_table_survives_empty_rows(temp_tracking_dir):
+  """The plain-text table renders headers even with no rows."""
+  runner.invoke(cli, ["add", "work", "--duration", "1"])
+
+  with patch(
+    "nytid.cli.track.make_stats_dates",
+    return_value=[],
+  ):
+    result = runner.invoke(cli, ["stats"])
+
+  assert result.exit_code == 0
+  assert "Date" in result.stdout
+  assert "Labels" in result.stdout
 @
 
 \subsection{Export Command}
@@ -10901,6 +10969,7 @@ sys.path.insert(0, '../src')
 from nytid.cli.track import (
     cli, TrackingEntry, ActiveSession,
     TRACKING_HASH_PREFIX_MIN_LENGTH,
+    TRACK_STATS_DAYS_CONFIG,
     AUTO_SUSPEND_CONFIG,
     TRACK_DEBUG_CONFIG,
     load_tracking_data, load_active_session,

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -5020,6 +5020,16 @@ child needs an atomic guard file so completion is recorded exactly once
 even if multiple cleanup paths race.  The helper functions below provide
 those two mechanisms.
 
+The guard is a \emph{directory}, because [[mkdir]] is the one filesystem
+operation every POSIX shell can perform atomically: it either creates
+the directory or fails, and exactly one racer sees success.  Deriving
+its path from the status file is what makes it disarmable.  A launch
+whose parent does not stick around to clean up puts both files in one
+throwaway directory; when the detached cleanup removes that directory,
+a later [[mkdir]] of the guard fails with [[ENOENT]] rather than
+succeeding on a fresh path---so releasing the guard and closing it
+permanently are the same act.
+
 <<helper functions>>=
 def make_tmux_channel(prefix: str) -> str:
     """Return a unique tmux wait-for channel name."""
@@ -5031,10 +5041,18 @@ def make_tmux_channel(prefix: str) -> str:
 
 def make_tmux_completion_guard(
     status_file: str | None,
-) -> str | None:
-    """Return the atomic completion guard path."""
+) -> str:
+    """Return the atomic completion guard path.
+
+    Derived from the status file when there is one, so that
+    removing the directory holding the status file also
+    removes -- and disarms -- the guard.
+    """
     if status_file is None:
-        return None
+        return os.path.join(
+            tempfile.gettempdir(),
+            f"nytid-guard-{os.getpid()}-{time.time_ns()}",
+        )
     return status_file + ".guard"
 
 
@@ -5279,6 +5297,7 @@ def run_tmux_command(
         remove_status_file = True
     if block:
         wait_channel = make_tmux_channel("done")
+    if status_file is not None or on_exit_shell is not None:
         completion_guard = make_tmux_completion_guard(
             status_file
         )
@@ -5363,12 +5382,34 @@ def run_tmux_command(
                 os.unlink(status_file)
             except OSError:
                 pass
-        if completion_guard is not None:
+        if block and completion_guard is not None:
             try:
                 os.rmdir(completion_guard)
             except OSError:
                 pass
 @
+
+Two details of the setup above are easy to get wrong, and getting either
+wrong breaks the exactly-once invariant.
+
+The guard is built whenever there is a status file \emph{or} an
+[[on_exit_shell]], not only when we block.  Both the pane wrapper and
+the [[pane-exited]]/[[pane-died]] hooks are handed the same
+[[completion_guard]], and [[build_tmux_completion_shell]] emits an
+unguarded body when it is [[None]].  Tying the guard to [[block]] left
+detached launches---every [[--no-block]] pane or window, and every
+detached [[todo start]]---running their finalize command twice: once
+from the wrapper as the child exits, once again from the hook after the
+pane dies.  [[_stop-detached]] tolerates that, but the todo finalize
+does not.
+
+The parent only tears the guard down when it blocked.  Having waited for
+the completion signal, it knows the guard has served its purpose.  A
+detached parent knows nothing of the sort: it returns while the pane is
+still alive, so removing the guard then would simply hand the later
+hooks a clean slate to re-claim.  Detached launches instead let their
+own cleanup remove the throwaway directory that holds guard and status
+alike (see \cref{track:detached-launch-dir}).
 
 Tracked window launches need one stronger serialization guarantee than
 steady-state hooks.  The [[tmux new-window]] command itself may spawn a
@@ -8649,23 +8690,39 @@ finally:
     )
 @
 
+\label{track:detached-launch-dir}
 For the non-blocking case, we create a temporary file for exit status
 and set up a finalize command that calls [[track stop]] when the pane
 exits.  The [[run_tmux_command]] function installs tmux hooks that
 execute the command automatically.
 
+That file lives in a directory of its own rather than directly in
+[[/tmp]], and the choice is load-bearing rather than tidiness.  The
+completion guard is derived from the status file's path, so it lands in
+the same directory; removing the directory as the finalize command's
+last step therefore deletes the status file, deletes the guard, and---
+because [[mkdir]] does not create intermediate directories---makes every
+subsequent attempt to claim the guard fail outright.  Nothing is left
+behind, and no late [[pane-died]] hook can re-run the finalize on a
+launch that has already finished.
+
+The ordering inside the finalize command matters: the directory must go
+last, after the tracking state has been updated, since removing it is
+what closes the launch.
+
 <<set up non-blocking tmux launch>>=
-exit_fd, exit_code_file = tempfile.mkstemp(
+launch_state_dir = tempfile.mkdtemp(
     prefix="nytid-track-",
-    suffix=".status",
 )
-os.close(exit_fd)
+exit_code_file = os.path.join(
+    launch_state_dir, "status",
+)
 finalize_cmd = \
     build_detached_track_finalize_command(
         launch_cleanup_labels, who
     )
 finalize_cmd += (
-    f"; rm -f {shlex.quote(exit_code_file)}"
+    f"; rm -rf {shlex.quote(launch_state_dir)}"
 )
 run_tmux_command(
     command_args,
@@ -11859,6 +11916,90 @@ def test_build_tmux_hook_command_uses_guarded_run_shell():
     assert "#{pane_dead_signal}" in hook
     assert "cleanup-command" in hook
     assert "tmux wait-for -S done-chan" in hook
+
+def test_make_tmux_completion_guard_without_status_file():
+  """A launch with no status file still gets a unique guard."""
+  first = make_tmux_completion_guard(None)
+  second = make_tmux_completion_guard(None)
+  assert first and second
+  assert first != second
+  assert make_tmux_completion_guard(
+    "/tmp/nytid.status"
+  ) == "/tmp/nytid.status.guard"
+
+
+def test_run_tmux_command_guards_detached_completion(
+  temp_tracking_dir,
+):
+  """A detached launch guards the wrapper and the exit hooks alike."""
+  observed = {}
+
+  def fake_subprocess_run(args, **kwargs):
+    if args[:2] == ["tmux", "split-window"]:
+      observed["argv"] = args
+      class Result:
+        stdout = "%42 @7 $9\n"
+      return Result()
+    class Result:
+      stdout = ""
+    return Result()
+
+  with patch(
+    "nytid.cli.track.subprocess.run",
+    side_effect=fake_subprocess_run,
+  ), patch(
+    "nytid.cli.track.install_tmux_exit_hooks",
+    side_effect=lambda pane_id, hook_command:
+      observed.__setitem__("hook", hook_command),
+  ):
+    result = run_tmux_command(
+      ["/bin/sh"],
+      cwd="/tmp",
+      env={},
+      block=False,
+      exit_status_file="/tmp/nytid-detached/status",
+      on_exit_shell="finalize-command",
+    )
+
+  assert result is None
+  guard = "mkdir /tmp/nytid-detached/status.guard"
+  wrapper = observed["argv"][-1]
+  assert guard in wrapper
+  assert "finalize-command" in wrapper
+  assert guard in observed["hook"]
+  assert "finalize-command" in observed["hook"]
+
+
+def test_start_no_block_finalize_disarms_guard(
+  temp_tracking_dir,
+):
+  """Detached cleanup removes the directory holding guard and status."""
+  with patch.dict(
+    os.environ, {"TMUX": "session"}, clear=True,
+  ), patch(
+    "nytid.cli.track.run_tmux_command",
+    return_value=None,
+  ) as mock_tmux:
+    result = runner.invoke(
+      cli, ["start", "grading", "--pane", "--no-block"],
+    )
+
+  assert result.exit_code == 0
+  call_kwargs = mock_tmux.call_args[1]
+  status_file = call_kwargs["exit_status_file"]
+  launch_dir = os.path.dirname(status_file)
+
+  assert make_tmux_completion_guard(status_file).startswith(
+    launch_dir + os.sep
+  )
+  assert "rm -rf" in call_kwargs["on_exit_shell"]
+  assert launch_dir in call_kwargs["on_exit_shell"]
+  assert call_kwargs["on_exit_shell"].index(
+    "_stop-detached"
+  ) < call_kwargs["on_exit_shell"].index("rm -rf")
+
+  os.rmdir(launch_dir)
+
 
 def test_install_tmux_exit_hooks_guards_pane_id():
     """Hooks use pane-existence guard to prevent

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -4525,6 +4525,44 @@ def test_status_with_batch_tracking(temp_tracking_dir):
 
 The notes command allows adding or updating notes/descriptions for any active label.
 
+Annotating a label is a read-modify-write of the session file, so it
+belongs behind [[mutate_worker_tracking_state]] like every other
+mutation.  Loading and saving directly would take a snapshot outside any
+lock and write it back later, and auto-suspend makes a competing writer
+ordinary rather than exotic: a [[pane-focus-out]] hook firing in between
+would have its work overwritten by a snapshot that still lists the
+suspended labels as active with their original start times.  The next
+stop would then record an interval overlapping the one the suspend
+already wrote---the same wall-clock time counted twice.
+
+The callback shape also gives us the answer we need: whether the label
+was active is decided inside the critical section, on state nobody else
+can be halfway through changing, so the message we print cannot describe
+a session that no longer exists.
+
+<<session management>>=
+def add_session_notes(
+    label: str,
+    notes: str,
+    *,
+    who: str = None,
+) -> tuple[bool, list[str]]:
+    """Annotate one active label under the tracking locks.
+
+    Returns whether the label was active, together with the
+    labels that were active at that moment.
+    """
+    outcome = {}
+
+    def update(session, history_entries):
+        outcome["added"] = session.add_notes(label, notes)
+        outcome["active"] = session.get_active_labels()
+        return session, history_entries
+
+    mutate_worker_tracking_state(update, who)
+    return outcome["added"], outcome["active"]
+@
+
 <<argument and option definitions>>=
 notes_label_arg = typer.Argument(
     ..., help="Label to add notes to",
@@ -4551,16 +4589,17 @@ def notes(
       nytid track notes DD1310 "Discussing course structure with TA"
       nytid track notes email "Answered student questions about lab 2"
     """
-    session = load_active_session(who)
+    added, active = add_session_notes(
+        label, note_text, who=who,
+    )
 
-    if not session.is_active():
+    if not active:
         typer.echo(
             "No active tracking session", err=True
         )
         raise typer.Exit(1)
 
-    if session.add_notes(label, note_text):
-        save_active_session(session, who)
+    if added:
         typer.echo(
             f"Added notes to '{label}': {note_text}"
         )
@@ -4569,12 +4608,55 @@ def notes(
             f"Label '{label}' is not currently "
             f"being tracked", err=True
         )
-        active = session.get_active_labels()
-        if active:
-            typer.echo(
-                f"Active labels: {', '.join(active)}"
-            )
+        typer.echo(
+            f"Active labels: {', '.join(active)}"
+        )
         raise typer.Exit(1)
+@
+
+The property worth pinning down is structural rather than observable
+from outside: the read and the write must happen inside one critical
+section.  We assert it where it is decided, by checking that the command
+reaches the session through [[mutate_worker_tracking_state]] at all---a
+future refactoring that reintroduces a bare load/save pair would fail
+here rather than in a rare interleaving nobody can reproduce:
+
+<<test functions>>=
+def test_notes_mutates_under_tracking_locks(temp_tracking_dir):
+  """Annotating goes through the shared locked mutation path."""
+  runner.invoke(cli, ["start", "A"])
+
+  real_mutate = mutate_worker_tracking_state
+  observed_workers = []
+
+  def recording_mutate(callback, who=None, post_update=None):
+    observed_workers.append(who)
+    return real_mutate(callback, who, post_update=post_update)
+
+  with patch(
+    "nytid.cli.track.mutate_worker_tracking_state",
+    side_effect=recording_mutate,
+  ):
+    result = runner.invoke(cli, ["notes", "A", "under lock"])
+
+  assert result.exit_code == 0
+  assert observed_workers == [default_username]
+  assert load_active_session().get_label_info("A")[1] == "under lock"
+
+def test_notes_rejects_inactive_label(temp_tracking_dir):
+  """Annotating an untracked label lists what is actually active."""
+  runner.invoke(cli, ["start", "A"])
+
+  result = runner.invoke(cli, ["notes", "B", "text"])
+  assert result.exit_code == 1
+  assert "not currently being tracked" in result.output
+  assert "Active labels: A" in result.output
+
+def test_notes_without_session_fails(temp_tracking_dir):
+  """Annotating with nothing active reports the empty session."""
+  result = runner.invoke(cli, ["notes", "A", "text"])
+  assert result.exit_code == 1
+  assert "No active tracking session" in result.output
 @
 
 \subsection{Tmux-Managed Commands}
@@ -10822,6 +10904,7 @@ from nytid.cli.track import (
     AUTO_SUSPEND_CONFIG,
     TRACK_DEBUG_CONFIG,
     load_tracking_data, load_active_session,
+    mutate_worker_tracking_state,
     format_duration,
     filter_entries, filter_entries_for_stats_window,
     normalize_tracking_entries,

--- a/src/nytid/cli/track.nw
+++ b/src/nytid/cli/track.nw
@@ -1257,26 +1257,50 @@ class ActiveSession:
             # Stop the N most recently started labels
             labels = self.label_order[-count:] if self.label_order else []
         # else: use the provided labels list
-        
-        # Remember stopped labels for resume functionality
-        self.last_stopped = labels.copy() if labels else []
-            
-        # Group labels that share the same start time and
-        # batch into a single entry, so that concurrent labels
-        # do not produce duplicate wall-clock intervals.
+@
+
+At this point [[labels]] is only a \emph{request}.  The caller may have
+named a label that is not being tracked---most often a typo---and the
+loop below simply skips such names.  The resume set must therefore be
+derived from what we actually stop, not from what was asked for.
+
+Recording the request instead is not a cosmetic slip: the caller
+[[stop_tracking_labels]] reports \enquote{none of the specified labels
+are currently tracking} by raising \emph{after}
+[[mutate_worker_tracking_state]] has already persisted the session.  A
+mistyped [[track stop]] would exit non-zero and \emph{still} leave
+[[last_stopped]] naming the phantom label, so the next bare
+[[track start]] would resume a label that never existed and the real
+previous context would be gone.
+
+We also leave [[last_stopped]] untouched when nothing was stopped.  A
+failed stop should be a no-op, and clearing the resume set would throw
+away the still-valid answer to \enquote{what did I stop last?}.
+
+Labels that share both a start time and a batch collapse into one
+entry.  Two labels started together cover the same wall-clock interval,
+so emitting them separately would double-count that time in every
+downstream total.
+
+<<active session class>>=
         groups = {}
+        stopped = []
         for label in labels:
             if label in self.active_labels:
                 start_time, notes, batch_id = (
                     self.active_labels.pop(label)
                 )
                 self.label_order.remove(label)
+                stopped.append(label)
                 key = (start_time, batch_id)
                 if key not in groups:
                     groups[key] = (
                         start_time, [], notes
                     )
                 groups[key][1].append(label)
+
+        if stopped:
+            self.last_stopped = stopped
 
         entries = []
         for key, (st, grp_labels, notes) in (
@@ -1289,6 +1313,37 @@ class ActiveSession:
             entries.append(entry)
 
         return entries
+@
+
+Let's verify that a stop naming an unknown label leaves the resume set
+alone---first at the class level, then end-to-end through the CLI, where
+the failing exit code and the surviving resume set must coexist:
+
+<<test functions>>=
+def test_failed_stop_keeps_last_stopped(temp_tracking_dir):
+  """A stop that matches nothing must not rewrite the resume set."""
+  session = ActiveSession()
+  session.start_labels(["A", "B"], datetime.datetime.now())
+  session.stop_labels()
+  assert set(session.last_stopped) == {"A", "B"}
+
+  assert session.stop_labels(["TYPO"]) == []
+  assert set(session.last_stopped) == {"A", "B"}
+
+def test_failed_stop_does_not_break_resume(temp_tracking_dir):
+  """A mistyped stop must not make bare start resume a phantom label."""
+  runner.invoke(cli, ["start", "A", "B"])
+  runner.invoke(cli, ["stop"])
+
+  result = runner.invoke(cli, ["stop", "TYPO"])
+  assert result.exit_code == 1
+
+  assert set(load_active_session().last_stopped) == {"A", "B"}
+
+  result = runner.invoke(cli, ["start"])
+  assert result.exit_code == 0
+  assert "TYPO" not in result.stdout
+  assert set(load_active_session().get_active_labels()) == {"A", "B"}
 @
 
 \subsubsection{Discarding an Active Session}

--- a/src/nytid/cli/utils/rooms.nw
+++ b/src/nytid/cli/utils/rooms.nw
@@ -106,34 +106,116 @@ return a CSV (list of tuples) of the free rooms:
 
 [(start, end, unbooked_rooms), ...]
 
-where start and end are datetime objects and unbooked_rooms is a set of 
+where start and end are strings and unbooked_rooms is a set of
 strings.
+@
+
+The tempting implementation---for each event, report every interesting
+room it does not book---is wrong, and wrong in the direction that gets
+someone turned away at a door.
+Freedom is a property of an \emph{instant}, not of an event: a room is
+free at some moment only if \emph{no} event books it then.
+Deriving the answer one event at a time can only ever consult one
+event, so with D1 booked 15--17 and D2 booked 15--16 it happily reports
+D1 free for the second row's 15--16 and D2 free for the first row's
+15--17.
+Both statements are false during the hour they overlap, and the
+command's help text invites the user to act on them.
+That the schedule contains such partial overlaps is not speculation:
+the [[booked]] command exists precisely because \enquote{some rooms are
+booked 15--17 and some 15--16}.
+
+So we invert the loop.
+First we cut the timeline at every point where anything starts or
+ends.
+Between two consecutive cuts nothing changes---by construction, no
+booking begins or ends there---so each such \emph{atomic} interval has
+a single, well-defined set of booked rooms, and subtracting it from the
+interesting rooms gives an answer that holds for the whole interval.
+Cutting this finely would make the output unreadable, though, so we
+glue back together any neighbours that turned out to say the same
+thing.
 <<helper functions>>=
 def free_rooms(ics_url: str) -> list[tuple]:
   """
   <<[[free_rooms]] doc>>
   """
-  results = []
   all_rooms = set(typerconf.get(INTERESTING_ROOMS))
 
   <<let [[schedule]] be the parsed ICS file we get from [[ics_url]]>>
-  for event in schedule.events:
-    start = event.start
-    end = event.end
-
-    <<let [[booked_rooms]] be the rooms of [[event]]>>
-
-    # If there are no booked rooms, we can skip this event.
-    if not booked_rooms:
-      continue
-
-    unbooked_rooms = all_rooms - booked_rooms
-    results.append((start, end, unbooked_rooms))
-
-  <<clean up [[results]]>>
+  <<let [[bookings]] be the room bookings in [[schedule]]>>
+  <<let [[results]] be the free rooms per atomic interval>>
+  <<merge neighbours that free the same rooms>>
+  <<format [[results]] for output>>
   return results
 <<imports>>=
 import datetime
+@
+
+Gathering the bookings is the old loop with its conclusion removed: we
+keep what each event books instead of deciding, then and there, what it
+leaves free.
+<<let [[bookings]] be the room bookings in [[schedule]]>>=
+bookings = []
+for event in schedule.events:
+  <<let [[booked_rooms]] be the rooms of [[event]]>>
+
+  # If there are no booked rooms, we can skip this event.
+  if not booked_rooms:
+    continue
+
+  bookings.append((event.start, event.end, booked_rooms))
+@
+
+The cut points are every start and every end, deduplicated and sorted;
+consecutive pairs of them are the atomic intervals.
+An interval that no booking overlaps gets no row, because the command
+documents an absent time as one where every room is free---emitting it
+would say the same thing at greater length.
+An interval where every interesting room is booked \emph{does} get a
+row, empty set and all: silence already means \enquote{everything
+free}, so an empty row is the only way left to say the opposite.
+<<let [[results]] be the free rooms per atomic interval>>=
+cuts = sorted({moment for start, end, _ in bookings
+                      for moment in (start, end)})
+results = []
+for start, end in zip(cuts, cuts[1:]):
+  booked = set()
+  for booking_start, booking_end, rooms in bookings:
+    if booking_start < end and booking_end > start:
+      booked |= rooms
+
+  if not booked:
+    continue
+
+  results.append((start, end, all_rooms - booked))
+@
+
+Neighbours that free exactly the same rooms describe one uninterrupted
+stretch, and the cut between them was an artefact of some \emph{other}
+room's booking changing.
+Extending the previous row rather than appending a new one restores the
+reading a person expects: back-to-back lectures in D1 are one span
+during which D2 and D3 are free, not two.
+<<merge neighbours that free the same rooms>>=
+merged = []
+for start, end, unbooked_rooms in results:
+  if merged and merged[-1][1] == start \
+             and merged[-1][2] == unbooked_rooms:
+    merged[-1] = (merged[-1][0], end, unbooked_rooms)
+  else:
+    merged.append((start, end, unbooked_rooms))
+
+results = merged
+@
+
+The rows come out in chronological order already, since they are built
+by walking the sorted cut points, so formatting is all that remains.
+<<format [[results]] for output>>=
+results = [(start.strftime(DATE_FORMAT),
+            end.strftime(DATE_FORMAT),
+            unbooked_rooms)
+           for start, end, unbooked_rooms in results]
 @
 
 A TimeEdit feed carries the rooms as a comma-separated list in
@@ -169,28 +251,7 @@ from nytid.schedules import read_calendar
 @
 
 
-\subsection{Clean up the results}
-
-Now that we have the CSV, we just have to merge all the overlap.
-We'll make it a simple algorithm:
-If the start and end are the same, merge them by taking the union.
-
-We'll use a dictionary to keep track of start and end times that are the same.
-We use the start and end as the key, the free rooms as the value.
-Then we can merge whenever the key already exists.
-<<clean up [[results]]>>=
-time_dict = {}
-for start, end, unbooked_rooms in results:
-  if (start, end) in time_dict:
-    time_dict[(start, end)] |= unbooked_rooms
-  else:
-    time_dict[(start, end)] = unbooked_rooms
-
-results = [(start.strftime(DATE_FORMAT),
-            end.strftime(DATE_FORMAT),
-            unbooked_rooms)
-           for (start, end), unbooked_rooms in time_dict.items()]
-results.sort()
+Both commands print timestamps, so they share one format.
 <<constants>>=
 DATE_FORMAT = "%Y-%m-%d %H:%M"
 @
@@ -264,6 +325,95 @@ def test_free_rooms_missing_location():
     assert len(result) == 1
     _, _, rooms = result[0]
     assert rooms == {"D2"}
+@
+
+The case the per-event computation got wrong is two bookings that
+overlap without sharing both endpoints.
+D1 is taken 15--17 and D2 only 15--16, so during the first hour nothing
+but D3 is free, and only in the second hour does D2 open up.
+The old code reported D1 free during 15--16, which is the answer that
+sends someone to a room in use.
+<<test functions>>=
+def test_free_rooms_partial_overlap():
+  """A room booked 15-17 is not free during 15-16."""
+  cal = make_schedule([
+    ("Long", "2024-01-15T15:00:00+01:00",
+     "2024-01-15T17:00:00+01:00", "D1"),
+    ("Short", "2024-01-15T15:00:00+01:00",
+     "2024-01-15T16:00:00+01:00", "D2"),
+  ])
+  with patch("nytid.cli.utils.rooms.read_calendar",
+             return_value=cal), \
+       patch("typerconf.get",
+             return_value=["D1", "D2", "D3"]):
+    result = free_rooms("http://example.com")
+    assert result == [
+      ("2024-01-15 15:00", "2024-01-15 16:00", {"D3"}),
+      ("2024-01-15 16:00", "2024-01-15 17:00", {"D2", "D3"}),
+    ]
+@
+
+Cutting at every boundary would also split runs that say the same
+thing, so the other half of the contract is that such runs come back
+out as one row: two back-to-back lectures in D1 leave D2 and D3 free
+for one continuous stretch, not two.
+<<test functions>>=
+def test_free_rooms_merges_adjacent_identical():
+  """Back-to-back bookings of one room give one free row."""
+  cal = make_schedule([
+    ("Lecture A", "2024-01-15T10:00:00+01:00",
+     "2024-01-15T11:00:00+01:00", "D1"),
+    ("Lecture B", "2024-01-15T11:00:00+01:00",
+     "2024-01-15T12:00:00+01:00", "D1"),
+  ])
+  with patch("nytid.cli.utils.rooms.read_calendar",
+             return_value=cal), \
+       patch("typerconf.get",
+             return_value=["D1", "D2", "D3"]):
+    result = free_rooms("http://example.com")
+    assert result == [
+      ("2024-01-15 10:00", "2024-01-15 12:00", {"D2", "D3"}),
+    ]
+@
+
+Finally, the two ways of saying \enquote{nothing to offer} must stay
+distinguishable.
+A gap between bookings carries no row, since an absent time already
+means every room is free; an interval in which every interesting room
+is taken carries a row with nothing in it, which is the only remaining
+way to say so.
+<<test functions>>=
+def test_free_rooms_skips_gaps_between_bookings():
+  """A time with no booking is absent, meaning all rooms free."""
+  cal = make_schedule([
+    ("Morning", "2024-01-15T10:00:00+01:00",
+     "2024-01-15T11:00:00+01:00", "D1"),
+    ("Afternoon", "2024-01-15T14:00:00+01:00",
+     "2024-01-15T15:00:00+01:00", "D1"),
+  ])
+  with patch("nytid.cli.utils.rooms.read_calendar",
+             return_value=cal), \
+       patch("typerconf.get",
+             return_value=["D1", "D2"]):
+    result = free_rooms("http://example.com")
+    assert [(start, end) for start, end, _ in result] == [
+      ("2024-01-15 10:00", "2024-01-15 11:00"),
+      ("2024-01-15 14:00", "2024-01-15 15:00"),
+    ]
+
+def test_free_rooms_reports_fully_booked_intervals():
+  """No room left free is still worth a row, unlike silence."""
+  cal = make_schedule([
+    ("Event", "2024-01-15T10:00:00+01:00",
+     "2024-01-15T12:00:00+01:00", "D1, D2"),
+  ])
+  with patch("nytid.cli.utils.rooms.read_calendar",
+             return_value=cal), \
+       patch("typerconf.get",
+             return_value=["D1", "D2"]):
+    assert free_rooms("http://example.com") == [
+      ("2024-01-15 10:00", "2024-01-15 12:00", set()),
+    ]
 @
 
 
@@ -346,36 +496,47 @@ def booked_cmd(<<arg [[delimiter]]>>):
     raise typer.Exit(1)
 @
 
-Now we implement the [[booked_rooms]] function similarly to the [[free_rooms]] 
-function.
+This function reuses the gathering step of [[free_rooms]] but stops
+there: reporting what is booked is exactly reporting the bookings, so
+cutting the timeline into atomic intervals would only obscure the
+answer.
+Where [[free_rooms]] must reason about instants---a claim of freedom is
+falsified by any overlapping booking---a claim that a room \emph{is}
+booked from 15 to 17 stands on its own, and keeping the interval the
+schedule states is what makes this command useful for spotting the
+ragged overlaps [[free_rooms]] has to work around.
+
+The one thing worth combining is bookings that state the same interval,
+which are one occasion split across rows; their union reads better than
+two rows.
 <<helper functions>>=
 def booked_rooms(ics_url: str) -> list[tuple]:
   """
-  Given a URL or path to a TimeEdit ICS file ([[ics_url]]),
-  return a ics (list of tuples) of the booked rooms:
+  Given a URL or path to a TimeEdit ICS file (`ics_url`),
+  return a list of tuples of the booked rooms:
 
   [(start, end, booked_rooms), ...]
 
-  where start and end are datetime objects and booked_rooms is a set of 
+  where start and end are strings and booked_rooms is a set of
   strings.
   """
-  results = []
-
   <<let [[schedule]] be the parsed ICS file we get from [[ics_url]]>>
-  for event in schedule.events:
-    start = event.start
-    end = event.end
-
-    <<let [[booked_rooms]] be the rooms of [[event]]>>
-
-    # If there are no booked rooms, we can skip this event.
-    if not booked_rooms:
-      continue
-
-    results.append((start, end, booked_rooms))
-
-  <<clean up [[results]]>>
+  <<let [[bookings]] be the room bookings in [[schedule]]>>
+  <<merge bookings stating the same interval>>
+  <<format [[results]] for output>>
   return results
+@
+
+<<merge bookings stating the same interval>>=
+time_dict = {}
+for start, end, rooms in bookings:
+  if (start, end) in time_dict:
+    time_dict[(start, end)] |= rooms
+  else:
+    time_dict[(start, end)] = rooms
+
+results = [(start, end, rooms)
+           for (start, end), rooms in sorted(time_dict.items())]
 @
 
 \subsection{Testing [[booked_rooms]]}

--- a/src/nytid/cli/utils/rooms.nw
+++ b/src/nytid/cli/utils/rooms.nw
@@ -121,8 +121,7 @@ def free_rooms(ics_url: str) -> list[tuple]:
     start = event.start
     end = event.end
 
-    booked_rooms = event.location.split(",")
-    <<turn [[booked_rooms]] into a set, properly>>
+    <<let [[booked_rooms]] be the rooms of [[event]]>>
 
     # If there are no booked rooms, we can skip this event.
     if not booked_rooms:
@@ -137,9 +136,22 @@ def free_rooms(ics_url: str) -> list[tuple]:
 import datetime
 @
 
-If there are no booked rooms for a time, we get an empty string in a 
-list---which will not be an empty set.
-<<turn [[booked_rooms]] into a set, properly>>=
+A TimeEdit feed carries the rooms as a comma-separated list in
+[[LOCATION]], so splitting on commas is all the parsing we need.
+The care goes into the two ways an event can fail to name a room, which
+[[icalendar]] reports differently.
+An event with an \emph{empty} [[LOCATION]] yields the empty string,
+which splits into a one-element list holding an empty string---not an
+empty set.
+An event with \emph{no} [[LOCATION]] property at all yields [[None]],
+and calling [[split]] on that raises [[AttributeError]]; since the
+whole query runs inside one [[try]], a single such event used to abort
+[[nytid utils rooms unbooked]] and [[booked]] with no output at all.
+Coercing with [[or ""]] folds the missing case into the empty case,
+which the check below already handles---and matches how
+[[schedules.format_event_csv]] treats the same property.
+<<let [[booked_rooms]] be the rooms of [[event]]>>=
+booked_rooms = (event.location or "").split(",")
 if len(booked_rooms) == 1 and booked_rooms[0].strip() == "":
   booked_rooms = set()
 else:
@@ -228,6 +240,30 @@ def test_free_rooms_empty_location():
              return_value=["D1", "D2"]):
     result = free_rooms("http://example.com")
     assert len(result) == 0
+@
+
+An event with no [[LOCATION]] property must be skipped just as quietly.
+We put a normal booking after it so the assertion distinguishes
+\enquote{skipped the bad event} from \enquote{gave up on the feed}:
+before the fix the [[AttributeError]] escaped and no results were
+produced at all.
+<<test functions>>=
+def test_free_rooms_missing_location():
+  """An event without LOCATION must not abort the query."""
+  cal = make_schedule([
+    ("Holiday", "2024-01-15T00:00:00+01:00",
+     "2024-01-15T23:59:00+01:00", None),
+    ("Event", "2024-01-16T10:00:00+01:00",
+     "2024-01-16T12:00:00+01:00", "D1"),
+  ])
+  with patch("nytid.cli.utils.rooms.read_calendar",
+             return_value=cal), \
+       patch("typerconf.get",
+             return_value=["D1", "D2"]):
+    result = free_rooms("http://example.com")
+    assert len(result) == 1
+    _, _, rooms = result[0]
+    assert rooms == {"D2"}
 @
 
 
@@ -330,8 +366,7 @@ def booked_rooms(ics_url: str) -> list[tuple]:
     start = event.start
     end = event.end
 
-    booked_rooms = event.location.split(",")
-    <<turn [[booked_rooms]] into a set, properly>>
+    <<let [[booked_rooms]] be the rooms of [[event]]>>
 
     # If there are no booked rooms, we can skip this event.
     if not booked_rooms:
@@ -374,6 +409,21 @@ def test_booked_rooms_merges_overlap():
     assert len(result) == 1
     _, _, rooms = result[0]
     assert rooms == {"D1", "D2"}
+
+def test_booked_rooms_missing_location():
+  """An event without LOCATION must not abort the query."""
+  cal = make_schedule([
+    ("Holiday", "2024-01-15T00:00:00+01:00",
+     "2024-01-15T23:59:00+01:00", None),
+    ("Event", "2024-01-16T10:00:00+01:00",
+     "2024-01-16T12:00:00+01:00", "D1"),
+  ])
+  with patch("nytid.cli.utils.rooms.read_calendar",
+             return_value=cal):
+    result = booked_rooms("http://example.com")
+    assert len(result) == 1
+    _, _, rooms = result[0]
+    assert rooms == {"D1"}
 @
 
 
@@ -396,16 +446,23 @@ from nytid.cli.utils.rooms import *
 @
 
 We build a mock calendar with events that have known rooms and times.
+A location of [[None]] means the event carries no [[LOCATION]] property
+at all, which is a different case from an empty one---and the case that
+used to crash the room commands.
 <<test helper: make rooms schedule>>=
 def make_schedule(events_data):
-  """Build a Calendar with events from (name, start, end, location)."""
+  """Build a Calendar with events from (name, start, end, location).
+
+  A location of None omits the LOCATION property entirely.
+  """
   cal = icalendar.Calendar()
   for name, start, end, location in events_data:
     e = icalendar.Event()
     e.summary = name
     e.start = datetime.datetime.fromisoformat(start)
     e.end = datetime.datetime.fromisoformat(end)
-    e.location = location
+    if location is not None:
+      e.location = location
     cal.add_component(e)
   return cal
 @

--- a/src/nytid/cli/zulip.nw
+++ b/src/nytid/cli/zulip.nw
@@ -212,6 +212,7 @@ def test_callback_hands_course_zuliprc_to_zulipcli(monkeypatch, tmp_path):
   import zulipcli
 
   (tmp_path / "prgi24").mkdir()
+  (tmp_path / "prgi24" / "config.json").write_text("{}")
   monkeypatch.setattr(zulip_module.registry, "get",
                       lambda name, config=None: tmp_path)
 
@@ -275,6 +276,7 @@ def test_course_zuliprc_in_course_dir(tmp_path):
   config = typerconf.Config()
   registry.add("reg", str(tmp_path), config=config)
   (tmp_path / "somecourse").mkdir()
+  (tmp_path / "somecourse" / "config.json").write_text("{}")
 
   path = course_zuliprc("somecourse", "reg", config=config)
   assert path == tmp_path / "somecourse" / ZULIPRC_FILENAME

--- a/src/nytid/courses/init.nw
+++ b/src/nytid/courses/init.nw
@@ -93,9 +93,37 @@ To create a course, we need a name for the course.
 <<new args>>=
 name: str,
 <<new doc>>=
-- `name` (mandatory), which is the human readable nickname of the course. This 
-  is used to refer to the course with other parts of nytid.
+- `name` (mandatory), which is the human readable nickname of the course. This
+  is used to refer to the course with other parts of nytid. It must be
+  non-empty, must not start with a period and must not contain a path
+  separator.
 
+@
+
+The name isn't only a label: we build the course's directory by
+appending it to the register's path, which makes it a path fragment.
+An unchecked path fragment can leave the register entirely.
+[[nytid courses new ../escaped]] would create the course in the
+register's \emph{parent}---where no register scan will ever find it,
+and where the shared directory's permissions, which are our entire
+access-control mechanism (\cref{cli.courses}), don't apply.
+A name containing a separator nests the course a level deeper than the
+scan looks, with the same effect.
+
+So we validate before creating anything.
+We reject a name that is empty, contains a path separator, or begins
+with a period.
+Rejecting the leading period is what rules out [[..]] and [[.]]
+themselves, and it also keeps course names clear of the hidden
+bookkeeping files that share these directories.
+[[registry.add]] validates register names for much the same reason
+(\cref{registry}); this brings courses into line with registers.
+<<check that [[name]] is a valid course name>>=
+if not name or name.startswith(".") \
+   or "/" in name or os.sep in name:
+  raise ValueError(f"`{name}` is not a valid course name: it must be "
+                   f"non-empty, must not start with a period and must "
+                   f"not contain a path separator.")
 @
 
 We will create the course by creating a directory in an available courses
@@ -105,6 +133,7 @@ Once the config is written the course exists; we log that at INFO,
 including which register it ended up in, since the register might
 have been selected automatically rather than by the user.
 <<new body>>=
+<<check that [[name]] is a valid course name>>
 <<determine which course register path [[register_path]] to use>>
 
 with storage.open_root(f"{register_path}/{name}") as root:
@@ -392,6 +421,23 @@ def test_new_leaves_no_config_on_failure():
 
   new(course_name, register, config=config)
   assert (reg_path / course_name / "config.json").exists()
+@
+
+The names that escape or hide the course must all be refused, and---
+just as importantly---refused before anything is written.
+We therefore assert on the register's contents rather than on the
+absence of one particular directory: the invariant is that a rejected
+name leaves the register exactly as it found it.
+<<test functions>>=
+def test_new_rejects_invalid_names():
+  import pytest
+  before = sorted(entry.name for entry in reg_path.iterdir())
+
+  for bad_name in ["../escaped", "a/b", "..", ".hidden", ""]:
+    with pytest.raises(ValueError):
+      new(bad_name, register, config=config)
+
+  assert sorted(entry.name for entry in reg_path.iterdir()) == before
 @
 
 

--- a/src/nytid/courses/init.nw
+++ b/src/nytid/courses/init.nw
@@ -20,6 +20,7 @@ manage courses found in the course registers.
 import typerconf
 
 import logging
+import os
 import pathlib
 from nytid.courses import registry
 from nytid import storage
@@ -117,10 +118,45 @@ with storage.open_root(f"{register_path}/{name}") as root:
                           f"{register_path}/{name}/config.json")
 
   <<add settings to [[course_conf]]>>
+  <<write [[course_conf]] to [[config.json]] atomically>>
 
-  with root.open("config.json", "w") as course_conf_file:
-    course_conf.write_config(course_conf_file)
   logging.info(f"Created course {name} in register {register}")
+@
+
+\subsection{Writing the config without risking corruption}
+
+Writing straight into [[config.json]] would make the file's contents
+depend on the serialisation succeeding.
+Opening for writing truncates the file immediately, whereas
+[[json.dump]] only discovers a value it can't serialise part-way
+through---leaving a half-written file that is neither absent nor
+readable.
+The course is then wedged: creating it again raises
+[[FileExistsError]] because a config exists, and reading it raises
+[[ValueError]] because the JSON is truncated.
+The only way out is to delete the course directory by hand.
+
+We avoid that by never letting a partial write reach [[config.json]].
+We serialise into a temporary file in the \emph{same} directory, then
+rename it over the target.
+Same directory means same file system, and that is precisely what makes
+[[os.replace]] atomic on POSIX: any reader sees either the old file or
+the complete new one, never a prefix of it.
+The temporary name carries the process id so that two concurrent
+creations can't corrupt each other's staging file, and we remove it on
+any failure so a crashed run leaves no debris in the course directory.
+<<write [[course_conf]] to [[config.json]] atomically>>=
+tmp_name = f".config.json.{os.getpid()}"
+try:
+  with root.open(tmp_name, "w") as course_conf_file:
+    course_conf.write_config(course_conf_file)
+  os.replace(root.path / tmp_name, root.path / "config.json")
+except BaseException:
+  try:
+    os.unlink(root.path / tmp_name)
+  except OSError:
+    pass
+  raise
 @
 
 Now we want to test the function~[[new]].
@@ -300,6 +336,14 @@ If the user didn't specify a data directory, then [[data_path]] will be
 In this case, we should update it with the default value.
 We get the default value from [[root.path]] (see
 [[<<new body>>]]).
+
+Whichever value we end up with, we store it as a string.
+The config is JSON, and the CLI declares its [[--data-path]] option as
+a [[pathlib.Path]] (\cref{cli.courses}), so Typer hands us a [[Path]]
+object that [[json.dump]] can't serialise.
+Coercing only inside the default branch would leave exactly the
+user-supplied case broken, so we convert once, after the default has
+been applied, and thereby cover both.
 <<process expected [[key]]s>>=
 try:
   data_path = kwdata["data_path"]
@@ -307,9 +351,9 @@ except KeyError:
   data_path = None
 
 if not data_path:
-  data_path = str(root.path / "data")
+  data_path = root.path / "data"
 
-kwdata["data_path"] = data_path
+kwdata["data_path"] = str(data_path)
 @
 
 \subsection{Testing the \texttt{new} function}
@@ -317,6 +361,37 @@ kwdata["data_path"] = data_path
 Now we can finally make the call to [[new]] to test it.
 <<call new to test>>=
 new(course, register, config=config)
+@
+
+The path the user supplies must survive the round trip through JSON.
+We read the written file directly rather than through
+[[get_course_config]], because what is under test is what [[new]]
+\emph{wrote}, not what the reader makes of it.
+<<test functions>>=
+def test_new_coerces_path_data_path():
+  import json
+  course_name = "pathcourse"
+  data_dir = pathlib.Path(tempfile.mkdtemp()) / "elsewhere"
+  new(course_name, register, {"data_path": data_dir}, config=config)
+  with open(reg_path / course_name / "config.json") as conf_file:
+    assert json.load(conf_file)["data_path"] == str(data_dir)
+@
+
+A failed serialisation must leave the course creatable.
+We provoke one with a value JSON can't represent and check that no
+config survives---and, crucially, that a subsequent honest attempt
+succeeds rather than tripping over the debris of the first.
+<<test functions>>=
+def test_new_leaves_no_config_on_failure():
+  import pytest
+  course_name = "failcourse"
+
+  with pytest.raises(TypeError):
+    new(course_name, register, {"unserialisable": object()}, config=config)
+  assert not (reg_path / course_name / "config.json").exists()
+
+  new(course_name, register, config=config)
+  assert (reg_path / course_name / "config.json").exists()
 @
 
 

--- a/src/nytid/courses/init.nw
+++ b/src/nytid/courses/init.nw
@@ -501,15 +501,36 @@ conf_path = None
 
 \subsection{Listing all courses in register}
 
-To list all the courses, we simply list all directories in the register's 
-directory.
+Every course is a directory in the register, but not every directory in
+the register is a course.
+A register is an ordinary shared directory, so it collects other
+things: a [[.git]] directory when the register is kept under version
+control, scratch directories, the remains of a course whose creation
+failed.
+
+Listing those as courses is not harmless.
+[[typerconf]] swallows the [[FileNotFoundError]] for a missing
+[[config.json]] and hands back an empty config, so a phantom course
+looks perfectly valid right up until someone reads a setting off it and
+gets a [[KeyError]] from what appears to be a real course.
+In the meantime it pads [[nytid courses ls]] and tab completion with
+entries the user never created.
+
+What makes a directory a course is the [[config.json]] that [[new]]
+writes into it (\cref{courses.CreatingTheCourse}), so that is what we
+test for.
+Asking whether that file exists also subsumes the directory test: a
+plain file has no [[config.json]] beneath it.
 <<functions>>=
 def all_courses(register_path: pathlib.Path) -> list[str]:
   """
   Returns a list (generator) of all courses found in `register_path`.
+
+  A subdirectory counts as a course only if it contains a
+  `config.json`.
   """
   for file in pathlib.Path(register_path).iterdir():
-    if file.is_dir():
+    if (file / "config.json").is_file():
       yield file.name
 @
 
@@ -594,4 +615,21 @@ def test_all_courses_empty():
   empty = pathlib.Path(tempfile.mkdtemp())
   courses_list = list(all_courses(empty))
   assert len(courses_list) == 0
+@
+
+The two kinds of clutter a register accumulates are a stray directory
+(here [[.git]], the one every version-controlled register has) and a
+stray file.
+Neither may appear as a course, and the real course must survive the
+filtering.
+<<test functions>>=
+def test_all_courses_skips_non_courses():
+  import os
+  os.makedirs(reg_path / ".git", exist_ok=True)
+  (reg_path / "stray.txt").write_text("not a course")
+
+  courses_list = list(all_courses(reg_path))
+  assert ".git" not in courses_list
+  assert "stray.txt" not in courses_list
+  assert course in courses_list
 

--- a/src/nytid/schedules.nw
+++ b/src/nytid/schedules.nw
@@ -1358,13 +1358,27 @@ def event_filter(events, whitelisted=TIMEEDIT_EVENTS):
     <<whitelisted events>>
   """
   for event in events:
+    summary = event.summary or ""
     for event_type in whitelisted:
-      if re.match(f"^{event_type}(,|\\s|$)", event.summary):
+      if re.match(f"^{event_type}(,|\\s|$)", summary):
         yield event
         break
 <<imports>>=
 import re
 @
+
+A [[VEVENT]] need not carry a [[SUMMARY]], and [[icalendar]] reports
+the absent property as [[None]] rather than an empty string, which
+[[re.match]] rejects with [[TypeError]].
+That exception surfaces at whoever drains the generator, and the two
+consumers fail differently and badly: [[schedule show]] catches it in
+its per-course handler and drops the \emph{entire course} from the
+schedule, while [[signupsheets generate]] has no such guard and shows
+the user a traceback.
+Coercing to the empty string is not merely defensive here---it is the
+whitelist's own answer.
+An unnamed event matches no entry, so it is excluded, which is exactly
+what the whitelist promises for anything it does not recognize.
 
 The events that we whitelist are taken from TimeEdits activity types\footnote{%
   URL: 
@@ -1442,6 +1456,20 @@ def test_event_filter_custom_whitelist():
 def test_event_filter_empty():
   result = list(event_filter([]))
   assert result == []
+@
+
+An event without a [[SUMMARY]] must be dropped like any other
+unrecognized event, not raise.
+We pair it with a matching event so the assertion tells apart
+\enquote{dropped the unnamed event} from \enquote{abandoned the feed}.
+<<test functions>>=
+def test_event_filter_missing_summary():
+  """An event without SUMMARY is dropped, not fatal."""
+  unnamed = icalendar.Event()
+  events = [unnamed, make_event(name="Laboration")]
+  result = list(event_filter(events))
+  assert len(result) == 1
+  assert result[0].summary == "Laboration"
 @
 
 

--- a/src/nytid/schedules.nw
+++ b/src/nytid/schedules.nw
@@ -443,6 +443,54 @@ we normalize here: dates become local midnight, naive times are
 interpreted as local time.
 Local is the right reading for both---an all-day event on the 15th
 means the 15th in the user's calendar, not in UTC.
+
+\paragraph{What \enquote{local} must mean}
+
+The obvious way to say \enquote{local} in Python is the no-argument
+[[datetime.astimezone()]], and that is what this function used to do.
+It produces a timezone-\emph{aware} value, so the invariant above
+holds---but the zone it attaches is a fixed offset
+([[datetime.timezone(datetime.timedelta(hours=2))]]), namely the offset
+that happened to be in effect at that one instant.
+A fixed offset has no daylight-saving rules, and that difference
+escapes as soon as anything derives a \emph{new} datetime from the
+value.
+Recurrence expansion (\cref{ExpandingRecurrences}) does exactly that:
+every occurrence of an [[RRULE]] inherits [[DTSTART]]'s [[tzinfo]], so
+a weekly meeting anchored in summer keeps reporting the summer offset
+all winter, and every occurrence past the October changeover is off by
+an hour.
+For an all-day event the error is worse than an hour: local midnight
+under the wrong offset falls at 23:00 the previous day, which changes
+the date, the weekday, and the ISO week number the schedule prints.
+
+So we attach the local \emph{zone} rather than the local offset.
+[[zoneinfo]] can build one from an IANA name, and [[tzlocal]] is what
+tells us which name the host is configured for---the standard library
+exposes no portable way to ask.
+We resolve it through a function rather than a module-level constant so
+that a process which changes its timezone, and a test that fakes one,
+both see the change.
+<<functions>>=
+def local_timezone():
+  """
+  Returns the host's local timezone as a `zoneinfo.ZoneInfo`.
+
+  Unlike the fixed offset that `datetime.astimezone()` attaches, the
+  returned zone carries the daylight-saving rules, so datetimes derived
+  from it get the offset in effect at their own time.
+  """
+  return zoneinfo.ZoneInfo(tzlocal.get_localzone_name())
+<<imports>>=
+import tzlocal
+import zoneinfo
+@
+
+With that settled, parsing is a sweep over the events, rewriting the
+two properties that carry times.
+We resolve the zone once per calendar rather than once per property:
+the answer cannot change while we parse, and the lookup reads the
+host's timezone configuration.
 <<functions>>=
 def parse_calendar(text):
   """
@@ -454,6 +502,7 @@ def parse_calendar(text):
   time. Raises ValueError if `text` is not valid ICS.
   """
   cal = icalendar.Calendar.from_ical(text)
+  local = local_timezone()
   for event in cal.events:
     for name in ("DTSTART", "DTEND"):
       <<normalize the [[name]] property of [[event]]>>
@@ -466,6 +515,10 @@ bare datetimes.
 The [[datetime]]-before-[[date]] test order matters:
 [[datetime.datetime]] is a subclass of [[datetime.date]], so testing
 [[date]] first would match everything.
+A floating time is normalized with [[replace]] rather than a
+conversion: the wall-clock reading is the part we trust---\enquote{ten
+o'clock} means ten o'clock here---and [[replace]] keeps it while
+declaring which zone it is read in.
 <<normalize the [[name]] property of [[event]]>>=
 value = event.get(name)
 if value is None:
@@ -473,10 +526,10 @@ if value is None:
 if isinstance(value.dt, datetime.datetime):
   if value.dt.tzinfo is None:
     del event[name]
-    event.add(name, value.dt.astimezone())
+    event.add(name, value.dt.replace(tzinfo=local))
 elif isinstance(value.dt, datetime.date):
   midnight = datetime.datetime(value.dt.year, value.dt.month,
-                               value.dt.day).astimezone()
+                               value.dt.day, tzinfo=local)
   del event[name]
   event.add(name, midnight)
 @
@@ -702,6 +755,90 @@ def test_no_window_keeps_master_event(tmp_path):
   path.write_text(make_recurring_ics())
   cal = read_calendar(str(path))
   assert len(cal.events) == 1
+@
+
+Expansion is also where the choice of [[tzinfo]] in
+\cref{ParsingCalendars} becomes observable, so this is where we pin it.
+Both tests below fake the local zone to Europe/Stockholm rather than
+setting [[TZ]] in the environment: the assertions must hold whatever
+timezone the developer's machine is in, and faking the resolver keeps
+the effect contained to the test instead of mutating process-global
+state.
+
+A floating weekly event anchored on 20 October 2024 crosses the
+European changeover the following week.
+Its wall-clock reading must stay at ten o'clock for every occurrence;
+with a fixed offset the later ones drift to nine.
+<<test functions>>=
+STOCKHOLM = "Europe/Stockholm"
+
+def fake_local_zone(monkeypatch, name=STOCKHOLM):
+  """Pins schedules' idea of the local zone; returns the zone."""
+  import zoneinfo
+  zone = zoneinfo.ZoneInfo(name)
+  monkeypatch.setattr(nytid.schedules, "local_timezone",
+                      lambda: zone)
+  return zone
+
+def make_dst_crossing_ics():
+  """Weekly floating event crossing the October 2024 changeover."""
+  return """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+SUMMARY:Weekly meeting
+DTSTART:20241020T100000
+DTEND:20241020T110000
+RRULE:FREQ=WEEKLY;COUNT=4
+END:VEVENT
+END:VCALENDAR"""
+
+def test_recurrence_keeps_wall_clock_across_dst(tmp_path,
+                                                monkeypatch):
+  zone = fake_local_zone(monkeypatch)
+  path = tmp_path / "dst.ics"
+  path.write_text(make_dst_crossing_ics())
+  window = (datetime.datetime(2024, 10, 1, tzinfo=zone),
+            datetime.datetime(2024, 11, 30, tzinfo=zone))
+  cal = read_calendar(str(path), window=window)
+  assert len(cal.events) == 4
+  hours = {event.start.astimezone(zone).hour
+           for event in cal.events}
+  assert hours == {10}
+@
+
+The all-day case is the same defect with a coarser symptom.
+A Monday all-day series anchored in January expands into July, where a
+frozen winter offset would place every occurrence at 23:00 on the
+preceding Sunday---a different date, weekday and ISO week than the one
+the calendar states.
+<<test functions>>=
+def make_all_day_recurring_ics():
+  """Weekly all-day event anchored on Monday 15 January 2024."""
+  return """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+SUMMARY:All day weekly
+DTSTART;VALUE=DATE:20240115
+DTEND;VALUE=DATE:20240116
+RRULE:FREQ=WEEKLY;COUNT=30
+END:VEVENT
+END:VCALENDAR"""
+
+def test_all_day_recurrence_keeps_date_across_dst(tmp_path,
+                                                  monkeypatch):
+  zone = fake_local_zone(monkeypatch)
+  path = tmp_path / "allday.ics"
+  path.write_text(make_all_day_recurring_ics())
+  window = (datetime.datetime(2024, 7, 1, tzinfo=zone),
+            datetime.datetime(2024, 7, 31, tzinfo=zone))
+  cal = read_calendar(str(path), window=window)
+  assert cal.events
+  for event in cal.events:
+    local = event.start.astimezone(zone)
+    assert local.hour == 0
+    assert local.weekday() == 0  # still a Monday
 @
 
 \subsection{Iterating events in chronological order}

--- a/src/nytid/schedules.nw
+++ b/src/nytid/schedules.nw
@@ -722,6 +722,30 @@ def expand_recurrences(calendar, window):
 import recurring_ical_events
 @
 
+Not every caller has a date range to offer, though.
+Exporting an ICS feed or writing a sign-up sheet covers \enquote{the
+course}, not a week the user picked---yet these callers need the
+occurrences just as much, since a sheet listing one row for a weekly
+lab is worse than useless.
+Leaving [[window]] unset is not an option for them, and inventing a
+range at each call site would scatter the same arbitrary choice around
+the code base.
+We therefore name the choice once: a span of [[horizon]] on either side
+of now.
+A year in each direction comfortably brackets any course while keeping
+the expansion finite, and the symmetry means a caller never has to
+reason about whether its data lies in the past or the future.
+<<functions>>=
+def default_window(horizon=datetime.timedelta(days=366)):
+  """
+  Returns a (start, end) window spanning `horizon` on either side of
+  now, for callers that need recurrences expanded but have no date
+  range of their own.
+  """
+  now = datetime.datetime.now().astimezone()
+  return (now - horizon, now + horizon)
+@
+
 Let's verify both behaviours with a weekly event: a window covering
 three occurrences yields three events, while no window preserves the
 single master event.
@@ -755,6 +779,23 @@ def test_no_window_keeps_master_event(tmp_path):
   path.write_text(make_recurring_ics())
   cal = read_calendar(str(path))
   assert len(cal.events) == 1
+@
+
+The default window has to be usable as a window---aware bounds
+straddling now---which is all a caller may assume about it.
+<<test functions>>=
+def test_default_window_brackets_now():
+  start, end = default_window()
+  now = datetime.datetime.now().astimezone()
+  assert start < now < end
+  assert start.tzinfo is not None and end.tzinfo is not None
+
+def test_default_window_honours_horizon(tmp_path):
+  """A short horizon still expands, but only nearby occurrences."""
+  path = tmp_path / "recurring.ics"
+  path.write_text(make_recurring_ics())
+  window = default_window(datetime.timedelta(days=1))
+  assert len(read_calendar(str(path), window=window).events) == 0
 @
 
 Expansion is also where the choice of [[tzinfo]] in

--- a/src/nytid/signup/hr/hr.nw
+++ b/src/nytid/signup/hr/hr.nw
@@ -947,6 +947,26 @@ def test_compute_amanuensis_data_periods_are_per_TA():
 @
 
 The [[compute_percentage]] function simply computes the average working time.
+
+A period of no days is not an exotic input here.
+[[sheet_date]] deliberately truncates the sheet's times to local
+midnight, so a TA booked on a single day arrives with
+[[earliest_date == latest_date]]; the caller can also force
+[[begin_date]] and [[end_date]] to the same day from [[--start]] and
+[[--end]].
+The division would then raise [[ZeroDivisionError]] from inside the
+[[elif]]-chain above---which runs \emph{before} the [[min_days]] check
+that was meant to reject such a period in the first place.
+
+We report such a period as zero rather than raising.
+An employment has day resolution, so a period spanning no days cannot
+express any working time at all, and reporting zero lets the
+[[elif]]-chain reject it the way it rejects every other period that is
+too thin: the TA falls through to [[continue]] and is left out.
+Raising would instead force a [[try]]/[[except]] on every caller,
+including the two in the CLI that print the percentage.
+The same reasoning covers an inverted period, so we guard on
+[[days <= 0]].
 <<functions>>=
 def compute_percentage(start, end, hours):
   """
@@ -954,8 +974,14 @@ def compute_percentage(start, end, hours):
     hours as a float.
 
   Output: a float in the interval [0, 1], which is the percentage of full time.
+  A period covering no days yields 0.0, since a contract cannot express
+  any working time over no days.
   """
   days = (end - start).total_seconds()/60/60/24
+
+  if days <= 0:
+    return 0.0
+
   return (hours / 1600) * (365 / days)
 @
 
@@ -971,6 +997,28 @@ def test_compute_percentage():
   result = compute_percentage(start, end, hours)
   expected = (160 / 1600) * (365 / 366)
   assert abs(result - expected) < 0.001
+@
+
+The degenerate periods must be answered, not raised on---both directly
+and through the amanuensis computation that forces a single-day period.
+<<test functions>>=
+def test_compute_percentage_same_day():
+  day = datetime.datetime(2024, 1, 1)
+  assert compute_percentage(day, day, 10) == 0.0
+
+def test_compute_percentage_inverted():
+  start = datetime.datetime(2024, 2, 1)
+  end = datetime.datetime(2024, 1, 1)
+  assert compute_percentage(start, end, 10) == 0.0
+
+def test_compute_amanuensis_data_single_day_period():
+  rows = [make_row(start="2024-09-02 10:00", end="2024-09-02 12:00",
+                   tas=["alice"])]
+  day = datetime.datetime(2024, 9, 2).astimezone()
+
+  data = compute_amanuensis_data(rows, begin_date=day, end_date=day)
+
+  assert data == {}
 @
 
 

--- a/src/nytid/signup/hr/hr.nw
+++ b/src/nytid/signup/hr/hr.nw
@@ -297,13 +297,38 @@ string, so that a change to the sheet format cannot silently desynchronize
 the writer and this reader.
 
 We start with a function to compute the number of hours spent per student.
+
+A row of the sign-up sheet is not the same thing as a session, and this
+is where the distinction bites.
+When [[generate_signup_sheet]] meets a hybrid event---one whose location
+includes a digital room---it writes the event out \emph{twice}, once for
+the physical rooms and once for the digital room, so that TAs can sign up
+separately for each.
+The two rows carry the same [[Event]], [[Start]] and [[End]]; only the
+[[Rooms]] column differs.
+Summing rows would therefore report a two-hour hybrid lab as four hours
+per student.
+
+We assume that a figure labelled \enquote{per student} describes what a
+single student is scheduled for, and a student cannot attend the campus
+half and the digital half of one session at the same time---so a session
+counts once however many rows it was split into.
+That is precisely what separates this function from [[hours_per_event]]
+below, which sums the same rows to describe the total supervision effort
+and \emph{should} count both halves.
+Without this distinction the two functions compute the same thing, and
+one of them is redundant.
+
+We identify a session by the three columns that [[generate_signup_sheet]]
+leaves untouched when it splits an event, and count each identity once.
 <<functions>>=
 def hours_per_student(csv_rows, round_time=round_time):
   """
   Input: The schedule as rows of CSV data as from csv.reader.
 
-  Output: A dictionary mapping event type to the total number of hours per 
-  student.
+  Output: A dictionary mapping event type to the total number of hours per
+  student. Sessions split across several rows (e.g. a hybrid event with
+  separate physical and digital rows) count once.
   """
 
   start_index = SIGNUP_SHEET_HEADER.index("Start")
@@ -311,8 +336,16 @@ def hours_per_student(csv_rows, round_time=round_time):
   event_index = SIGNUP_SHEET_HEADER.index("Event")
 
   event_hours = dict()
+  counted_sessions = set()
 
   for row in csv_rows:
+    session = (row[event_index], row[start_index], row[end_index])
+
+    if session in counted_sessions:
+      continue
+
+    counted_sessions.add(session)
+
     time = round_time(
       datetime.datetime.strptime(row[end_index], STRPTIME_FORMAT)
       - datetime.datetime.strptime(row[start_index], STRPTIME_FORMAT))
@@ -348,6 +381,36 @@ def test_hours_per_student_multiple():
   result = hours_per_student(rows)
   assert "Laboration" in result
   assert "Övning" in result
+@
+
+The rows below are shaped exactly as [[generate_signup_sheet]] emits them
+for one hybrid two-hour lab.
+The student-facing figure stays at two hours, while [[hours_per_event]]
+still sees both halves.
+Two genuinely distinct sessions of the same type must of course still
+add up.
+<<test functions>>=
+def test_hours_per_student_hybrid_counted_once():
+  rows = [
+    make_row(event="Laboration", rooms="D1"),
+    make_row(event="Laboration", rooms="Digital"),
+  ]
+
+  assert hours_per_student(rows)["Laboration"] \
+           == datetime.timedelta(hours=2)
+  assert hours_per_event(rows)["Laboration"] \
+           == datetime.timedelta(hours=4)
+
+def test_hours_per_student_distinct_sessions_add_up():
+  rows = [
+    make_row(event="Laboration",
+             start="2024-09-02 10:00", end="2024-09-02 12:00"),
+    make_row(event="Laboration",
+             start="2024-09-03 10:00", end="2024-09-03 12:00"),
+  ]
+
+  assert hours_per_student(rows)["Laboration"] \
+           == datetime.timedelta(hours=4)
 @
 
 Now we can compute the hours per TA.

--- a/src/nytid/signup/hr/hr.nw
+++ b/src/nytid/signup/hr/hr.nw
@@ -713,20 +713,37 @@ def test_sheet_date():
   assert date.hour == 0 and date.minute == 0
 @
 
-We start by finding all start and end dates for every TA.
+We start by finding the earliest start and the latest end among the
+rows.
+
+The names we give the row-local variables matter more than they look.
+This chunk and [[<<expand earliest and latest dates if beneficial>>]]
+below are written a page apart, but [[notangle]] splices both into the
+same function body, so every name introduced here is still live down
+there.
+The parameters [[begin_date]] and [[end_date]] are exactly such names.
+An earlier version of this chunk stored the row's end date in a variable
+called [[end_date]], which silently overwrote the caller's \emph{forced}
+end date before the code below ever got to read it---so a contract's end
+date became whatever the last row of the sheet happened to say, and the
+result depended on the order of the CSV rows.
+The start side survived by luck alone: its parameter is spelled
+[[begin_date]], so the row-local [[start_date]] happened not to collide.
+We therefore prefix both row-local names with [[row_]], which puts them
+in a namespace the function signature cannot reach.
 <<compute the earliest and latest dates for each TA>>=
 for ta in ta_hours.keys():
   earliest_date = sheet_date(csv_rows[0][start_index])
   latest_date = sheet_date(csv_rows[0][end_index])
 
   for row in csv_rows:
-    start_date = sheet_date(row[start_index])
-    end_date = sheet_date(row[end_index])
+    row_start = sheet_date(row[start_index])
+    row_end = sheet_date(row[end_index])
 
-    if start_date < earliest_date:
-      earliest_date = start_date
-    if end_date > latest_date:
-      latest_date = end_date
+    if row_start < earliest_date:
+      earliest_date = row_start
+    if row_end > latest_date:
+      latest_date = row_end
 
   hours = ta_hours[ta].total_seconds()/60/60
 
@@ -830,6 +847,52 @@ elif compute_percentage(earliest_date, latest_date, hours) >= low_percentage:
   pass
 else:
   continue # skip to next TA
+@
+
+Both halves of the computation are now in view, so we can check the
+property that ties them together: what the caller forces must reach the
+output untouched.
+The TA below works in September and December, so the row scan would
+otherwise leave December behind as the end date.
+We drop [[low_percentage]] to zero to isolate the date handling from the
+percentage thresholds.
+<<test functions>>=
+def test_compute_amanuensis_data_honours_forced_dates():
+  rows = [
+    make_row(start="2024-09-02 10:00", end="2024-09-02 12:00",
+             tas=["alice"]),
+    make_row(start="2024-12-10 10:00", end="2024-12-10 12:00",
+             tas=["alice"]),
+  ]
+  begin = datetime.datetime(2024, 8, 1).astimezone()
+  end = datetime.datetime(2025, 1, 31).astimezone()
+
+  data = compute_amanuensis_data(rows, low_percentage=0,
+                                 begin_date=begin, end_date=end)
+
+  assert data["alice"][0] == begin
+  assert data["alice"][1] == end
+@
+
+The forced dates must also be independent of the order of the rows,
+which is the symptom a leaked row-local produces.
+<<test functions>>=
+def test_compute_amanuensis_data_forced_end_ignores_row_order():
+  rows = [
+    make_row(start="2024-09-02 10:00", end="2024-09-02 12:00",
+             tas=["alice"]),
+    make_row(start="2024-12-10 10:00", end="2024-12-10 12:00",
+             tas=["alice"]),
+  ]
+  end = datetime.datetime(2025, 1, 31).astimezone()
+
+  forwards = compute_amanuensis_data(rows, low_percentage=0,
+                                     end_date=end)
+  backwards = compute_amanuensis_data(list(reversed(rows)),
+                                      low_percentage=0, end_date=end)
+
+  assert forwards["alice"][1] == end
+  assert forwards == backwards
 @
 
 The [[compute_percentage]] function simply computes the average working time.

--- a/src/nytid/signup/hr/hr.nw
+++ b/src/nytid/signup/hr/hr.nw
@@ -713,8 +713,21 @@ def test_sheet_date():
   assert date.hour == 0 and date.minute == 0
 @
 
-We start by finding the earliest start and the latest end among the
-rows.
+We start by finding the earliest start and the latest end among the rows
+the TA is actually booked on.
+
+Restricting the scan to the TA's own rows is what makes the period
+personal.
+Were we to scan the whole sheet, the inner loop would not mention [[ta]]
+anywhere---it would be loop-invariant, and every TA would come out with
+the same period, namely the span of the entire course.
+That is not a cosmetic difference, because the two halves of the
+contract would then be measured over different populations: the hours
+come from the TA's own bookings, but the days would come from everyone's.
+A TA who only works in December would be handed an August start date and
+their hours would be spread over five months instead of one, which can
+push a genuinely over-cap appointment below the 50 percent ceiling of the
+Higher Education Ordinance without anyone noticing.
 
 The names we give the row-local variables matter more than they look.
 This chunk and [[<<expand earliest and latest dates if beneficial>>]]
@@ -733,10 +746,12 @@ We therefore prefix both row-local names with [[row_]], which puts them
 in a namespace the function signature cannot reach.
 <<compute the earliest and latest dates for each TA>>=
 for ta in ta_hours.keys():
-  earliest_date = sheet_date(csv_rows[0][start_index])
-  latest_date = sheet_date(csv_rows[0][end_index])
+  <<let [[ta_rows]] be the rows where [[ta]] is booked>>
 
-  for row in csv_rows:
+  earliest_date = sheet_date(ta_rows[0][start_index])
+  latest_date = sheet_date(ta_rows[0][end_index])
+
+  for row in ta_rows:
     row_start = sheet_date(row[start_index])
     row_end = sheet_date(row[end_index])
 
@@ -755,7 +770,20 @@ for ta in ta_hours.keys():
   ta_data[ta] = (earliest_date, latest_date, hours)
 @
 
-Now we want to try to use different start and end dates to optimize the period 
+We select the TA's rows with the same membership test that
+[[hours_per_TA]] uses (\cref{HoursPerTA}), rather than a private one, so
+that the period and the hours are always derived from the identical set
+of bookings---a row where the TA is only a reserve contributes to
+neither.
+Indexing [[ta_rows[0] ]] needs no emptiness check: [[ta_hours]] contains
+a TA precisely when [[hours_per_TA]] found that TA booked on at least one
+row, so the list is guaranteed non-empty for every key we iterate over.
+<<let [[ta_rows]] be the rows where [[ta]] is booked>>=
+ta_rows = [row for row in csv_rows
+           if ta in sheets.get_booked_TAs_from_csv(row)[0]]
+@
+
+Now we want to try to use different start and end dates to optimize the period
 for the student.
 We first try with the start and end dates expanded to the semester, then the 
 first and last of the months, finally the exact dates.
@@ -893,6 +921,29 @@ def test_compute_amanuensis_data_forced_end_ignores_row_order():
 
   assert forwards["alice"][1] == end
   assert forwards == backwards
+@
+
+The per-TA scan is visible in the same output.
+Alice works one day in February and Bob one day in September, which puts
+them in different semesters, so rounding to the semester must send them
+to different periods.
+A scan over the whole sheet would instead give both of them February as
+the earliest date, and both would be rounded into the spring semester.
+<<test functions>>=
+def test_compute_amanuensis_data_periods_are_per_TA():
+  rows = [
+    make_row(start="2024-02-10 10:00", end="2024-02-10 12:00",
+             tas=["alice"]),
+    make_row(start="2024-09-02 10:00", end="2024-09-02 12:00",
+             tas=["bob"]),
+  ]
+
+  data = compute_amanuensis_data(rows, low_percentage=0, min_days=1)
+
+  assert data["alice"][0].date() == datetime.date(2024, 1, 1)
+  assert data["alice"][1].date() == datetime.date(2024, 6, 30)
+  assert data["bob"][0].date() == datetime.date(2024, 8, 1)
+  assert data["bob"][1].date() == datetime.date(2025, 1, 31)
 @
 
 The [[compute_percentage]] function simply computes the average working time.

--- a/src/nytid/signup/sheets.nw
+++ b/src/nytid/signup/sheets.nw
@@ -62,7 +62,7 @@ def generate_signup_sheet(outfile, url,
   <<let [[out]] be [[outfile]] open for writing>>
   with out:
     csvout = csv.writer(out, delimiter="\t")
-    calendar = nytid.schedules.read_calendar(url)
+    calendar = nytid.schedules.read_calendar(url, window=window)
 
     max_num_TAs = 0
     rows = []
@@ -87,6 +87,68 @@ try:
 except FileNotFoundError:
   os.makedirs(os.path.dirname(outfile), exist_ok=True)
   out = open(outfile, "w")
+@
+
+A TimeEdit schedule states a weekly lab \emph{once}, as a single
+[[VEVENT]] carrying an [[RRULE]]; the individual sessions are implicit
+until something expands them
+(\cref{ExpandingRecurrences} in the schedules chapter).
+A sign-up sheet is precisely a list of those sessions, so reading the
+calendar without a window produced a sheet with one row where the term
+has a dozen---and the missing rows are not visibly missing, so the
+sheet looks finished.
+The window is a parameter rather than a fixed choice made here, because
+only the caller knows which stretch of the calendar the sheet is for.
+It defaults to [[None]], which is [[read_calendar]]'s own default and
+therefore leaves existing callers exactly as they were.
+<<more signup args doc>>=
+- window is an optional (start, end) pair of datetimes. When given,
+  recurring events are expanded into their occurrences within it;
+  when None (the default), the calendar is read as it is.
+<<more signup args>>=
+window=None,
+@
+
+The two behaviours are worth contrasting directly, since the failing
+one produced a plausible-looking sheet rather than an error: the same
+weekly session yields one row per occurrence with a window, and a
+single row without.
+<<test functions>>=
+def make_recurring_course_ics():
+  """A weekly lab stated once, as three occurrences would be."""
+  return """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+SUMMARY:Laboration
+DTSTART:20240115T100000Z
+DTEND:20240115T120000Z
+LOCATION:D1
+RRULE:FREQ=WEEKLY;COUNT=3
+END:VEVENT
+END:VCALENDAR"""
+
+def generated_sheet_rows(tmp_path, window):
+  """Generates a sheet from the weekly lab, returns its lines."""
+  ics = tmp_path / "course.ics"
+  ics.write_text(make_recurring_course_ics())
+  out = tmp_path / "sheet.csv"
+  generate_signup_sheet(str(out), str(ics),
+                        needed_TAs=lambda event: 1,
+                        window=window)
+  return out.read_text().splitlines()
+
+def test_generate_signup_sheet_expands_recurrences(tmp_path):
+  """A weekly session becomes one row per occurrence."""
+  window = (datetime(2024, 1, 1).astimezone(),
+            datetime(2024, 3, 1).astimezone())
+  rows = generated_sheet_rows(tmp_path, window)
+  assert len(rows) == 1 + 3  # header plus three occurrences
+
+def test_generate_signup_sheet_without_window(tmp_path):
+  """Without a window only the master event becomes a row."""
+  rows = generated_sheet_rows(tmp_path, None)
+  assert len(rows) == 1 + 1  # header plus the master event
 @
 
 To generate the rows of the sheet, we simply go through the calendar in

--- a/src/nytid/signup/sheets.nw
+++ b/src/nytid/signup/sheets.nw
@@ -182,10 +182,23 @@ However, we make this optional, but on by default.
   their own rows in the sign-up sheet. Default is True.
 <<more signup args>>=
 digital_separately=True,
+@
+
+We read the location once, through [[or ""]], because a [[VEVENT]] need
+not carry a [[LOCATION]] at all and [[icalendar]] reports the absent
+property as [[None]] rather than an empty string.
+Asking [[None]] whether it contains \enquote{digital} raises
+[[AttributeError]], and nothing guards the row loop, so one room-less
+event in the course's feed aborted [[signupsheets generate]] with a
+traceback and no sheet at all.
+The empty string answers the question correctly---an event with no room
+has no digital room either---so it takes the ordinary path and gets its
+single row, which is what a room-less session should produce.
 <<append [[event]] data to [[rows]]>>=
-if digital_separately and "digital" in event.location.casefold():
-  TAs_per_room = num_TAs // (event.location.count(",") + 1)
-  <<remove digital from [[event.location]]>>
+location = event.location or ""
+if digital_separately and "digital" in location.casefold():
+  TAs_per_room = num_TAs // (location.count(",") + 1)
+  <<remove digital from [[location]]>>
   if event.location: # check if digital was the only room
     rows.append([*event_to_CSV(event),
                 max(num_TAs-TAs_per_room, 1)]) # at least one TA
@@ -194,6 +207,16 @@ if digital_separately and "digital" in event.location.casefold():
                max(TAs_per_room, 1)])
 else:
   rows.append([*event_to_CSV(event), num_TAs])
+@
+
+The row builder needs the same coercion for the same reason, and here
+it also keeps the CSV honest: without it the row would carry [[None]],
+and the field would come out empty only because [[csv.writer]] happens
+to render [[None]] that way.
+Saying \enquote{no rooms} explicitly means the row is well-formed
+whoever consumes it.
+This mirrors [[schedules.format_event_csv]], which already writes
+[[event.location or ""]].
 <<functions>>=
 def event_to_CSV(event):
   """
@@ -206,7 +229,7 @@ def event_to_CSV(event):
     event.summary,
     event.start.astimezone().strftime(STRPTIME_FORMAT),
     event.end.astimezone().strftime(STRPTIME_FORMAT),
-    event.location
+    event.location or ""
   ]
 <<constants>>=
 SIGNUP_SHEET_HEADER = [
@@ -216,16 +239,50 @@ SIGNUP_SHEET_HEADER = [
 STRPTIME_FORMAT = "%Y-%m-%d %H:%M"
 @
 
-When we remove digital from the location, we want to remove it in a way that 
+When we remove digital from the location, we want to remove it in a way that
 doesn't break the list of rooms.
-So we want to remove it either with a preceding comma, or a trailing comma, but 
+So we want to remove it either with a preceding comma, or a trailing comma, but
 not both.
-We're fine removing it if it's the only room, since then we would detect it 
+We're fine removing it if it's the only room, since then we would detect it
 above.
-<<remove digital from [[event.location]]>>=
+We substitute over the coerced [[location]] rather than [[event.location]]
+so that this chunk, too, is independent of whether the property was set.
+<<remove digital from [[location]]>>=
 event.location = re.sub(r"(,\s*digital|digital,\s*|digital)", "",
-                        event.location,
+                        location,
                         flags=re.IGNORECASE).strip()
+@
+
+Let's verify that a session without a room still becomes a row.
+The whole command dies on such an event otherwise, so the assertion
+that matters is simply that a sheet gets written at all; we check the
+room field is empty rather than absent so the row stays aligned with
+the header.
+<<test functions>>=
+def make_roomless_course_ics():
+  """A whitelisted session carrying no LOCATION property."""
+  return """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+SUMMARY:Laboration
+DTSTART:20240115T100000Z
+DTEND:20240115T120000Z
+END:VEVENT
+END:VCALENDAR"""
+
+def test_generate_signup_sheet_without_location(tmp_path):
+  """An event with no room must not abort the whole sheet."""
+  ics = tmp_path / "course.ics"
+  ics.write_text(make_roomless_course_ics())
+  out = tmp_path / "sheet.csv"
+  generate_signup_sheet(str(out), str(ics),
+                        needed_TAs=lambda event: 1)
+  rows = out.read_text().splitlines()
+  assert len(rows) == 1 + 1  # header plus the one session
+  fields = rows[1].split("\t")
+  assert fields[SIGNUP_SHEET_HEADER.index("Event")] == "Laboration"
+  assert fields[SIGNUP_SHEET_HEADER.index("Rooms")] == ""
 @
 
 Finally, we can use the function as follows.

--- a/src/nytid/signup/utils.nw
+++ b/src/nytid/signup/utils.nw
@@ -18,16 +18,33 @@ type ([[VEVENT]]), so matching against it would silently never
 recognize a lab or tutorial.
 The base algorithm counts on one TA per group.
 If there are no groups, we use one TA per room.
+
+[[DESCRIPTION]] and [[LOCATION]] are optional iCalendar properties, and
+[[icalendar]] reports an absent one as [[None]] rather than as the empty
+string.
+Calling [[.split()]] on that raises [[AttributeError]], which aborts the
+whole [[nytid signupsheets generate]] run over a single bare calendar
+entry, with nothing in the traceback to say which entry it was.
+We therefore substitute the empty string, which is not merely a way to
+avoid the crash but the correct reading of an absent property: an event
+with no description mentions no groups, and [["".split(",")]] is a
+one-element list, so an event with no stated location is treated as one
+room.
+Both are exactly what the fallbacks below already do for an event whose
+description and location are present but say nothing useful.
 <<functions>>=
 def needed_TAs(event, <<[[needed_TAs]] args>>):
   """
   Takes an event and returns the number of TAs needed
   """
-  num_groups = event.description.split().count("grupp")
-  if num_groups == 0:
-    num_groups = event.description.split().count("group")
+  description = event.description or ""
+  location = event.location or ""
 
-  num_rooms = len(event.location.split(","))
+  num_groups = description.split().count("grupp")
+  if num_groups == 0:
+    num_groups = description.split().count("group")
+
+  num_rooms = len(location.split(","))
 
   if "laboration" in event.summary or "Laboration" in event.summary:
     <<compute [[num_TAs]] for lab>>
@@ -163,4 +180,28 @@ def test_needed_TAs_english_groups():
   event = make_event(name="Laboration",
                      description="group A group B")
   assert needed_TAs(event) == 2
+@
+
+\subsection{Events missing optional properties}
+
+An event without a [[DESCRIPTION]] or without a [[LOCATION]] must not
+abort the sign-up-sheet generation.
+These are the cases where [[icalendar]] hands us [[None]], so they are
+the ones a mock cannot exercise---the real [[icalendar.Event]] built by
+[[make_event]] can.
+<<test functions>>=
+def test_needed_TAs_no_description():
+  event = make_event(name="Laboration", location="D1",
+                     description=None)
+  assert needed_TAs(event) == 1
+
+def test_needed_TAs_no_location():
+  event = make_event(name="Övning", location=None,
+                     description="grupp 1")
+  assert needed_TAs(event) == 1
+
+def test_needed_TAs_no_description_no_location():
+  event = make_event(name="Seminarium", location=None,
+                     description=None)
+  assert needed_TAs(event) == 1
 @

--- a/src/nytid/storage/init.nw
+++ b/src/nytid/storage/init.nw
@@ -226,7 +226,7 @@ We also want to test when the storage root doesn't exist.
 <<test functions>>=
 def test_non_existing():
   test_string = "StorageRoot test"
-  new_root_dir = f"{root_dir}/non-existing-subdirectory"
+  new_root_dir = f"{root_dir.name}/non-existing-subdirectory"
 
   with StorageRoot(new_root_dir) as root:
     with root.open("test.txt", "w") as f:

--- a/src/nytid/storage/init.nw
+++ b/src/nytid/storage/init.nw
@@ -121,6 +121,7 @@ def open_root(*args, **kwargs) -> StorageRoot:
 We also add the tests in a test file that will be used by [[pytest]].
 We need a temporary directory that we can use as the root.
 <<test [[storage.py]]>>=
+import os
 import pathlib
 import tempfile
 
@@ -152,15 +153,23 @@ def open(self, *args, **kwargs):
   return open(*args, **kwargs, opener=self.__opener)
 @
 
-The opener is a particular function that the [[open]] built-in will call to 
+The opener is a particular function that the [[open]] built-in will call to
 open the file.
 This opener will ensure that the filename is relative to the root.
 Now, this requires the directory to be opened.
 We will ensure it's opened.
+
+We ask whether the descriptor [[is None]] rather than whether it is
+false.
+A file descriptor is a small integer, and 0 is a perfectly legitimate
+one: a process whose standard input has been closed gets 0 for the next
+file it opens.
+A truthiness test would then read an open root as unopened and reopen
+it on every single file access.
 <<StorageRoot methods>>=
 def __opener(self, path, flags):
   """The opener, used internally"""
-  if not self.__dir_fd:
+  if self.__dir_fd is None:
     self.open_dir()
   return os.open(path, flags, dir_fd=self.__dir_fd)
 @
@@ -169,12 +178,24 @@ self.__dir_fd = None
 @
 
 We want to be able to open and close the directory file descriptor.
+
+Opening a root that is already open must not just overwrite the
+descriptor: the old one would never be closed, and the process would
+leak one descriptor per call until it hits its limit.
+A second open would only hand us another descriptor for the same
+directory, so there is nothing to gain from it; doing nothing is both
+the cheapest and the correct behaviour.
 <<StorageRoot methods>>=
 def open_dir(self):
   """
-  Open the storage root directory. Note that this is done automatically when 
+  Open the storage root directory. Note that this is done automatically when
   opening a file using the `open` method.
+
+  Opening a root that is already open is a no-op.
   """
+  if self.__dir_fd is not None:
+    return
+
   try:
     <<open root directory file descriptor>>
   except FileNotFoundError:
@@ -183,13 +204,66 @@ def open_dir(self):
 self.__dir_fd = os.open(self.path, os.O_RDONLY)
 @
 
-Since this causes the directory file descriptor to be open, we need some way to 
+Since this causes the directory file descriptor to be open, we need some way to
 close it as well.
+
+Closing has to tolerate a root that was never opened, and that is not a
+hypothetical case.
+[[open_root]] constructs without opening, so [[get_course_data]]
+(\cref{courses}) hands out exactly such roots; and [[__exit__]] calls
+[[close]] unconditionally, so a [[with]] block whose body failed before
+touching any file closes an unopened root on the way out.
+Handing [[None]] to [[os.close]] raises [[TypeError]], which would
+replace the error the user actually needs to see with a confusing one
+from the cleanup path.
+The same guard makes a repeated [[close]] harmless.
 <<StorageRoot methods>>=
 def close(self):
-  """Close the storage root"""
+  """Close the storage root.
+
+  Closing a root that is not open is a no-op, so repeated
+  closes are safe.
+  """
+  if self.__dir_fd is None:
+    return
+
   os.close(self.__dir_fd)
   self.__dir_fd = None
+@
+
+Both no-ops are worth asserting, since both used to raise:
+<<test functions>>=
+def test_close_without_open():
+  root = StorageRoot(root_dir.name)
+  root.close()
+
+def test_double_close():
+  root = StorageRoot(root_dir.name)
+  root.open_dir()
+  root.close()
+  root.close()
+@
+
+The leak is only observable by counting the process's open descriptors,
+which we can do on systems that expose [[/proc]]; elsewhere we skip
+rather than assert something weaker.
+<<test functions>>=
+def test_open_dir_does_not_leak_descriptors():
+  import pytest
+
+  fd_dir = pathlib.Path("/proc/self/fd")
+  if not fd_dir.is_dir():
+    pytest.skip("counting open descriptors needs /proc")
+
+  root = StorageRoot(root_dir.name)
+  root.open_dir()
+  before = len(os.listdir(fd_dir))
+  for _ in range(10):
+    root.open_dir()
+  after = len(os.listdir(fd_dir))
+  root.close()
+
+  assert after == before
 @
 
 We test this as follows.

--- a/tests/conftest.nw
+++ b/tests/conftest.nw
@@ -67,6 +67,18 @@ with a [[who]] argument that varies per invocation,
 whereas the history paths are nullary and can use a fixed
 [[return_value]].
 
+We also patch [[get_tmux_server_start_time]], for a
+different kind of isolation: the tmux server key embeds
+the server's start time, which the real helper obtains by
+querying the running tmux server.  Tests must be hermetic
+and deterministic, so the fixture pins the start time to
+the value baked into the test scaffold's
+[[TEST_SERVER_KEY]] (generation [[123-1700000000]],
+matching the server PID [[123]] that tests put in their
+fake [[$TMUX]] values).  Tests that need a different
+answer---or that assert the helper is \emph{not}
+called---simply patch it again; the innermost patch wins.
+
 <<tracking fixture>>=
 @pytest.fixture
 def temp_tracking_dir():
@@ -103,6 +115,10 @@ def temp_tracking_dir():
         with patch(
             "nytid.cli.track.get_tracking_dir",
             return_value=temp_dir,
+        ), patch(
+            "nytid.cli.track"
+            ".get_tmux_server_start_time",
+            return_value="1700000000",
         ), patch(
             "nytid.cli.track"
             ".get_tracking_data_file",


### PR DESCRIPTION
- **Bumps version**
- **Fix schedule show crash on unranked todos**
- **Use tempdir path, not repr, in test_non_existing**
- **Skip courses lacking a data directory**
- **Stop row scan from clobbering forced end date**
- **Derive resume set from labels actually stopped**
- **Write course config atomically**
- **Validate deadlines and harden priority math**
- **Scan only the TA's own rows for contract dates**
- **Guard the register scan in get_courses_configs**
- **Reject stop times that would invert an entry**
- **Survive events without description or location**
- **Attach the local zone, not a fixed offset**
- **Parse the YAML estimate in add --edit**
- **Report a period of no days as zero percent**
- **Keep legacy session visible in track status**
- **Count a hybrid session once per student**
- **Tolerate events without a LOCATION property**
- **Remove whole subtree in rm, not just children**
- **Drop events without SUMMARY instead of raising**
- **Guard completion for non-blocking tmux launches**
- **List only directories that hold a config.json**
- **Validate the course name in courses.new**
- **Guard the input iterator in map_drop_exceptions**
- **Make timesheet storage survive a fresh install**
- **Complete course names across every register**
- **Treat an unset todo owner as the default user**
- **Fix StorageRoot's directory descriptor lifecycle**
- **Publish tmux context even without auto-suspend**
- **Reassign timed-out todos after stopping them**
- **Filter the shown range in local time**
- **Order subcommand groups deterministically**
- **Route track notes through the locked mutation path**
- **Reject a stats window shorter than one day**
- **Recurse editor reconciliation into grandchildren**
- **Make the mine subcommands survive a missing register**
- **Treat unset who as the current user in ls**
- **Cover the whole end date in schedule show**
- **Give done and rm their own --force options**
- **Act on the exit code of detached tmux runs**
- **Expand course recurrences everywhere they are read**
- **Guard stop against a vanished todo**
- **Compute free rooms per instant, not per event**
- **Tolerate sessions without a room in sign-up sheets**
- **Key tmux state by server instance, sweep dead servers**
